### PR TITLE
feat(kcal-assistant): nightly SQLite backup CronJob

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/backup-cronjob.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/backup-cronjob.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kcal-assistant-backup
+  labels:
+    app: kcal-assistant
+
+spec:
+  schedule: "0 3 * * *"
+  timeZone: "Europe/Stockholm"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        metadata:
+          labels:
+            app: kcal-assistant-backup
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+          containers:
+            - name: backup
+              image: oven/bun:1-alpine
+              imagePullPolicy: IfNotPresent
+              command: ["bun", "run", "/app/backup.ts"]
+              env:
+                - name: SRC
+                  value: "/data/kcal.db"
+              volumeMounts:
+                - name: script
+                  mountPath: /app
+                  readOnly: true
+                - name: homelab-storage
+                  mountPath: /data
+                  subPath: kcal-assistant/data
+                  readOnly: true
+                - name: homelab-storage
+                  mountPath: /backups
+                  subPath: kcal-assistant/backups
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+          volumes:
+            - name: script
+              configMap:
+                name: kcal-assistant-backup-script
+            - name: homelab-storage
+              persistentVolumeClaim:
+                claimName: homelab-nfs-pvc

--- a/kubernetes/apps/home-automation/kcal-assistant/backup.ts
+++ b/kubernetes/apps/home-automation/kcal-assistant/backup.ts
@@ -1,0 +1,21 @@
+// Nightly SQLite backup: open read-only, serialize a consistent snapshot,
+// write to /backups with weekday rotation (7 files, overwritten weekly).
+import { Database } from "bun:sqlite";
+
+const srcPath = process.env.SRC ?? "/data/kcal.db";
+const src = new Database(srcPath, { readonly: true });
+const snapshot = src.serialize();
+src.close();
+
+const weekday = new Date()
+  .toLocaleDateString("en-US", { weekday: "short", timeZone: "Europe/Stockholm" })
+  .toLowerCase();
+const dest = `/backups/kcal-${weekday}.db`;
+await Bun.write(dest, snapshot);
+
+// Restore check: the snapshot must open and contain the products table.
+const check = new Database(dest, { readonly: true });
+const row = check.query<{ n: number }, []>("SELECT count(*) AS n FROM products").get();
+check.close();
+
+console.log(`backup ok: ${dest} (${snapshot.byteLength} bytes, ${row?.n} products)`);

--- a/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
@@ -9,3 +9,9 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./backup-cronjob.yaml
+
+configMapGenerator:
+  - name: kcal-assistant-backup-script
+    files:
+      - backup.ts


### PR DESCRIPTION
Nightly (03:00 Europe/Stockholm) CronJob that snapshots the kcal SQLite DB via bun:sqlite serialize (read-only, consistent) to `kcal-assistant/backups` with weekday rotation (7 files). Script tested locally; restore check included (opens snapshot, counts products). Note: Flux Local Test failures are the pre-existing repo issue documented on #356.