### PR TITLE
feat(kcal-assistant): add kcal tracking MCP server

### DIFF
--- a/kcal-assistant/.dockerignore
+++ b/kcal-assistant/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+tests
+seed
+scripts
+*.db
+*.db-journal
+README.md
+Dockerfile
+.dockerignore

--- a/kcal-assistant/.gitignore
+++ b/kcal-assistant/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+*.db
+*.db-journal
+seed/products.json

--- a/kcal-assistant/Dockerfile
+++ b/kcal-assistant/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1-alpine
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+COPY src ./src
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    DB_PATH=/app/data/kcal.db
+
+# uid 1000, matches fsGroup 1000 on the NFS subPath
+USER bun
+EXPOSE 3000
+CMD ["bun", "run", "src/index.ts"]

--- a/kcal-assistant/README.md
+++ b/kcal-assistant/README.md
@@ -1,0 +1,64 @@
+# kcal-assistant
+
+Personal MCP server for Philip's calorie tracking, used as a custom connector in the Claude app. Holds the product database, meal log, standing preferences/rules, and an Open Food Facts lookup. Runs on the homelab cluster at `https://kcal.rutberg.dev/mcp/<token>`.
+
+The server owns all arithmetic: item macros, day totals and remaining vs targets are computed here with the "räkna högt" rules (kcal/fat/carbs rounded up, protein rounded down) so the LLM never does math.
+
+## Run locally
+
+```bash
+bun install
+MCP_TOKEN=dev DB_PATH=./dev.db bun run src/index.ts
+curl localhost:3000/healthz
+npx @modelcontextprotocol/inspector   # connect Streamable HTTP to http://localhost:3000/mcp/dev
+```
+
+## Test
+
+```bash
+bun test          # unit + integration (real MCP client over HTTP)
+bunx tsc --noEmit
+```
+
+## Environment
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `MCP_TOKEN` | yes | - | Secret URL path segment; requests to `/mcp/<MCP_TOKEN>` are served, all else 404s |
+| `DB_PATH` | no | `./kcal.db` | SQLite file (NFS-mounted in the cluster) |
+| `PORT` | no | `3000` | HTTP port |
+
+## Seed products
+
+```bash
+bun scripts/seed.ts --url https://kcal.rutberg.dev/mcp/<token> --file seed/products.json
+```
+
+`seed/products.json` is gitignored; see `seed/products.example.json` for the shape.
+
+## Deployment
+
+Manifests live in `kubernetes/apps/home-automation/kcal-assistant/`. Image is built by `.github/workflows/kcal-assistant.yaml` on pushes to `main` touching this directory, tagged `docker.io/rutbergphilip/kcal-assistant:v<package.json version>`.
+
+Release: bump `version` in `package.json`, bump the image tag in `deployment.yaml`, merge, `task reconcile`.
+
+The Deployment must keep `replicas: 1` and `strategy: Recreate` — SQLite on NFS tolerates exactly one writer process.
+
+## Rotate the token
+
+1. `openssl rand -hex 32`
+2. Update `MCP_TOKEN` in `kubernetes/apps/home-automation/kcal-assistant/secret.sops.yaml` (decrypt, edit, `sops --encrypt --in-place`)
+3. Merge + `task reconcile`, wait for the pod to restart
+4. Update the connector URL in claude.ai → Settings → Connectors
+
+Note: the token is part of the URL. Don't paste the full connector URL into chats or logs.
+
+## Claude Project instructions (paste into the project using this connector)
+
+> Du är min kalorilogg-assistent. Vid start av varje konversation: anropa `get_context` och följ reglerna och målen som returneras.
+>
+> När jag nämner mat: sök först med `search_products`. Om produkten saknas, använd `lookup_nutrition`, visa förslaget för mig, och spara sedan med `save_product` (avrunda uppåt, markera osäkra värden som overifierade).
+>
+> Logga måltider med `log_meal` och använd ALLTID serverns siffror, räkna aldrig själv. Vid rättelser: `edit_meal` respektive `save_product`.
+>
+> Svar per loggad måltid: alla fyra makron, betyg 1-10 med kort motivering, löpande dagstotal och kvar mot dagens mål. Svenska. Inga tankstreck. Nya stående regler sparas med `save_preference`.

--- a/kcal-assistant/bun.lock
+++ b/kcal-assistant/bun.lock
@@ -1,0 +1,214 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "kcal-assistant",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.0",
+        "zod": "^3.25.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.8.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.28", "", {}, "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+  }
+}

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kcal-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/kcal-assistant/scripts/seed.ts
+++ b/kcal-assistant/scripts/seed.ts
@@ -1,0 +1,44 @@
+// Bulk-import products via the MCP API itself:
+//   bun scripts/seed.ts --url https://kcal.rutberg.dev/mcp/<token> --file seed/products.json
+// The file is a JSON array shaped like seed/products.example.json.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+function arg(name: string): string {
+  const index = process.argv.indexOf(`--${name}`);
+  const value = index >= 0 ? process.argv[index + 1] : undefined;
+  if (!value) {
+    console.error(`Usage: bun scripts/seed.ts --url <mcp-url> --file <products.json>`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const url = arg("url");
+const file = arg("file");
+
+const products: unknown[] = await Bun.file(file).json();
+if (!Array.isArray(products)) throw new Error("Seed file must be a JSON array");
+
+const client = new Client({ name: "kcal-seed", version: "0.1.0" });
+await client.connect(new StreamableHTTPClientTransport(new URL(url)));
+
+let ok = 0;
+let failed = 0;
+for (const product of products) {
+  const name = (product as { name?: string }).name ?? "<namnlös>";
+  const result = await client.callTool({ name: "save_product", arguments: product as Record<string, unknown> });
+  if (result.isError) {
+    failed++;
+    const detail = (result.content as Array<{ text?: string }>)[0]?.text;
+    console.error(`FAIL  ${name}: ${detail}`);
+  } else {
+    ok++;
+    console.log(`ok    ${name}`);
+  }
+}
+
+await client.close();
+console.log(`\nDone: ${ok} saved, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/kcal-assistant/seed/products.example.json
+++ b/kcal-assistant/seed/products.example.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Kycklingfilé",
+    "per_100g": { "kcal": 106, "protein": 23, "fat": 1.5, "carbs": 0 },
+    "aliases": ["kyckling"],
+    "verified": true
+  },
+  {
+    "name": "ProPud Milkshake Choklad",
+    "brand": "NJIE",
+    "per_100g": { "kcal": 58, "protein": 6.1, "fat": 0.9, "carbs": 4.7 },
+    "aliases": ["propud", "proteinshake"],
+    "portions": [{ "name": "flaska", "grams": 330 }],
+    "notes": "ProPud betyder alltid flaskan, aldrig burken",
+    "verified": true
+  },
+  {
+    "name": "Kycklingkebab fryst",
+    "brand": "Eldorado",
+    "per_100g": { "kcal": 113, "protein": 9.7, "fat": 3.3, "carbs": 11.1 },
+    "aliases": ["kebab", "kycklingkebaben"],
+    "portions": [{ "name": "påse", "grams": 500 }],
+    "notes": "Väg fryst",
+    "verified": true
+  }
+]

--- a/kcal-assistant/src/config.ts
+++ b/kcal-assistant/src/config.ts
@@ -1,0 +1,13 @@
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+export const config = {
+  get token(): string {
+    return requireEnv("MCP_TOKEN");
+  },
+  dbPath: process.env.DB_PATH ?? "./kcal.db",
+  port: Number(process.env.PORT ?? 3000),
+};

--- a/kcal-assistant/src/db/index.ts
+++ b/kcal-assistant/src/db/index.ts
@@ -1,0 +1,23 @@
+import { Database } from "bun:sqlite";
+import { migrate } from "./migrations";
+import { config } from "../config";
+
+export function openDb(path: string): Database {
+  const db = new Database(path, { create: true });
+  // SQLite-on-NFS safety: TRUNCATE journal (WAL needs shared mmap, unsafe on
+  // NFS) + FULL sync. Single k8s replica with strategy Recreate guarantees
+  // one writer process.
+  db.run("PRAGMA journal_mode = TRUNCATE");
+  db.run("PRAGMA synchronous = FULL");
+  db.run("PRAGMA busy_timeout = 5000");
+  db.run("PRAGMA foreign_keys = ON");
+  migrate(db);
+  return db;
+}
+
+let singleton: Database | undefined;
+
+export function getDb(): Database {
+  singleton ??= openDb(config.dbPath);
+  return singleton;
+}

--- a/kcal-assistant/src/db/meals.ts
+++ b/kcal-assistant/src/db/meals.ts
@@ -1,0 +1,263 @@
+import type { Database } from "bun:sqlite";
+import { type Macros, roundMacros, scaleMacros, scalePer100g, sumMacros } from "../lib/macros";
+import { getProduct } from "./products";
+import { getTargetsFor, type DayTargets } from "./preferences";
+import { todayStockholm, isValidDate } from "../lib/dates";
+
+export interface MealItemInput {
+  product_id?: number;
+  description?: string;
+  grams?: number;
+  portion_name?: string;
+  quantity?: number;
+  macros?: Macros;
+}
+
+export interface MealItemView extends Macros {
+  id: number;
+  product_id: number | null;
+  description: string;
+  grams: number | null;
+  quantity: number | null;
+  portion_name: string | null;
+}
+
+export interface MealView extends Macros {
+  id: number;
+  name: string;
+  post_gym_shake: boolean;
+  logged_at: string;
+  items: MealItemView[];
+}
+
+export interface DayView {
+  date: string;
+  day_type: string;
+  targets: DayTargets;
+  meals: MealView[];
+  totals: Macros;
+  remaining: { kcal: number; protein_to_min: number; fat_to_min: number; carbs: number | null };
+}
+
+function resolveDate(date?: string): string {
+  if (date === undefined) return todayStockholm();
+  if (!isValidDate(date)) throw new Error(`Invalid date: ${date} (expected YYYY-MM-DD)`);
+  return date;
+}
+
+function ensureDay(db: Database, date: string): void {
+  db.run("INSERT OR IGNORE INTO days (date) VALUES (?)", [date]);
+}
+
+interface ResolvedItem {
+  product_id: number | null;
+  description: string;
+  grams: number | null;
+  quantity: number | null;
+  portion_name: string | null;
+  macros: Macros;
+}
+
+function resolveItem(db: Database, item: MealItemInput): ResolvedItem {
+  if (item.macros) {
+    const description =
+      item.description ?? (item.product_id ? getProduct(db, item.product_id)?.name : undefined);
+    if (!description) throw new Error("Ad-hoc item needs a description");
+    return {
+      product_id: item.product_id ?? null,
+      description,
+      grams: item.grams ?? null,
+      quantity: item.quantity ?? null,
+      portion_name: null,
+      macros: roundMacros(item.macros),
+    };
+  }
+
+  if (!item.product_id) throw new Error("Item needs product_id or explicit macros");
+  const product = getProduct(db, item.product_id);
+  if (!product) throw new Error(`Product ${item.product_id} not found`);
+
+  if (item.portion_name !== undefined) {
+    const portion = product.portions.find(
+      (p) => p.name.toLowerCase() === item.portion_name!.toLowerCase(),
+    );
+    if (!portion) {
+      const known = product.portions.map((p) => p.name).join(", ") || "inga";
+      throw new Error(`"${product.name}" has no portion "${item.portion_name}" (known: ${known})`);
+    }
+    const quantity = item.quantity ?? 1;
+    let macros: Macros;
+    if (
+      portion.kcal !== null &&
+      portion.protein !== null &&
+      portion.fat !== null &&
+      portion.carbs !== null
+    ) {
+      macros = scaleMacros(
+        { kcal: portion.kcal, protein: portion.protein, fat: portion.fat, carbs: portion.carbs },
+        quantity,
+      );
+    } else if (portion.grams !== null) {
+      if (!product.per_100g)
+        throw new Error(`"${product.name}" lacks per-100g values for gram-based portion`);
+      macros = scalePer100g(product.per_100g, portion.grams * quantity);
+    } else {
+      throw new Error(`Portion "${portion.name}" on "${product.name}" has neither grams nor macros`);
+    }
+    return {
+      product_id: product.id,
+      description: item.description ?? product.name,
+      grams: portion.grams !== null ? portion.grams * quantity : null,
+      quantity,
+      portion_name: portion.name,
+      macros,
+    };
+  }
+
+  if (item.grams !== undefined) {
+    if (!product.per_100g) throw new Error(`"${product.name}" lacks per-100g values`);
+    return {
+      product_id: product.id,
+      description: item.description ?? product.name,
+      grams: item.grams,
+      quantity: null,
+      portion_name: null,
+      macros: scalePer100g(product.per_100g, item.grams),
+    };
+  }
+
+  throw new Error(`Item for "${product.name}" needs grams, portion_name or explicit macros`);
+}
+
+function insertItems(db: Database, mealId: number, items: MealItemInput[]): void {
+  if (items.length === 0) throw new Error("A meal needs at least one item");
+  for (const input of items) {
+    const r = resolveItem(db, input);
+    db.run(
+      `INSERT INTO meal_items (meal_id, product_id, description, grams, quantity, portion_name, kcal, protein, fat, carbs)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        mealId,
+        r.product_id,
+        r.description,
+        r.grams,
+        r.quantity,
+        r.portion_name,
+        r.macros.kcal,
+        r.macros.protein,
+        r.macros.fat,
+        r.macros.carbs,
+      ],
+    );
+  }
+}
+
+export function getDay(db: Database, date?: string): DayView {
+  const resolved = resolveDate(date);
+  ensureDay(db, resolved);
+  const day = db
+    .query<{ date: string; day_type: string }, [string]>(
+      "SELECT date, day_type FROM days WHERE date = ?",
+    )
+    .get(resolved)!;
+  const targets = getTargetsFor(db, day.day_type);
+
+  const mealRows = db
+    .query<{ id: number; name: string; post_gym_shake: number; logged_at: string }, [string]>(
+      "SELECT id, name, post_gym_shake, logged_at FROM meals WHERE day_date = ? ORDER BY post_gym_shake ASC, logged_at ASC, id ASC",
+    )
+    .all(resolved);
+
+  const meals: MealView[] = mealRows.map((m) => {
+    const items = db
+      .query<MealItemView, [number]>(
+        "SELECT id, product_id, description, grams, quantity, portion_name, kcal, protein, fat, carbs FROM meal_items WHERE meal_id = ? ORDER BY id",
+      )
+      .all(m.id);
+    const mealMacros = sumMacros(items);
+    return {
+      id: m.id,
+      name: m.name,
+      post_gym_shake: m.post_gym_shake === 1,
+      logged_at: m.logged_at,
+      items,
+      ...mealMacros,
+    };
+  });
+
+  const totals = sumMacros(meals);
+  const r1 = (x: number) => Math.round(x * 10) / 10;
+  return {
+    date: resolved,
+    day_type: day.day_type,
+    targets,
+    meals,
+    totals,
+    remaining: {
+      kcal: targets.kcal - totals.kcal,
+      protein_to_min: Math.max(0, r1(targets.protein_min - totals.protein)),
+      fat_to_min: Math.max(0, r1(targets.fat_min - totals.fat)),
+      carbs: targets.carbs === null ? null : r1(targets.carbs - totals.carbs),
+    },
+  };
+}
+
+export function logMeal(
+  db: Database,
+  input: { name: string; date?: string; post_gym_shake?: boolean; items: MealItemInput[] },
+): { meal_id: number; day: DayView } {
+  const date = resolveDate(input.date);
+  const mealId = db.transaction(() => {
+    ensureDay(db, date);
+    const result = db.run("INSERT INTO meals (day_date, name, post_gym_shake) VALUES (?, ?, ?)", [
+      date,
+      input.name,
+      input.post_gym_shake ? 1 : 0,
+    ]);
+    const id = Number(result.lastInsertRowid);
+    insertItems(db, id, input.items);
+    return id;
+  })();
+  return { meal_id: mealId, day: getDay(db, date) };
+}
+
+export function editMeal(
+  db: Database,
+  input: {
+    meal_id: number;
+    action: "update" | "delete";
+    name?: string;
+    post_gym_shake?: boolean;
+    items?: MealItemInput[];
+  },
+): DayView {
+  const meal = db
+    .query<{ day_date: string }, [number]>("SELECT day_date FROM meals WHERE id = ?")
+    .get(input.meal_id);
+  if (!meal) throw new Error(`Meal ${input.meal_id} not found`);
+
+  db.transaction(() => {
+    if (input.action === "delete") {
+      db.run("DELETE FROM meals WHERE id = ?", [input.meal_id]);
+      return;
+    }
+    db.run(
+      "UPDATE meals SET name = coalesce(?, name), post_gym_shake = coalesce(?, post_gym_shake) WHERE id = ?",
+      [input.name ?? null, input.post_gym_shake === undefined ? null : input.post_gym_shake ? 1 : 0, input.meal_id],
+    );
+    if (input.items !== undefined) {
+      db.run("DELETE FROM meal_items WHERE meal_id = ?", [input.meal_id]);
+      insertItems(db, input.meal_id, input.items);
+    }
+  })();
+
+  return getDay(db, meal.day_date);
+}
+
+export function setDayType(db: Database, dayType: string, date?: string): DayView {
+  getTargetsFor(db, dayType); // validates the type
+  const resolved = resolveDate(date);
+  ensureDay(db, resolved);
+  db.run("UPDATE days SET day_type = ? WHERE date = ?", [dayType, resolved]);
+  return getDay(db, resolved);
+}

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -1,0 +1,112 @@
+import type { Database } from "bun:sqlite";
+
+// Ordered migrations tracked via PRAGMA user_version. Append-only; no down
+// migrations (single user — restore from backup instead).
+const MIGRATIONS: string[] = [
+  // 1: initial schema + seeds
+  `
+  CREATE TABLE products (
+    id           INTEGER PRIMARY KEY,
+    name         TEXT NOT NULL,
+    brand        TEXT,
+    kcal_100g    REAL, protein_100g REAL, fat_100g REAL, carbs_100g REAL,
+    notes        TEXT,
+    verified     INTEGER NOT NULL DEFAULT 1,
+    source       TEXT NOT NULL DEFAULT 'manual',
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE product_aliases (
+    id         INTEGER PRIMARY KEY,
+    product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    alias      TEXT NOT NULL COLLATE NOCASE
+  );
+  CREATE INDEX idx_aliases_product ON product_aliases(product_id);
+
+  CREATE TABLE product_portions (
+    id         INTEGER PRIMARY KEY,
+    product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    name       TEXT NOT NULL COLLATE NOCASE,
+    grams      REAL,
+    kcal REAL, protein REAL, fat REAL, carbs REAL
+  );
+  CREATE INDEX idx_portions_product ON product_portions(product_id);
+
+  CREATE VIRTUAL TABLE products_fts USING fts5(
+    name, brand, aliases, notes,
+    tokenize = "unicode61 remove_diacritics 2"
+  );
+
+  CREATE TABLE days (
+    date     TEXT PRIMARY KEY,
+    day_type TEXT NOT NULL DEFAULT 'vilodag'
+             CHECK (day_type IN ('vilodag','gymdag','flexdag')),
+    note     TEXT
+  );
+
+  CREATE TABLE day_targets (
+    day_type    TEXT PRIMARY KEY CHECK (day_type IN ('vilodag','gymdag','flexdag')),
+    kcal        INTEGER NOT NULL,
+    protein_min REAL NOT NULL,
+    fat_min     REAL NOT NULL,
+    carbs       REAL
+  );
+
+  CREATE TABLE meals (
+    id             INTEGER PRIMARY KEY,
+    day_date       TEXT NOT NULL REFERENCES days(date),
+    name           TEXT NOT NULL,
+    post_gym_shake INTEGER NOT NULL DEFAULT 0,
+    logged_at      TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX idx_meals_day ON meals(day_date);
+
+  CREATE TABLE meal_items (
+    id           INTEGER PRIMARY KEY,
+    meal_id      INTEGER NOT NULL REFERENCES meals(id) ON DELETE CASCADE,
+    product_id   INTEGER REFERENCES products(id) ON DELETE SET NULL,
+    description  TEXT NOT NULL,
+    grams        REAL, quantity REAL, portion_name TEXT,
+    kcal REAL NOT NULL, protein REAL NOT NULL, fat REAL NOT NULL, carbs REAL NOT NULL
+  );
+  CREATE INDEX idx_items_meal ON meal_items(meal_id);
+
+  CREATE TABLE preferences (
+    id         INTEGER PRIMARY KEY,
+    category   TEXT NOT NULL DEFAULT 'regel',
+    content    TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 100,
+    active     INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  -- Placeholder targets; Philip corrects them via set_targets.
+  INSERT INTO day_targets (day_type, kcal, protein_min, fat_min, carbs) VALUES
+    ('vilodag', 2000, 180, 60, NULL),
+    ('gymdag',  2400, 180, 60, NULL),
+    ('flexdag', 2600, 160, 50, NULL);
+
+  INSERT INTO preferences (category, content, sort_order) VALUES
+    ('stil',  'Svara alltid på svenska', 10),
+    ('stil',  'Använd aldrig tankstreck', 20),
+    ('stil',  'Svara kort och sifferdrivet', 30),
+    ('stil',  'Vid varje loggad måltid: visa alla fyra makron (kcal, protein, fett, kolhydrater), betyg 1-10 med kort motivering, och löpande dagssumma mot dagens mål', 40),
+    ('regel', 'Räkna högt: avrunda kcal, fett och kolhydrater uppåt vid osäkerhet, protein nedåt', 50),
+    ('regel', 'Osäkra eller uppskattade produktvärden markeras som overifierade', 60),
+    ('regel', 'Ingen kompensation dagen efter en flexdag', 70),
+    ('regel', 'Post-gym-shaken listas alltid sist i dagslistan', 80);
+  `,
+];
+
+export function migrate(db: Database): void {
+  const current = db.query<{ user_version: number }, []>("PRAGMA user_version").get()!
+    .user_version;
+  for (let version = current + 1; version <= MIGRATIONS.length; version++) {
+    const sql = MIGRATIONS[version - 1]!;
+    db.transaction(() => {
+      db.run(sql);
+      db.run(`PRAGMA user_version = ${version}`);
+    })();
+  }
+}

--- a/kcal-assistant/src/db/preferences.ts
+++ b/kcal-assistant/src/db/preferences.ts
@@ -1,0 +1,98 @@
+import type { Database } from "bun:sqlite";
+
+export interface Preference {
+  id: number;
+  category: string;
+  content: string;
+  sort_order: number;
+}
+
+export interface DayTargets {
+  day_type: string;
+  kcal: number;
+  protein_min: number;
+  fat_min: number;
+  carbs: number | null;
+}
+
+export function listPreferences(db: Database): Preference[] {
+  return db
+    .query<Preference, []>(
+      "SELECT id, category, content, sort_order FROM preferences WHERE active = 1 ORDER BY category, sort_order, id",
+    )
+    .all();
+}
+
+export function savePreference(
+  db: Database,
+  input: { id?: number; content: string; category?: string; sort_order?: number },
+): Preference[] {
+  if (input.id) {
+    const exists = db.query("SELECT 1 FROM preferences WHERE id = ?").get(input.id);
+    if (!exists) throw new Error(`Preference ${input.id} not found`);
+    db.run(
+      `UPDATE preferences SET
+         content = ?,
+         category = coalesce(?, category),
+         sort_order = coalesce(?, sort_order),
+         active = 1,
+         updated_at = datetime('now')
+       WHERE id = ?`,
+      [input.content, input.category ?? null, input.sort_order ?? null, input.id],
+    );
+  } else {
+    db.run("INSERT INTO preferences (category, content, sort_order) VALUES (?, ?, ?)", [
+      input.category ?? "regel",
+      input.content,
+      input.sort_order ?? 100,
+    ]);
+  }
+  return listPreferences(db);
+}
+
+export function deletePreference(db: Database, id: number): Preference[] {
+  db.run("UPDATE preferences SET active = 0, updated_at = datetime('now') WHERE id = ?", [id]);
+  return listPreferences(db);
+}
+
+export function getTargets(db: Database): DayTargets[] {
+  return db
+    .query<DayTargets, []>(
+      "SELECT day_type, kcal, protein_min, fat_min, carbs FROM day_targets ORDER BY day_type",
+    )
+    .all();
+}
+
+export function getTargetsFor(db: Database, dayType: string): DayTargets {
+  const row = db
+    .query<DayTargets, [string]>(
+      "SELECT day_type, kcal, protein_min, fat_min, carbs FROM day_targets WHERE day_type = ?",
+    )
+    .get(dayType);
+  if (!row) throw new Error(`Unknown day type: ${dayType}`);
+  return row;
+}
+
+export function setTargets(
+  db: Database,
+  input: {
+    day_type: string;
+    kcal?: number;
+    protein_min?: number;
+    fat_min?: number;
+    carbs?: number | null;
+  },
+): DayTargets[] {
+  const exists = db.query("SELECT 1 FROM day_targets WHERE day_type = ?").get(input.day_type);
+  if (!exists) throw new Error(`Unknown day type: ${input.day_type}`);
+  db.run(
+    `UPDATE day_targets SET
+       kcal = coalesce(?, kcal),
+       protein_min = coalesce(?, protein_min),
+       fat_min = coalesce(?, fat_min),
+       carbs = coalesce(?, carbs)
+     WHERE day_type = ?`,
+    [input.kcal ?? null, input.protein_min ?? null, input.fat_min ?? null, input.carbs ?? null, input.day_type],
+  );
+  return getTargets(db);
+}

--- a/kcal-assistant/src/db/products.ts
+++ b/kcal-assistant/src/db/products.ts
@@ -1,0 +1,249 @@
+import type { Database } from "bun:sqlite";
+import type { Macros } from "../lib/macros";
+
+export interface PortionInput {
+  name: string;
+  grams?: number | null;
+  kcal?: number | null;
+  protein?: number | null;
+  fat?: number | null;
+  carbs?: number | null;
+}
+
+export interface ProductInput {
+  id?: number;
+  name: string;
+  brand?: string | null;
+  per_100g?: Macros | null;
+  aliases?: string[];
+  portions?: PortionInput[];
+  notes?: string | null;
+  verified?: boolean;
+  source?: string;
+}
+
+export interface Portion {
+  id: number;
+  name: string;
+  grams: number | null;
+  kcal: number | null;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
+}
+
+export interface Product {
+  id: number;
+  name: string;
+  brand: string | null;
+  per_100g: Macros | null;
+  aliases: string[];
+  portions: Portion[];
+  notes: string | null;
+  verified: boolean;
+  source: string;
+  updated_at: string;
+}
+
+interface ProductRow {
+  id: number;
+  name: string;
+  brand: string | null;
+  kcal_100g: number | null;
+  protein_100g: number | null;
+  fat_100g: number | null;
+  carbs_100g: number | null;
+  notes: string | null;
+  verified: number;
+  source: string;
+  updated_at: string;
+}
+
+function hydrate(db: Database, row: ProductRow): Product {
+  const aliases = db
+    .query<{ alias: string }, [number]>(
+      "SELECT alias FROM product_aliases WHERE product_id = ? ORDER BY id",
+    )
+    .all(row.id)
+    .map((r) => r.alias);
+  const portions = db
+    .query<Portion, [number]>(
+      "SELECT id, name, grams, kcal, protein, fat, carbs FROM product_portions WHERE product_id = ? ORDER BY id",
+    )
+    .all(row.id);
+  const hasMacros =
+    row.kcal_100g !== null &&
+    row.protein_100g !== null &&
+    row.fat_100g !== null &&
+    row.carbs_100g !== null;
+  return {
+    id: row.id,
+    name: row.name,
+    brand: row.brand,
+    per_100g: hasMacros
+      ? {
+          kcal: row.kcal_100g!,
+          protein: row.protein_100g!,
+          fat: row.fat_100g!,
+          carbs: row.carbs_100g!,
+        }
+      : null,
+    aliases,
+    portions,
+    notes: row.notes,
+    verified: row.verified === 1,
+    source: row.source,
+    updated_at: row.updated_at,
+  };
+}
+
+export function getProduct(db: Database, id: number): Product | null {
+  const row = db
+    .query<ProductRow, [number]>("SELECT * FROM products WHERE id = ?")
+    .get(id);
+  return row ? hydrate(db, row) : null;
+}
+
+function rebuildFtsRow(db: Database, id: number): void {
+  db.run("DELETE FROM products_fts WHERE rowid = ?", [id]);
+  const row = db
+    .query<ProductRow, [number]>("SELECT * FROM products WHERE id = ?")
+    .get(id);
+  if (!row) return;
+  const aliases = db
+    .query<{ alias: string }, [number]>("SELECT alias FROM product_aliases WHERE product_id = ?")
+    .all(id)
+    .map((r) => r.alias)
+    .join(" ");
+  db.run(
+    "INSERT INTO products_fts (rowid, name, brand, aliases, notes) VALUES (?, ?, ?, ?, ?)",
+    [id, row.name, row.brand ?? "", aliases, row.notes ?? ""],
+  );
+}
+
+export function saveProduct(db: Database, input: ProductInput): Product {
+  const save = db.transaction(() => {
+    let id = input.id;
+    const m = input.per_100g;
+    if (id) {
+      const exists = db.query("SELECT 1 FROM products WHERE id = ?").get(id);
+      if (!exists) throw new Error(`Product ${id} not found`);
+      db.run(
+        `UPDATE products SET
+           name = ?, brand = ?, kcal_100g = ?, protein_100g = ?, fat_100g = ?, carbs_100g = ?,
+           notes = ?, verified = ?, source = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          input.name,
+          input.brand ?? null,
+          m?.kcal ?? null,
+          m?.protein ?? null,
+          m?.fat ?? null,
+          m?.carbs ?? null,
+          input.notes ?? null,
+          input.verified === false ? 0 : 1,
+          input.source ?? "manual",
+          id,
+        ],
+      );
+    } else {
+      const result = db.run(
+        `INSERT INTO products (name, brand, kcal_100g, protein_100g, fat_100g, carbs_100g, notes, verified, source)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          input.name,
+          input.brand ?? null,
+          m?.kcal ?? null,
+          m?.protein ?? null,
+          m?.fat ?? null,
+          m?.carbs ?? null,
+          input.notes ?? null,
+          input.verified === false ? 0 : 1,
+          input.source ?? "manual",
+        ],
+      );
+      id = Number(result.lastInsertRowid);
+    }
+
+    // Aliases/portions replaced wholesale when provided — simplest correct
+    // semantics for "rätta på ett ställe".
+    if (input.aliases !== undefined) {
+      db.run("DELETE FROM product_aliases WHERE product_id = ?", [id]);
+      for (const alias of input.aliases) {
+        db.run("INSERT INTO product_aliases (product_id, alias) VALUES (?, ?)", [id, alias]);
+      }
+    }
+    if (input.portions !== undefined) {
+      db.run("DELETE FROM product_portions WHERE product_id = ?", [id]);
+      for (const p of input.portions) {
+        db.run(
+          "INSERT INTO product_portions (product_id, name, grams, kcal, protein, fat, carbs) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          [id, p.name, p.grams ?? null, p.kcal ?? null, p.protein ?? null, p.fat ?? null, p.carbs ?? null],
+        );
+      }
+    }
+
+    rebuildFtsRow(db, id);
+    return id;
+  });
+
+  const id = save();
+  return getProduct(db, id)!;
+}
+
+export function searchProducts(db: Database, query: string, limit = 8): Product[] {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) return [];
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+
+  // Pass 1: FTS5 prefix match over name/brand/aliases/notes, bm25-ranked.
+  // remove_diacritics 2 makes "vitlokssas" hit "vitlökssås".
+  const ftsQuery = tokens.map((t) => `"${t.replace(/"/g, '""')}"*`).join(" OR ");
+  const ftsHits = db
+    .query<{ rowid: number }, [string, number]>(
+      "SELECT rowid FROM products_fts WHERE products_fts MATCH ? ORDER BY bm25(products_fts) LIMIT ?",
+    )
+    .all(ftsQuery, limit);
+  for (const hit of ftsHits) {
+    if (!seen.has(hit.rowid)) {
+      seen.add(hit.rowid);
+      ids.push(hit.rowid);
+    }
+  }
+
+  // Pass 2: substring fallback for Swedish compound words ("kyckling" inside
+  // "Kycklingkebab") and reverse containment for definite forms
+  // ("kycklingkebaben" contains alias/name "kycklingkebab").
+  if (ids.length < limit) {
+    for (const token of tokens) {
+      if (token.length < 3) continue;
+      const like = `%${token}%`;
+      const rows = db
+        .query<{ id: number }, [string, string, string, string]>(
+          `SELECT DISTINCT p.id FROM products p
+           LEFT JOIN product_aliases a ON a.product_id = p.id
+           WHERE p.name LIKE ?1 COLLATE NOCASE
+              OR a.alias LIKE ?1 COLLATE NOCASE
+              OR (length(p.name) >= 5 AND ?2 LIKE '%' || p.name || '%' COLLATE NOCASE)
+              OR (length(a.alias) >= 4 AND ?2 LIKE '%' || a.alias || '%' COLLATE NOCASE)
+           LIMIT ?3`,
+        )
+        // @ts-expect-error bun:sqlite positional params tuple typing
+        .all(like, token, limit);
+      for (const row of rows) {
+        if (!seen.has(row.id)) {
+          seen.add(row.id);
+          ids.push(row.id);
+        }
+      }
+      if (ids.length >= limit) break;
+    }
+  }
+
+  return ids.slice(0, limit).map((id) => getProduct(db, id)!);
+}

--- a/kcal-assistant/src/index.ts
+++ b/kcal-assistant/src/index.ts
@@ -1,0 +1,23 @@
+import { config } from "./config";
+import { getDb } from "./db/index";
+import { createHttpServer } from "./server";
+
+const db = getDb(); // opens + migrates before we accept traffic
+const server = createHttpServer({ token: config.token, db });
+
+server.listen(config.port, () => {
+  console.log(`kcal-assistant listening on :${config.port} (db: ${config.dbPath})`);
+});
+
+function shutdown(signal: string): void {
+  console.log(`${signal} received, shutting down`);
+  server.close(() => {
+    db.close();
+    process.exit(0);
+  });
+  // NFS or a stuck client shouldn't block pod termination.
+  setTimeout(() => process.exit(0), 5_000).unref();
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/kcal-assistant/src/lib/dates.ts
+++ b/kcal-assistant/src/lib/dates.ts
@@ -1,0 +1,20 @@
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// sv-SE happens to format dates as ISO YYYY-MM-DD.
+const stockholmFormatter = new Intl.DateTimeFormat("sv-SE", {
+  timeZone: "Europe/Stockholm",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+export function todayStockholm(): string {
+  return stockholmFormatter.format(new Date());
+}
+
+export function isValidDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const [y, m, d] = value.split("-").map(Number) as [number, number, number];
+  const date = new Date(Date.UTC(y, m - 1, d));
+  return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
+}

--- a/kcal-assistant/src/lib/macros.ts
+++ b/kcal-assistant/src/lib/macros.ts
@@ -1,0 +1,53 @@
+export interface Macros {
+  kcal: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+}
+
+// "Räkna högt": kcal/fat/carbs round up, protein rounds down so an estimate
+// can never falsely satisfy the proteingolv. The 1e-9 tolerance keeps float
+// noise (0.1 + 0.2) from bumping a value a whole decimal step.
+function directedRound(value: number, decimals: number, up: boolean): number {
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  const nearest = Math.round(scaled);
+  if (Math.abs(scaled - nearest) < 1e-9) return nearest / factor;
+  return (up ? Math.ceil(scaled) : Math.floor(scaled)) / factor;
+}
+
+export function roundMacros(raw: Macros): Macros {
+  return {
+    kcal: directedRound(raw.kcal, 0, true),
+    protein: directedRound(raw.protein, 1, false),
+    fat: directedRound(raw.fat, 1, true),
+    carbs: directedRound(raw.carbs, 1, true),
+  };
+}
+
+export function scaleMacros(base: Macros, factor: number): Macros {
+  return roundMacros({
+    kcal: base.kcal * factor,
+    protein: base.protein * factor,
+    fat: base.fat * factor,
+    carbs: base.carbs * factor,
+  });
+}
+
+export function scalePer100g(per100g: Macros, grams: number): Macros {
+  return scaleMacros(per100g, grams / 100);
+}
+
+export function sumMacros(items: Macros[]): Macros {
+  return roundMacros(
+    items.reduce(
+      (acc, m) => ({
+        kcal: acc.kcal + m.kcal,
+        protein: acc.protein + m.protein,
+        fat: acc.fat + m.fat,
+        carbs: acc.carbs + m.carbs,
+      }),
+      { kcal: 0, protein: 0, fat: 0, carbs: 0 },
+    ),
+  );
+}

--- a/kcal-assistant/src/mcp.ts
+++ b/kcal-assistant/src/mcp.ts
@@ -1,0 +1,19 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { registerContextTools } from "./tools/context";
+import { registerProductTools } from "./tools/products";
+import { registerMealTools } from "./tools/meals";
+import { registerPreferenceTools } from "./tools/preferences";
+import { registerNutritionTools } from "./tools/nutrition";
+
+// A fresh McpServer per request (stateless Streamable HTTP). The Database is
+// the shared singleton — safe because bun:sqlite is synchronous.
+export function buildMcpServer(db: Database): McpServer {
+  const server = new McpServer({ name: "kcal-assistant", version: "0.1.0" });
+  registerContextTools(server, db);
+  registerProductTools(server, db);
+  registerMealTools(server, db);
+  registerPreferenceTools(server, db);
+  registerNutritionTools(server);
+  return server;
+}

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -1,0 +1,60 @@
+import { createServer, type Server } from "node:http";
+import { timingSafeEqual } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { buildMcpServer } from "./mcp";
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufB, bufB); // constant-ish time even on length mismatch
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+export function createHttpServer(opts: { token: string; db: Database }): Server {
+  return createServer(async (req, res) => {
+    try {
+      if (req.method === "GET" && req.url === "/healthz") {
+        res.writeHead(200, { "content-type": "application/json" }).end('{"ok":true}');
+        return;
+      }
+
+      const match = req.url?.match(/^\/mcp\/([^/?#]+)$/);
+      if (match && safeEqual(decodeURIComponent(match[1]!), opts.token)) {
+        if (req.method !== "POST") {
+          res.writeHead(405, { allow: "POST" }).end();
+          return;
+        }
+        // Stateless mode: fresh server + transport per request, plain JSON
+        // responses (no SSE), so nginx buffering never gets in the way.
+        const mcp = buildMcpServer(opts.db);
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse: true,
+        });
+        res.on("close", () => {
+          void transport.close();
+          void mcp.close();
+        });
+        await mcp.connect(transport);
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      // Everything else 404s, including claude.ai's /.well-known/oauth-*
+      // probes — a clean 404 is how it concludes the connector is no-auth.
+      // Never echo the URL back: it may contain a mistyped token.
+      res.writeHead(404, { "content-type": "application/json" }).end('{"error":"not found"}');
+    } catch (error) {
+      console.error("request failed:", error instanceof Error ? error.message : error);
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" }).end('{"error":"internal"}');
+      } else {
+        res.end();
+      }
+    }
+  });
+}

--- a/kcal-assistant/src/services/openfoodfacts.ts
+++ b/kcal-assistant/src/services/openfoodfacts.ts
@@ -1,0 +1,89 @@
+// Open Food Facts lookup — read-only; the LLM reviews candidates before
+// anything is saved (with verified:false and values rounded up).
+
+const USER_AGENT = "kcal-assistant/0.1 (personal homelab use)";
+const TIMEOUT_MS = 8_000;
+const FIELDS = "code,product_name,brands,quantity,serving_size,nutriments";
+
+export interface NutritionCandidate {
+  name: string;
+  brand: string | null;
+  barcode: string | null;
+  per_100g: {
+    kcal: number | null;
+    protein: number | null;
+    fat: number | null;
+    carbs: number | null;
+  };
+  serving_size: string | null;
+  package_quantity: string | null;
+  confidence: "complete" | "partial";
+  url: string;
+}
+
+interface OffProduct {
+  code?: string;
+  product_name?: string;
+  brands?: string;
+  quantity?: string;
+  serving_size?: string;
+  nutriments?: Record<string, number | string>;
+}
+
+function toCandidate(p: OffProduct): NutritionCandidate | null {
+  const n = p.nutriments ?? {};
+  const num = (key: string): number | null => {
+    const v = n[key];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+  };
+  const per100g = {
+    kcal: num("energy-kcal_100g"),
+    protein: num("proteins_100g"),
+    fat: num("fat_100g"),
+    carbs: num("carbohydrates_100g"),
+  };
+  const name = p.product_name?.trim();
+  if (!name) return null;
+  const complete = Object.values(per100g).every((v) => v !== null);
+  return {
+    name,
+    brand: p.brands?.trim() || null,
+    barcode: p.code ?? null,
+    per_100g: per100g,
+    serving_size: p.serving_size?.trim() || null,
+    package_quantity: p.quantity?.trim() || null,
+    confidence: complete ? "complete" : "partial",
+    url: p.code ? `https://world.openfoodfacts.org/product/${p.code}` : "",
+  };
+}
+
+async function offFetch(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`Open Food Facts returned HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function searchNutrition(query: string, limit = 6): Promise<NutritionCandidate[]> {
+  const url =
+    "https://world.openfoodfacts.org/cgi/search.pl?action=process&json=1&search_simple=1" +
+    `&search_terms=${encodeURIComponent(query)}` +
+    "&tagtype_0=countries&tag_contains_0=contains&tag_0=sweden" +
+    `&page_size=${limit}&fields=${FIELDS}&lc=sv`;
+  const data = (await offFetch(url)) as { products?: OffProduct[] };
+  return (data.products ?? []).map(toCandidate).filter((c): c is NutritionCandidate => c !== null);
+}
+
+export async function lookupBarcode(barcode: string): Promise<NutritionCandidate | null> {
+  const url = `https://world.openfoodfacts.org/api/v2/product/${encodeURIComponent(barcode)}.json?fields=${FIELDS}`;
+  try {
+    const data = (await offFetch(url)) as { status?: number; product?: OffProduct };
+    if (data.status !== 1 || !data.product) return null;
+    return toCandidate(data.product);
+  } catch (e) {
+    if (e instanceof Error && e.message.includes("404")) return null;
+    throw e;
+  }
+}

--- a/kcal-assistant/src/tools/context.ts
+++ b/kcal-assistant/src/tools/context.ts
@@ -1,0 +1,42 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { getDay } from "../db/meals";
+import { listPreferences, getTargets, type Preference } from "../db/preferences";
+import { dateSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+function groupPreferences(prefs: Preference[]): Record<string, Array<{ id: number; content: string }>> {
+  const grouped: Record<string, Array<{ id: number; content: string }>> = {};
+  for (const p of prefs) {
+    (grouped[p.category] ??= []).push({ id: p.id, content: p.content });
+  }
+  return grouped;
+}
+
+export function registerContextTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "get_context",
+    {
+      description:
+        "Call this at the START of every conversation. Returns Philip's standing rules and style preferences (follow them exactly; user-facing text is Swedish), all day-type targets, and today's log with totals and remaining vs targets. Always use the server's numbers, never compute macros yourself.",
+      inputSchema: { date: dateSchema.optional() },
+    },
+    wrap(({ date }) =>
+      jsonResult({
+        preferences: groupPreferences(listPreferences(db)),
+        all_targets: getTargets(db),
+        day: getDay(db, date),
+      }),
+    ),
+  );
+
+  server.registerTool(
+    "get_day",
+    {
+      description:
+        "Get the meal log for a day (default today): day type, targets, meals in display order (post-gym shake last), per-meal macros, totals and remaining.",
+      inputSchema: { date: dateSchema.optional() },
+    },
+    wrap(({ date }) => jsonResult(getDay(db, date))),
+  );
+}

--- a/kcal-assistant/src/tools/meals.ts
+++ b/kcal-assistant/src/tools/meals.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { logMeal, editMeal, setDayType } from "../db/meals";
+import { setTargets } from "../db/preferences";
+import { dateSchema, dayTypeSchema, mealItemSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+export function registerMealTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "log_meal",
+    {
+      description:
+        "Log a meal. The server computes all macros (item, meal, day totals, remaining vs targets) with the 'räkna högt' rounding rules; ALWAYS present the returned numbers as-is. Items reference known products (product_id + grams, or product_id + portion_name + quantity) or are ad-hoc (description + macros). Set post_gym_shake:true for the post-gym shake so it sorts last.",
+      inputSchema: {
+        name: z.string().min(1).describe("Meal name, e.g. 'Frukost', 'Lunch'"),
+        items: z.array(mealItemSchema).min(1),
+        date: dateSchema.optional(),
+        post_gym_shake: z.boolean().optional(),
+      },
+    },
+    wrap((input) => jsonResult(logMeal(db, input))),
+  );
+
+  server.registerTool(
+    "edit_meal",
+    {
+      description:
+        "Correct or remove a logged meal. action 'update' can rename, toggle post_gym_shake, and replace ALL items when items is provided; action 'delete' removes the meal. Returns the recomputed day.",
+      inputSchema: {
+        meal_id: z.number().int(),
+        action: z.enum(["update", "delete"]),
+        name: z.string().optional(),
+        post_gym_shake: z.boolean().optional(),
+        items: z.array(mealItemSchema).optional(),
+      },
+    },
+    wrap((input) => jsonResult(editMeal(db, input))),
+  );
+
+  server.registerTool(
+    "set_day_type",
+    {
+      description:
+        "Set or change a day's type (vilodag/gymdag/flexdag), also mid-day when Philip decides how he feels. Returns the day with the new targets and remaining.",
+      inputSchema: { day_type: dayTypeSchema, date: dateSchema.optional() },
+    },
+    wrap(({ day_type, date }) => jsonResult(setDayType(db, day_type, date))),
+  );
+
+  server.registerTool(
+    "set_targets",
+    {
+      description:
+        "Adjust the standing targets for one day type: kcal budget, protein_min (proteingolv), fat_min (fettgolv), optional carbs. Only provided fields change.",
+      inputSchema: {
+        day_type: dayTypeSchema,
+        kcal: z.number().int().positive().optional(),
+        protein_min: z.number().positive().optional(),
+        fat_min: z.number().positive().optional(),
+        carbs: z.number().positive().optional(),
+      },
+    },
+    wrap((input) => jsonResult({ all_targets: setTargets(db, input) })),
+  );
+}

--- a/kcal-assistant/src/tools/nutrition.ts
+++ b/kcal-assistant/src/tools/nutrition.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { searchNutrition, lookupBarcode } from "../services/openfoodfacts";
+import { jsonResult, wrap } from "./util";
+
+export function registerNutritionTools(server: McpServer): void {
+  server.registerTool(
+    "lookup_nutrition",
+    {
+      description:
+        "Look up nutrition data for a NEW product in Open Food Facts (read-only, saves nothing). Use when search_products finds nothing. Show the candidate to Philip before saving; then call save_product with source:'off', verified:false unless confirmed from packaging, and round kcal/fat/carbs UP, protein DOWN. 'partial' confidence means some macros are missing.",
+      inputSchema: {
+        query: z.string().optional().describe("Product name, ideally with brand"),
+        barcode: z.string().optional().describe("EAN barcode for an exact match"),
+      },
+    },
+    wrap(async ({ query, barcode }) => {
+      if (barcode) {
+        const candidate = await lookupBarcode(barcode);
+        return jsonResult({ candidates: candidate ? [candidate] : [] });
+      }
+      if (!query) throw new Error("Provide query or barcode");
+      return jsonResult({ candidates: await searchNutrition(query) });
+    }),
+  );
+}

--- a/kcal-assistant/src/tools/preferences.ts
+++ b/kcal-assistant/src/tools/preferences.ts
@@ -1,0 +1,31 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { savePreference, deletePreference } from "../db/preferences";
+import { jsonResult, wrap } from "./util";
+
+export function registerPreferenceTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "save_preference",
+    {
+      description:
+        "Save a standing rule or style preference so it applies in every future conversation (returned by get_context). Pass id to rewrite an existing one. Categories: 'regel' (diet/counting rules), 'stil' (response format), 'mål' (goals).",
+      inputSchema: {
+        id: z.number().int().optional(),
+        content: z.string().min(1).describe("The rule, in Swedish"),
+        category: z.enum(["regel", "stil", "mål"]).optional(),
+        sort_order: z.number().int().optional(),
+      },
+    },
+    wrap((input) => jsonResult({ preferences: savePreference(db, input) })),
+  );
+
+  server.registerTool(
+    "delete_preference",
+    {
+      description: "Retire a standing rule by id. Returns the remaining active preferences.",
+      inputSchema: { id: z.number().int() },
+    },
+    wrap(({ id }) => jsonResult({ preferences: deletePreference(db, id) })),
+  );
+}

--- a/kcal-assistant/src/tools/products.ts
+++ b/kcal-assistant/src/tools/products.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { getProduct, saveProduct, searchProducts } from "../db/products";
+import { macrosSchema, portionSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+export function registerProductTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "search_products",
+    {
+      description:
+        "Fuzzy search the product database. Handles vague Swedish phrasing ('den där kycklingkebaben'), missing diacritics and compound words. Returns candidates; pick the right one or ask the user if ambiguous. Always search before logging or creating a product.",
+      inputSchema: {
+        query: z.string().min(1).describe("Free-text search, Swedish"),
+        limit: z.number().int().min(1).max(20).optional(),
+      },
+    },
+    wrap(({ query, limit }) => jsonResult({ candidates: searchProducts(db, query, limit ?? 8) })),
+  );
+
+  server.registerTool(
+    "get_product",
+    {
+      description: "Get full detail for one product by id: macros per 100g, aliases, portions, notes/rules.",
+      inputSchema: { id: z.number().int() },
+    },
+    wrap(({ id }) => {
+      const product = getProduct(db, id);
+      if (!product) throw new Error(`Product ${id} not found`);
+      return jsonResult(product);
+    }),
+  );
+
+  server.registerTool(
+    "save_product",
+    {
+      description:
+        "Create a product, or update one by passing id (THE single place to correct values when packaging/recipes change). aliases and portions replace the existing lists wholesale when provided. For estimated values set verified:false and round kcal/fat/carbs UP, protein DOWN. Store product-specific rules in notes (e.g. 'väg fryst').",
+      inputSchema: {
+        id: z.number().int().optional().describe("Set to update an existing product"),
+        name: z.string().min(1),
+        brand: z.string().optional(),
+        per_100g: macrosSchema.optional(),
+        aliases: z.array(z.string()).optional().describe("Colloquial names Philip uses"),
+        portions: z.array(portionSchema).optional(),
+        notes: z.string().optional(),
+        verified: z.boolean().optional().describe("false = estimated/uncertain values"),
+        source: z.enum(["manual", "off", "estimate"]).optional(),
+      },
+    },
+    wrap((input) => jsonResult(saveProduct(db, input))),
+  );
+}

--- a/kcal-assistant/src/tools/schemas.ts
+++ b/kcal-assistant/src/tools/schemas.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const macrosSchema = z.object({
+  kcal: z.number(),
+  protein: z.number(),
+  fat: z.number(),
+  carbs: z.number(),
+});
+
+export const dateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .describe("Date as YYYY-MM-DD (Europe/Stockholm). Omit for today.");
+
+export const dayTypeSchema = z
+  .enum(["vilodag", "gymdag", "flexdag"])
+  .describe("Day type controlling the targets");
+
+export const mealItemSchema = z
+  .object({
+    product_id: z.number().optional().describe("Known product id from search_products"),
+    description: z.string().optional().describe("Item text; required for ad-hoc items"),
+    grams: z.number().positive().optional().describe("Weight in grams (per-100g products)"),
+    portion_name: z.string().optional().describe("Named portion, e.g. 'flaska'"),
+    quantity: z.number().positive().optional().describe("Portion count, default 1"),
+    macros: macrosSchema.optional().describe("Explicit macros for ad-hoc items"),
+  })
+  .describe("One meal item: product_id+grams, product_id+portion_name, or description+macros");
+
+export const portionSchema = z.object({
+  name: z.string().describe("Portion name, e.g. 'flaska', 'påse', 'portion'"),
+  grams: z.number().positive().optional().describe("Portion weight; macros derived from per-100g"),
+  kcal: z.number().optional(),
+  protein: z.number().optional(),
+  fat: z.number().optional(),
+  carbs: z.number().optional(),
+});

--- a/kcal-assistant/src/tools/util.ts
+++ b/kcal-assistant/src/tools/util.ts
@@ -1,0 +1,18 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function jsonResult(data: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+// Uniform error surface: tools throw plain Errors; the LLM gets a compact
+// {error} payload it can act on (ask the user, retry with other params).
+export function wrap<A>(fn: (args: A) => CallToolResult | Promise<CallToolResult>) {
+  return async (args: A): Promise<CallToolResult> => {
+    try {
+      return await fn(args);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+    }
+  };
+}

--- a/kcal-assistant/tests/macros.test.ts
+++ b/kcal-assistant/tests/macros.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  roundMacros,
+  scalePer100g,
+  scaleMacros,
+  sumMacros,
+  type Macros,
+} from "../src/lib/macros";
+import { todayStockholm, isValidDate } from "../src/lib/dates";
+
+describe("roundMacros (räkna högt)", () => {
+  test("rounds kcal up to whole number", () => {
+    expect(roundMacros({ kcal: 123.2, protein: 10, fat: 5, carbs: 2 }).kcal).toBe(124);
+    expect(roundMacros({ kcal: 123, protein: 10, fat: 5, carbs: 2 }).kcal).toBe(123);
+  });
+
+  test("rounds fat and carbs up to 1 decimal", () => {
+    const r = roundMacros({ kcal: 100, protein: 10, fat: 10.11, carbs: 3.401 });
+    expect(r.fat).toBe(10.2);
+    expect(r.carbs).toBe(3.5);
+  });
+
+  test("rounds protein DOWN to 1 decimal (never overstate vs proteingolv)", () => {
+    expect(roundMacros({ kcal: 100, protein: 30.29, fat: 5, carbs: 2 }).protein).toBe(30.2);
+    expect(roundMacros({ kcal: 100, protein: 30.2, fat: 5, carbs: 2 }).protein).toBe(30.2);
+  });
+
+  test("is immune to float noise (0.1 + 0.2 stays 0.3, not 0.4)", () => {
+    const r = roundMacros({ kcal: 100, protein: 0.1 + 0.2, fat: 0.1 + 0.2, carbs: 29.9 });
+    expect(r.fat).toBe(0.3);
+    expect(r.protein).toBe(0.3);
+    expect(r.carbs).toBe(29.9);
+  });
+});
+
+describe("scalePer100g", () => {
+  test("scales per-100g values by grams and rounds", () => {
+    const per100: Macros = { kcal: 100, protein: 10, fat: 5, carbs: 2 };
+    expect(scalePer100g(per100, 250)).toEqual({ kcal: 250, protein: 25, fat: 12.5, carbs: 5 });
+  });
+
+  test("rounds high on fractional results", () => {
+    const per100: Macros = { kcal: 113, protein: 9.7, fat: 3.3, carbs: 11.1 };
+    const r = scalePer100g(per100, 85);
+    expect(r.kcal).toBe(97); // 96.05 -> up
+    expect(r.protein).toBe(8.2); // 8.245 -> down
+    expect(r.fat).toBe(2.9); // 2.805 -> up
+    expect(r.carbs).toBe(9.5); // 9.435 -> up
+  });
+});
+
+describe("scaleMacros", () => {
+  test("multiplies portion macros by quantity and rounds", () => {
+    const portion: Macros = { kcal: 210, protein: 20, fat: 5, carbs: 15 };
+    expect(scaleMacros(portion, 2)).toEqual({ kcal: 420, protein: 40, fat: 10, carbs: 30 });
+  });
+});
+
+describe("sumMacros", () => {
+  test("sums item snapshots and rounds once at the end", () => {
+    const items: Macros[] = [
+      { kcal: 97, protein: 8.2, fat: 2.9, carbs: 9.5 },
+      { kcal: 250, protein: 25, fat: 12.5, carbs: 5 },
+      { kcal: 420, protein: 8.2, fat: 10, carbs: 30 },
+    ];
+    const r = sumMacros(items);
+    expect(r).toEqual({ kcal: 767, protein: 41.4, fat: 25.4, carbs: 44.5 });
+  });
+
+  test("empty list sums to zero", () => {
+    expect(sumMacros([])).toEqual({ kcal: 0, protein: 0, fat: 0, carbs: 0 });
+  });
+});
+
+describe("dates", () => {
+  test("todayStockholm returns YYYY-MM-DD", () => {
+    expect(todayStockholm()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("isValidDate accepts real dates and rejects garbage", () => {
+    expect(isValidDate("2026-07-06")).toBe(true);
+    expect(isValidDate("2026-13-01")).toBe(false);
+    expect(isValidDate("igår")).toBe(false);
+    expect(isValidDate("2026-7-6")).toBe(false);
+  });
+});

--- a/kcal-assistant/tests/meals.test.ts
+++ b/kcal-assistant/tests/meals.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+import { logMeal, editMeal, getDay, setDayType } from "../src/db/meals";
+import {
+  listPreferences,
+  savePreference,
+  deletePreference,
+  getTargets,
+  setTargets,
+} from "../src/db/preferences";
+
+const DATE = "2026-07-06";
+let db: Database;
+let chickenId: number;
+let propudId: number;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  chickenId = saveProduct(db, {
+    name: "Kycklingfilé",
+    per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+  }).id;
+  propudId = saveProduct(db, {
+    name: "ProPud",
+    per_100g: { kcal: 60, protein: 11, fat: 0.4, carbs: 3.1 },
+    portions: [{ name: "flaska", kcal: 198, protein: 36.3, fat: 1.4, carbs: 10.3 }],
+  }).id;
+});
+
+describe("logMeal", () => {
+  test("per-100g item: server computes rounded snapshot and day totals", () => {
+    const { day } = logMeal(db, {
+      name: "Lunch",
+      date: DATE,
+      items: [{ product_id: chickenId, grams: 250 }],
+    });
+    expect(day.meals).toHaveLength(1);
+    const meal = day.meals[0]!;
+    expect(meal.items[0]!.description).toBe("Kycklingfilé");
+    expect(meal.kcal).toBe(265); // 106*2.5
+    expect(meal.protein).toBe(57.5);
+    expect(day.totals.kcal).toBe(265);
+    expect(day.remaining.kcal).toBe(day.targets.kcal - 265);
+  });
+
+  test("portion item with explicit macros times quantity", () => {
+    const { day } = logMeal(db, {
+      name: "Kvällsmål",
+      date: DATE,
+      items: [{ product_id: propudId, portion_name: "flaska", quantity: 2 }],
+    });
+    expect(day.totals.kcal).toBe(396);
+    expect(day.totals.protein).toBe(72.6);
+  });
+
+  test("ad-hoc item with direct macros", () => {
+    const { day } = logMeal(db, {
+      name: "Restaurang",
+      date: DATE,
+      items: [{ description: "Kebabtallrik ute", macros: { kcal: 1100.2, protein: 45.05, fat: 55, carbs: 90 } }],
+    });
+    expect(day.totals.kcal).toBe(1101); // ceil
+    expect(day.totals.protein).toBe(45); // floor to 1 decimal
+  });
+
+  test("post-gym shake always sorts last regardless of log order", () => {
+    logMeal(db, {
+      name: "Post-gym shake",
+      date: DATE,
+      post_gym_shake: true,
+      items: [{ product_id: propudId, portion_name: "flaska" }],
+    });
+    logMeal(db, { name: "Middag", date: DATE, items: [{ product_id: chickenId, grams: 200 }] });
+    const day = getDay(db, DATE);
+    expect(day.meals.map((m) => m.name)).toEqual(["Middag", "Post-gym shake"]);
+  });
+
+  test("rejects product item without grams or portion", () => {
+    expect(() =>
+      logMeal(db, { name: "Fel", date: DATE, items: [{ product_id: chickenId }] }),
+    ).toThrow();
+  });
+
+  test("rejects unknown portion name", () => {
+    expect(() =>
+      logMeal(db, {
+        name: "Fel",
+        date: DATE,
+        items: [{ product_id: chickenId, portion_name: "flaska" }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("day handling", () => {
+  test("day defaults to vilodag and can switch type mid-day", () => {
+    logMeal(db, { name: "Frukost", date: DATE, items: [{ product_id: chickenId, grams: 100 }] });
+    expect(getDay(db, DATE).day_type).toBe("vilodag");
+    const day = setDayType(db, "gymdag", DATE);
+    expect(day.day_type).toBe("gymdag");
+    const gymTargets = getTargets(db).find((t) => t.day_type === "gymdag")!;
+    expect(day.targets.kcal).toBe(gymTargets.kcal);
+    expect(day.remaining.kcal).toBe(gymTargets.kcal - day.totals.kcal);
+  });
+
+  test("getDay for a date with no meals returns empty day", () => {
+    const day = getDay(db, "2026-01-01");
+    expect(day.meals).toHaveLength(0);
+    expect(day.totals.kcal).toBe(0);
+  });
+
+  test("days are independent", () => {
+    logMeal(db, { name: "Lunch", date: DATE, items: [{ product_id: chickenId, grams: 100 }] });
+    expect(getDay(db, "2026-07-05").totals.kcal).toBe(0);
+    expect(getDay(db, DATE).totals.kcal).toBe(106);
+  });
+});
+
+describe("editMeal", () => {
+  test("update replaces items and recomputes totals", () => {
+    const { meal_id } = logMeal(db, {
+      name: "Lunch",
+      date: DATE,
+      items: [{ product_id: chickenId, grams: 250 }],
+    });
+    const day = editMeal(db, {
+      meal_id,
+      action: "update",
+      items: [{ product_id: chickenId, grams: 150 }],
+    });
+    expect(day.totals.kcal).toBe(159);
+  });
+
+  test("delete removes the meal", () => {
+    const { meal_id } = logMeal(db, {
+      name: "Fel måltid",
+      date: DATE,
+      items: [{ product_id: chickenId, grams: 100 }],
+    });
+    const day = editMeal(db, { meal_id, action: "delete" });
+    expect(day.meals).toHaveLength(0);
+    expect(day.totals.kcal).toBe(0);
+  });
+});
+
+describe("preferences and targets", () => {
+  test("style rules are seeded", () => {
+    const prefs = listPreferences(db);
+    expect(prefs.length).toBeGreaterThan(3);
+    expect(prefs.some((p) => p.content.includes("svenska"))).toBe(true);
+  });
+
+  test("savePreference adds and upserts", () => {
+    const before = listPreferences(db).length;
+    const after = savePreference(db, { content: "ProPud betyder alltid flaskan", category: "regel" });
+    expect(after.length).toBe(before + 1);
+    const added = after.find((p) => p.content.includes("ProPud"))!;
+    const updated = savePreference(db, { id: added.id, content: "ProPud betyder flaskan, aldrig burken" });
+    expect(updated.length).toBe(before + 1);
+    expect(updated.find((p) => p.id === added.id)!.content).toContain("aldrig burken");
+  });
+
+  test("deletePreference retires a rule", () => {
+    const prefs = savePreference(db, { content: "Tillfällig regel" });
+    const id = prefs.find((p) => p.content === "Tillfällig regel")!.id;
+    const after = deletePreference(db, id);
+    expect(after.some((p) => p.id === id)).toBe(false);
+  });
+
+  test("setTargets updates one day type", () => {
+    const rows = setTargets(db, { day_type: "gymdag", kcal: 2600, protein_min: 190 });
+    const gym = rows.find((t) => t.day_type === "gymdag")!;
+    expect(gym.kcal).toBe(2600);
+    expect(gym.protein_min).toBe(190);
+    // other types untouched
+    expect(rows.filter((t) => t.day_type !== "gymdag")).toHaveLength(2);
+  });
+});

--- a/kcal-assistant/tests/products.test.ts
+++ b/kcal-assistant/tests/products.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct, getProduct, searchProducts } from "../src/db/products";
+
+let db: Database;
+beforeEach(() => {
+  db = openDb(":memory:");
+});
+
+describe("migrations", () => {
+  test("applies all migrations and records user_version", () => {
+    const { user_version } = db
+      .query<{ user_version: number }, []>("PRAGMA user_version")
+      .get()!;
+    expect(user_version).toBeGreaterThanOrEqual(1);
+  });
+
+  test("FTS5 table exists and is queryable", () => {
+    const row = db.query<{ n: number }, []>("SELECT count(*) AS n FROM products_fts").get()!;
+    expect(row.n).toBe(0);
+  });
+
+  test("opening the same db twice is idempotent", () => {
+    // migrations already applied; re-running against a file path must not throw.
+    // :memory: gives a fresh db each open, so simulate by applying to a temp file.
+    const tmp = `/tmp/kcal-test-${process.pid}.db`;
+    openDb(tmp).close();
+    expect(() => openDb(tmp).close()).not.toThrow();
+  });
+});
+
+describe("saveProduct / getProduct", () => {
+  test("creates a product with aliases, portions and notes", () => {
+    const p = saveProduct(db, {
+      name: "Kycklingkebab",
+      brand: "Eldorado",
+      per_100g: { kcal: 113, protein: 9.7, fat: 3.3, carbs: 11.1 },
+      aliases: ["kebab", "den där kycklingkebaben"],
+      portions: [{ name: "påse", grams: 500 }],
+      notes: "Väg fryst",
+      verified: true,
+    });
+    expect(p.id).toBeGreaterThan(0);
+    const fetched = getProduct(db, p.id)!;
+    expect(fetched.name).toBe("Kycklingkebab");
+    expect(fetched.aliases).toEqual(["kebab", "den där kycklingkebaben"]);
+    expect(fetched.portions).toHaveLength(1);
+    expect(fetched.portions[0]!.grams).toBe(500);
+    expect(fetched.notes).toBe("Väg fryst");
+    expect(fetched.verified).toBe(true);
+  });
+
+  test("update by id replaces aliases and portions wholesale", () => {
+    const p = saveProduct(db, {
+      name: "ProPud",
+      per_100g: { kcal: 63, protein: 11, fat: 0.5, carbs: 3.5 },
+      aliases: ["propud"],
+      portions: [{ name: "flaska", grams: 330 }],
+    });
+    const updated = saveProduct(db, {
+      id: p.id,
+      name: "ProPud Chokladboll",
+      per_100g: { kcal: 60, protein: 11, fat: 0.4, carbs: 3.1 },
+      aliases: ["propud", "proteinpudding"],
+      portions: [{ name: "flaska", kcal: 198, protein: 36.3, fat: 1.4, carbs: 10.3 }],
+      notes: "ProPud betyder flaskan",
+    });
+    expect(updated.id).toBe(p.id);
+    expect(updated.name).toBe("ProPud Chokladboll");
+    expect(updated.aliases).toEqual(["propud", "proteinpudding"]);
+    expect(updated.portions).toHaveLength(1);
+    expect(updated.portions[0]!.kcal).toBe(198);
+    expect(updated.portions[0]!.grams).toBeNull();
+  });
+
+  test("unverified estimate keeps its source marker", () => {
+    const p = saveProduct(db, {
+      name: "Okänd sås",
+      per_100g: { kcal: 200, protein: 1, fat: 20, carbs: 4 },
+      verified: false,
+      source: "estimate",
+    });
+    expect(getProduct(db, p.id)!.verified).toBe(false);
+    expect(getProduct(db, p.id)!.source).toBe("estimate");
+  });
+});
+
+describe("searchProducts", () => {
+  beforeEach(() => {
+    saveProduct(db, {
+      name: "Kycklingkebab",
+      aliases: ["kebab"],
+      per_100g: { kcal: 113, protein: 9.7, fat: 3.3, carbs: 11.1 },
+    });
+    saveProduct(db, {
+      name: "Vitlökssås",
+      aliases: ["min vitlökssås"],
+      per_100g: { kcal: 250, protein: 1, fat: 25, carbs: 5 },
+    });
+    saveProduct(db, {
+      name: "Kycklingfilé",
+      per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+    });
+  });
+
+  test("finds by exact-ish name token", () => {
+    const hits = searchProducts(db, "vitlökssås");
+    expect(hits.map((h) => h.name)).toContain("Vitlökssås");
+  });
+
+  test("tolerates missing diacritics (vitlokssas hits Vitlökssås)", () => {
+    const hits = searchProducts(db, "vitlokssas");
+    expect(hits.map((h) => h.name)).toContain("Vitlökssås");
+  });
+
+  test("finds compound-word product from vague definite-form phrase", () => {
+    const hits = searchProducts(db, "den där kycklingkebaben");
+    expect(hits.map((h) => h.name)).toContain("Kycklingkebab");
+  });
+
+  test("substring token matches inside compound words", () => {
+    const hits = searchProducts(db, "kyckling");
+    const names = hits.map((h) => h.name);
+    expect(names).toContain("Kycklingkebab");
+    expect(names).toContain("Kycklingfilé");
+  });
+
+  test("respects limit", () => {
+    expect(searchProducts(db, "kyckling", 1)).toHaveLength(1);
+  });
+
+  test("returns empty for nonsense", () => {
+    expect(searchProducts(db, "zzzqqqxxx")).toHaveLength(0);
+  });
+});

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { createHttpServer } from "../src/server";
+import { openDb } from "../src/db/index";
+
+const TOKEN = "test-token-123";
+let httpServer: Server;
+let db: Database;
+let baseUrl: string;
+
+beforeAll(async () => {
+  db = openDb(":memory:");
+  httpServer = createHttpServer({ token: TOKEN, db });
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => httpServer.close(resolve));
+});
+
+async function connect(): Promise<Client> {
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp/${TOKEN}`)));
+  return client;
+}
+
+function parseResult(result: Awaited<ReturnType<Client["callTool"]>>): any {
+  const content = result.content as Array<{ type: string; text: string }>;
+  return JSON.parse(content[0]!.text);
+}
+
+describe("http routing", () => {
+  test("healthz returns 200", async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test("wrong token returns 404", async () => {
+    const res = await fetch(`${baseUrl}/mcp/wrong-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("oauth discovery probes return 404", async () => {
+    const res = await fetch(`${baseUrl}/.well-known/oauth-authorization-server`);
+    expect(res.status).toBe(404);
+  });
+
+  test("GET on mcp endpoint returns 405", async () => {
+    const res = await fetch(`${baseUrl}/mcp/${TOKEN}`);
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("mcp over streamable http", () => {
+  test("lists all 12 tools", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        "get_context",
+        "search_products",
+        "get_product",
+        "save_product",
+        "lookup_nutrition",
+        "log_meal",
+        "edit_meal",
+        "get_day",
+        "set_day_type",
+        "set_targets",
+        "save_preference",
+        "delete_preference",
+      ].sort(),
+    );
+    await client.close();
+  });
+
+  test("get_context returns preferences and today's day", async () => {
+    const client = await connect();
+    const ctx = parseResult(await client.callTool({ name: "get_context", arguments: {} }));
+    expect(ctx.preferences.stil.length).toBeGreaterThan(0);
+    expect(ctx.day.day_type).toBe("vilodag");
+    expect(ctx.day.targets.kcal).toBeGreaterThan(0);
+    await client.close();
+  });
+
+  test("full logging flow: save_product -> search -> log_meal -> totals", async () => {
+    const client = await connect();
+    const saved = parseResult(
+      await client.callTool({
+        name: "save_product",
+        arguments: {
+          name: "Testkyckling",
+          per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+          aliases: ["testkycklingen"],
+        },
+      }),
+    );
+    expect(saved.id).toBeGreaterThan(0);
+
+    const hits = parseResult(
+      await client.callTool({ name: "search_products", arguments: { query: "testkyckling" } }),
+    );
+    expect(hits.candidates.map((c: any) => c.id)).toContain(saved.id);
+
+    const logged = parseResult(
+      await client.callTool({
+        name: "log_meal",
+        arguments: {
+          name: "Testlunch",
+          date: "2026-07-06",
+          items: [{ product_id: saved.id, grams: 200 }],
+        },
+      }),
+    );
+    expect(logged.day.totals.kcal).toBe(212);
+    expect(logged.day.remaining.kcal).toBe(logged.day.targets.kcal - 212);
+    await client.close();
+  });
+
+  test("tool errors come back as isError with a message", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "log_meal",
+      arguments: { name: "Trasig", items: [{ product_id: 99999, grams: 100 }] },
+    });
+    expect(result.isError).toBe(true);
+    await client.close();
+  });
+});

--- a/kcal-assistant/tsconfig.json
+++ b/kcal-assistant/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "tests", "scripts"]
+}

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -1,0 +1,78 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: kcal-assistant
+  labels:
+    app: kcal-assistant
+
+spec:
+  replicas: 1
+  # SQLite on NFS tolerates exactly one writer process; never run two pods.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: kcal-assistant
+  template:
+    metadata:
+      labels:
+        app: kcal-assistant
+
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: kcal-assistant
+          image: rutbergphilip/kcal-assistant:v0.1.0
+          imagePullPolicy: IfNotPresent
+
+          ports:
+            - name: http
+              containerPort: 3000
+
+          env:
+            - name: TZ
+              value: "Europe/Stockholm"
+            - name: PORT
+              value: "3000"
+            - name: DB_PATH
+              value: "/app/data/kcal.db"
+            - name: MCP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kcal-assistant-secrets
+                  key: MCP_TOKEN
+
+          volumeMounts:
+            - name: homelab-storage
+              mountPath: /app/data
+              subPath: kcal-assistant/data
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+
+      volumes:
+        - name: homelab-storage
+          persistentVolumeClaim:
+            claimName: homelab-nfs-pvc

--- a/kubernetes/apps/home-automation/kcal-assistant/ingress.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kcal-assistant
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+
+spec:
+  ingressClassName: external
+  rules:
+    - host: kcal.rutberg.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kcal-assistant
+                port:
+                  number: 3000

--- a/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home-automation
+
+resources:
+  - ./secret.sops.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./ingress.yaml

--- a/kubernetes/apps/home-automation/kcal-assistant/secret.sops.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcal-assistant-secrets
+  namespace: home-automation
+type: Opaque
+stringData:
+  MCP_TOKEN: ENC[AES256_GCM,data:uHDOSc/TwGNKSatOoi28LzcMHxWUnaSr4p1IF5LqPR4Tr08qG8SdozeHwBVprx/3mbMM54LGRXxYxKf/gl//Kg==,iv:tolRZwwfmJCtkV8fp2OUMY0+bEGcfOwKwv9h32ygbOk=,tag:bxdl6VsH2yK2L3bpsx6Www==,type:str]
+sops:
+  age:
+    - recipient: age10ppc643t645d2ph0czpz64zq9ezj0j9xu0c0mjytm6a34fzulqhqa8pp2k
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHSWNFVTV0dHlPUkMzdXkw
+        YjEvRi9HZkpoSXFTUXA2bmZLWkk2YzZyNEU0CnFwZjhmanc2WmJTYmlJUXlhLyty
+        SkhVNFBpTXVSekFxd0FBdExpU1psR0UKLS0tIHBWYUVzYlV3UU9MdE9IRWpZeFE5
+        Q0NreEVacmZCcTNaMGJmVlpQTnVBSEEKeGwtmdPL+QM5fIB9KD9tkW2LHMGK684B
+        zmVdYNZ22llTulkAiO9yhuHIeC16akJFuK4oNdwhEk0ZDT/C63xgXw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-06T16:26:28Z"
+  mac: ENC[AES256_GCM,data:1Njgwqw9mXkOhFeuM9SwucLjUJ8VU86E6nvgUD7qSCKCsOjytuhzPaTJk2Ub8MSrxdSonQ5tnkKUGEEDaxXlkAVJY0uVYs0a6NpcSvYcOExnmQcPpJ+Z6jo3mLCR5NeglUUuRl3DRA7/L1inRPeAmGqOD8dsjJuiTyz1Z2C07ho=,iv:Pi1g7US6emPwv2/JNWwfaGJprp69idxcfhLh8qg/pvc=,tag:hreXJPsaX8m4puWz6WYl+Q==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.10.2

--- a/kubernetes/apps/home-automation/kcal-assistant/service.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kcal-assistant
+  labels:
+    app: kcal-assistant
+
+spec:
+  type: ClusterIP
+  selector:
+    app: kcal-assistant
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./homarr
   - ./market-monitor
   - ./restock-watcher
+  - ./kcal-assistant


### PR DESCRIPTION
## Summary

Personal MCP server for calorie logging, used as a **custom connector in the Claude app** (per the Kcal Tracking Assistant PRD, fas 1 + nutrition lookup).

- **App** (`kcal-assistant/`): Bun + TypeScript, stateless Streamable HTTP MCP server with 12 tools — product DB with FTS5 fuzzy Swedish search (diacritics + compound-word tolerant), meal log with **server-computed macros** ("räkna högt": kcal/fat/carbs up, protein down), day types (vilo/gym/flex) with targets, persistent preferences, Open Food Facts lookup. 46 tests (unit + real MCP client integration).
- **Deploy** (`kubernetes/apps/home-automation/kcal-assistant/`): market-monitor-pattern raw manifests. Single replica + `Recreate` (SQLite on NFS = one writer), NFS subPath `kcal-assistant/data`, `kcal.rutberg.dev` via external ingress, SOPS-encrypted `MCP_TOKEN` as secret URL path segment.

## Verified locally

- `bun test`: 46 pass; `tsc --noEmit` clean
- amd64-container: healthz, FTS5 search, uid-1000 NFS write path
- Seed script + fuzzy search ("den där kycklingkebaben" → Kycklingkebab) end-to-end
- Open Food Facts live query ("propud" → complete Swedish products)

## After merge (manual steps)

1. **Image**: the CI workflow file (`.github/workflows/kcal-assistant.yaml`) could NOT be pushed — the git PAT lacks `workflow` scope. It exists locally; push it after `gh auth refresh -h github.com -s workflow`, and add `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets. Until an image exists at `rutbergphilip/kcal-assistant:v0.1.0`, the pod stays in ImagePullBackOff (harmless).
2. `task reconcile`, verify `curl https://kcal.rutberg.dev/healthz`
3. claude.ai → Settings → Connectors → add `https://kcal.rutberg.dev/mcp/<token>` (token: `sops -d kubernetes/apps/home-automation/kcal-assistant/secret.sops.yaml`)
4. Seed products: `bun scripts/seed.ts --url ... --file seed/products.json`
5. Create the Claude Project with the instructions from `kcal-assistant/README.md`