### PR TITLE
feat(kcal-assistant): v0.3.0 - weight/TDEE trend, batch calculator, day preview

### DIFF
--- a/kcal-assistant/README.md
+++ b/kcal-assistant/README.md
@@ -1,6 +1,8 @@
 # kcal-assistant
 
-Personal MCP server for Philip's calorie tracking, used as a custom connector in the Claude app. Holds the product database, meal log, standing preferences/rules, an Open Food Facts lookup, live discovery against his ICA store (Maxi ICA Stormarknad Nynäshamn via handlaprivatkund.ica.se, `search_store`), and a week summary (`get_week`). Runs on the homelab cluster at `https://kcal.rutberg.dev/mcp/<token>`.
+Personal MCP server for Philip's calorie tracking, used as a custom connector in the Claude app. Holds the product database, meal log, standing preferences/rules, an Open Food Facts lookup, live discovery against his ICA store (Maxi ICA Stormarknad Nynäshamn via handlaprivatkund.ica.se, `search_store`), week summaries (`get_week`), a weight log with backwards-computed TDEE (`log_weight`/`get_trend`), a mealprep batch calculator (`compute_batch`), and dry-run day planning (`preview_day`). Runs on the homelab cluster at `https://kcal.rutberg.dev/mcp/<token>`.
+
+The server owns ALL nutrition math: item/meal/day computation at logging, plan previews, batch per-100g derivation, and the TDEE trend (`TDEE = snittintag + Δkg × 7700 ÷ dagar`, intake averaged over the same span as the weight delta, with staleness and uncertainty flags). Weight data lives only in the SQLite database, never in this repo.
 
 Note on ICA: the endpoints are the store site's own web API (no auth). Its WAF requires a browser User-Agent. Nutrition per 100g/100ml is parsed from the product pages' näringsvärde table; details are cached in-memory for 7 days.
 

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/batch.ts
+++ b/kcal-assistant/src/db/batch.ts
@@ -1,0 +1,74 @@
+import type { Database } from "bun:sqlite";
+import { type Macros, scalePer100g, sumMacros } from "../lib/macros";
+import { resolveItem, type MealItemInput } from "./meals";
+import { saveProduct, type Product } from "./products";
+
+export interface BatchInput {
+  name: string;
+  product_id?: number;
+  ingredients: MealItemInput[];
+  cooked_weight_g?: number;
+  portion?: { name: string; grams?: number; count?: number };
+  aliases?: string[];
+  notes?: string;
+  save?: boolean;
+}
+
+export interface BatchResult {
+  total: Macros;
+  cooked_weight_g: number;
+  per_100g: Macros;
+  portion: ({ name: string; grams: number } & Macros) | null;
+  saved_product?: Product;
+}
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+export function computeBatch(db: Database, input: BatchInput): BatchResult {
+  const resolved = input.ingredients.map((ingredient) => resolveItem(db, ingredient));
+
+  let cooked = input.cooked_weight_g;
+  if (cooked === undefined) {
+    if (resolved.some((r) => r.grams === null)) {
+      throw new Error("cooked_weight_g krävs när någon ingrediens saknar gram");
+    }
+    cooked = resolved.reduce((sum, r) => sum + r.grams!, 0);
+  }
+  if (!(cooked > 0)) throw new Error("cooked_weight_g måste vara större än 0");
+
+  const total = sumMacros(resolved.map((r) => r.macros));
+  // Plain nearest rounding: ingredients are already directionally rounded once;
+  // "räkna högt" applies to uncertainty, not to derived arithmetic — logging a
+  // portion applies the directional rounding exactly once.
+  const per100g: Macros = {
+    kcal: round2((total.kcal * 100) / cooked),
+    protein: round2((total.protein * 100) / cooked),
+    fat: round2((total.fat * 100) / cooked),
+    carbs: round2((total.carbs * 100) / cooked),
+  };
+
+  let portion: BatchResult["portion"] = null;
+  if (input.portion) {
+    const grams =
+      input.portion.grams ??
+      (input.portion.count !== undefined && input.portion.count > 0
+        ? Math.round((cooked / input.portion.count) * 10) / 10
+        : null);
+    if (grams === null) throw new Error("portion behöver grams eller count");
+    portion = { name: input.portion.name, grams, ...scalePer100g(per100g, grams) };
+  }
+
+  const result: BatchResult = { total, cooked_weight_g: cooked, per_100g: per100g, portion };
+  if (input.save) {
+    result.saved_product = saveProduct(db, {
+      id: input.product_id,
+      name: input.name,
+      per_100g: per100g,
+      aliases: input.aliases,
+      portions: portion ? [{ name: portion.name, grams: portion.grams }] : undefined,
+      notes: input.notes,
+      source: "manual",
+    });
+  }
+  return result;
+}

--- a/kcal-assistant/src/db/meals.ts
+++ b/kcal-assistant/src/db/meals.ts
@@ -49,7 +49,7 @@ function ensureDay(db: Database, date: string): void {
   db.run("INSERT OR IGNORE INTO days (date) VALUES (?)", [date]);
 }
 
-interface ResolvedItem {
+export interface ResolvedItem {
   product_id: number | null;
   description: string;
   grams: number | null;
@@ -58,7 +58,7 @@ interface ResolvedItem {
   macros: Macros;
 }
 
-function resolveItem(db: Database, item: MealItemInput): ResolvedItem {
+export function resolveItem(db: Database, item: MealItemInput): ResolvedItem {
   if (item.macros) {
     const description =
       item.description ?? (item.product_id ? getProduct(db, item.product_id)?.name : undefined);
@@ -152,23 +152,14 @@ function insertItems(db: Database, mealId: number, items: MealItemInput[]): void
   }
 }
 
-export function getDay(db: Database, date?: string): DayView {
-  const resolved = resolveDate(date);
-  ensureDay(db, resolved);
-  const day = db
-    .query<{ date: string; day_type: string }, [string]>(
-      "SELECT date, day_type FROM days WHERE date = ?",
-    )
-    .get(resolved)!;
-  const targets = getTargetsFor(db, day.day_type);
-
+function readMeals(db: Database, date: string): MealView[] {
   const mealRows = db
     .query<{ id: number; name: string; post_gym_shake: number; logged_at: string }, [string]>(
       "SELECT id, name, post_gym_shake, logged_at FROM meals WHERE day_date = ? ORDER BY post_gym_shake ASC, logged_at ASC, id ASC",
     )
-    .all(resolved);
+    .all(date);
 
-  const meals: MealView[] = mealRows.map((m) => {
+  return mealRows.map((m) => {
     const items = db
       .query<MealItemView, [number]>(
         "SELECT id, product_id, description, grams, quantity, portion_name, kcal, protein, fat, carbs FROM meal_items WHERE meal_id = ? ORDER BY id",
@@ -184,7 +175,18 @@ export function getDay(db: Database, date?: string): DayView {
       ...mealMacros,
     };
   });
+}
 
+export function getDay(db: Database, date?: string): DayView {
+  const resolved = resolveDate(date);
+  ensureDay(db, resolved);
+  const day = db
+    .query<{ date: string; day_type: string }, [string]>(
+      "SELECT date, day_type FROM days WHERE date = ?",
+    )
+    .get(resolved)!;
+  const targets = getTargetsFor(db, day.day_type);
+  const meals = readMeals(db, resolved);
   const totals = sumMacros(meals);
   const r1 = (x: number) => Math.round(x * 10) / 10;
   return {
@@ -308,6 +310,81 @@ export function getWeek(db: Database, endDate?: string): WeekView {
     days_logged: logged.length,
     avg_logged: avgLogged,
     avg_target_kcal: Math.round(days.reduce((a, day) => a + day.target_kcal, 0) / days.length),
+  };
+}
+
+export interface PreviewMealInput {
+  name: string;
+  items: MealItemInput[];
+  post_gym_shake?: boolean;
+}
+
+export interface PreviewMealView extends Macros {
+  name: string;
+  post_gym_shake: boolean;
+  items: Array<{ description: string; grams: number | null } & Macros>;
+}
+
+export interface DayPreview {
+  date: string;
+  day_type: string;
+  targets: DayTargets;
+  logged_meals: Array<{ name: string } & Macros>;
+  planned_meals: PreviewMealView[];
+  totals: Macros;
+  remaining: DayView["remaining"];
+  checks: { protein_floor_ok: boolean; fat_floor_ok: boolean };
+}
+
+// Dry-run day planning: identical math to logging, zero writes (no ensureDay).
+export function previewDay(
+  db: Database,
+  input: { date?: string; meals: PreviewMealInput[]; include_logged?: boolean },
+): DayPreview {
+  const date = resolveDate(input.date);
+  const dayRow = db
+    .query<{ day_type: string }, [string]>("SELECT day_type FROM days WHERE date = ?")
+    .get(date);
+  const dayType = dayRow?.day_type ?? "vilodag";
+  const targets = getTargetsFor(db, dayType);
+
+  const logged = input.include_logged === false ? [] : readMeals(db, date);
+  const planned: PreviewMealView[] = input.meals.map((meal) => {
+    const resolved = meal.items.map((item) => resolveItem(db, item));
+    const macros = sumMacros(resolved.map((r) => r.macros));
+    return {
+      name: meal.name,
+      post_gym_shake: meal.post_gym_shake ?? false,
+      items: resolved.map((r) => ({ description: r.description, grams: r.grams, ...r.macros })),
+      ...macros,
+    };
+  });
+
+  const totals = sumMacros([...logged, ...planned]);
+  const r1 = (x: number) => Math.round(x * 10) / 10;
+  return {
+    date,
+    day_type: dayType,
+    targets,
+    logged_meals: logged.map((m) => ({
+      name: m.name,
+      kcal: m.kcal,
+      protein: m.protein,
+      fat: m.fat,
+      carbs: m.carbs,
+    })),
+    planned_meals: planned,
+    totals,
+    remaining: {
+      kcal: targets.kcal - totals.kcal,
+      protein_to_min: Math.max(0, r1(targets.protein_min - totals.protein)),
+      fat_to_min: Math.max(0, r1(targets.fat_min - totals.fat)),
+      carbs: targets.carbs === null ? null : r1(targets.carbs - totals.carbs),
+    },
+    checks: {
+      protein_floor_ok: totals.protein >= targets.protein_min,
+      fat_floor_ok: totals.fat >= targets.fat_min,
+    },
   };
 }
 

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -97,6 +97,15 @@ const MIGRATIONS: string[] = [
     ('regel', 'Ingen kompensation dagen efter en flexdag', 70),
     ('regel', 'Post-gym-shaken listas alltid sist i dagslistan', 80);
   `,
+  // 2: weight log
+  `
+  CREATE TABLE weights (
+    date       TEXT PRIMARY KEY,
+    weight_kg  REAL NOT NULL CHECK (weight_kg > 0 AND weight_kg < 500),
+    note       TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/weights.ts
+++ b/kcal-assistant/src/db/weights.ts
@@ -1,0 +1,48 @@
+import type { Database } from "bun:sqlite";
+import { computeTrend, type TrendResult, type WeightEntry } from "../lib/trend";
+import { todayStockholm, isValidDate, toEpochDays } from "../lib/dates";
+
+export interface WeightTrendView extends TrendResult {
+  weights: WeightEntry[]; // weighings inside the window, ascending
+}
+
+export function logWeight(
+  db: Database,
+  input: { weight_kg: number; date?: string; note?: string },
+): WeightTrendView {
+  if (!(input.weight_kg > 0 && input.weight_kg < 500)) {
+    throw new Error(`Orimlig vikt: ${input.weight_kg} kg`);
+  }
+  let date = input.date ?? todayStockholm();
+  if (!isValidDate(date)) throw new Error(`Invalid date: ${date} (expected YYYY-MM-DD)`);
+  db.run(
+    `INSERT INTO weights (date, weight_kg, note) VALUES (?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET
+       weight_kg = excluded.weight_kg,
+       note = coalesce(excluded.note, weights.note)`,
+    [date, input.weight_kg, input.note ?? null],
+  );
+  return getTrend(db);
+}
+
+export function getTrend(db: Database, windowDays = 28): WeightTrendView {
+  const allWeights = db
+    .query<WeightEntry, []>("SELECT date, weight_kg FROM weights ORDER BY date")
+    .all();
+  const intakeRows = db
+    .query<{ date: string; kcal: number }, []>(
+      "SELECT m.day_date AS date, SUM(mi.kcal) AS kcal FROM meals m JOIN meal_items mi ON mi.meal_id = m.id GROUP BY m.day_date",
+    )
+    .all();
+  const result = computeTrend({
+    weights: allWeights,
+    intakeByDate: new Map(intakeRows.map((r) => [r.date, r.kcal])),
+    windowDays,
+  });
+  const weights = result.latest
+    ? allWeights.filter(
+        (w) => toEpochDays(w.date) >= toEpochDays(result.latest!.date) - (windowDays - 1),
+      )
+    : [];
+  return { ...result, weights };
+}

--- a/kcal-assistant/src/lib/dates.ts
+++ b/kcal-assistant/src/lib/dates.ts
@@ -12,6 +12,20 @@ export function todayStockholm(): string {
   return stockholmFormatter.format(new Date());
 }
 
+// UTC-day based date arithmetic — immune to DST since dates are pure Y-M-D.
+export function toEpochDays(date: string): number {
+  const [y, m, d] = date.split("-").map(Number) as [number, number, number];
+  return Date.UTC(y, m - 1, d) / 86_400_000;
+}
+
+export function epochDaysToDate(days: number): string {
+  return new Date(days * 86_400_000).toISOString().slice(0, 10);
+}
+
+export function addDays(date: string, n: number): string {
+  return epochDaysToDate(toEpochDays(date) + n);
+}
+
 export function isValidDate(value: string): boolean {
   if (!DATE_RE.test(value)) return false;
   const [y, m, d] = value.split("-").map(Number) as [number, number, number];

--- a/kcal-assistant/src/lib/trend.ts
+++ b/kcal-assistant/src/lib/trend.ts
@@ -1,0 +1,105 @@
+import { toEpochDays, epochDaysToDate, todayStockholm } from "./dates";
+
+// Backwards-computed TDEE from weight change + logged intake:
+//   TDEE = snittintag + (viktförändring kg × 7700 ÷ antal dagar)
+// Weights are noisy (water, woosh), so both endpoints are means over the
+// first/second half of the window, and intake is averaged over exactly the
+// span between those two mean dates — never over days outside the delta.
+
+export interface WeightEntry {
+  date: string;
+  weight_kg: number;
+}
+
+export interface Trend {
+  delta_kg: number; // positive = loss
+  span_days: number;
+  rate_kg_week: number;
+  avg_intake: number | null;
+  intake_days: number;
+  span_total_days: number;
+  est_tdee: number | null;
+  uncertain: boolean; // < 50% of span days have logged intake
+}
+
+export interface TrendResult {
+  latest: WeightEntry | null;
+  window_days: number;
+  stale: boolean; // latest weighing older than 7 days
+  trend: Trend | null;
+  reason?: string;
+}
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+export function computeTrend(input: {
+  weights: WeightEntry[];
+  intakeByDate: Map<string, number>;
+  windowDays?: number;
+  today?: string;
+}): TrendResult {
+  const windowDays = input.windowDays ?? 28;
+  const sorted = [...input.weights].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const latest = sorted.at(-1) ?? null;
+  if (!latest) {
+    return { latest: null, window_days: windowDays, stale: false, trend: null, reason: "inga viktloggar" };
+  }
+
+  const today = input.today ?? todayStockholm();
+  const stale = toEpochDays(today) - toEpochDays(latest.date) > 7;
+
+  const latestEpoch = toEpochDays(latest.date);
+  const windowStart = latestEpoch - (windowDays - 1);
+  const midpoint = windowStart + windowDays / 2;
+  const inWindow = sorted.filter((w) => toEpochDays(w.date) >= windowStart);
+  const firstHalf = inWindow.filter((w) => toEpochDays(w.date) < midpoint);
+  const secondHalf = inWindow.filter((w) => toEpochDays(w.date) >= midpoint);
+
+  const base = { latest, window_days: windowDays, stale };
+  if (firstHalf.length < 2 || secondHalf.length < 2) {
+    return { ...base, trend: null, reason: "för få viktloggar i fönstret (minst 2 i varje halva behövs)" };
+  }
+
+  const mean = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length;
+  const anchorWeight = mean(firstHalf.map((w) => w.weight_kg));
+  const endWeight = mean(secondHalf.map((w) => w.weight_kg));
+  const anchorDate = mean(firstHalf.map((w) => toEpochDays(w.date)));
+  const endDate = mean(secondHalf.map((w) => toEpochDays(w.date)));
+  const span = endDate - anchorDate;
+  if (span < 7) {
+    return { ...base, trend: null, reason: "för kort mätspann mellan vägningsgrupperna" };
+  }
+
+  const delta = anchorWeight - endWeight; // positive = loss
+
+  // Intake over exactly the delta span (integer days between the mean dates).
+  const spanStart = Math.ceil(anchorDate);
+  const spanEnd = Math.floor(endDate);
+  const spanTotalDays = spanEnd - spanStart + 1;
+  let intakeSum = 0;
+  let intakeDays = 0;
+  for (let epoch = spanStart; epoch <= spanEnd; epoch++) {
+    const kcal = input.intakeByDate.get(epochDaysToDate(epoch));
+    if (kcal !== undefined) {
+      intakeSum += kcal;
+      intakeDays++;
+    }
+  }
+  const avgIntake = intakeDays > 0 ? Math.round(intakeSum / intakeDays) : null;
+  const estTdee =
+    avgIntake === null ? null : Math.round((avgIntake + (delta * 7700) / span) / 10) * 10;
+
+  return {
+    ...base,
+    trend: {
+      delta_kg: round2(delta),
+      span_days: round2(span),
+      rate_kg_week: round2((delta / span) * 7),
+      avg_intake: avgIntake,
+      intake_days: intakeDays,
+      span_total_days: spanTotalDays,
+      est_tdee: estTdee,
+      uncertain: intakeDays / spanTotalDays < 0.5,
+    },
+  };
+}

--- a/kcal-assistant/src/mcp.ts
+++ b/kcal-assistant/src/mcp.ts
@@ -6,6 +6,7 @@ import { registerMealTools } from "./tools/meals";
 import { registerPreferenceTools } from "./tools/preferences";
 import { registerNutritionTools } from "./tools/nutrition";
 import { registerStoreTools } from "./tools/store";
+import { registerWeightTools } from "./tools/weights";
 
 // A fresh McpServer per request (stateless Streamable HTTP). The Database is
 // the shared singleton — safe because bun:sqlite is synchronous.
@@ -17,5 +18,6 @@ export function buildMcpServer(db: Database): McpServer {
   registerPreferenceTools(server, db);
   registerNutritionTools(server);
   registerStoreTools(server);
+  registerWeightTools(server, db);
   return server;
 }

--- a/kcal-assistant/src/tools/context.ts
+++ b/kcal-assistant/src/tools/context.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "bun:sqlite";
 import { getDay, getWeek } from "../db/meals";
+import { getTrend } from "../db/weights";
 import { listPreferences, getTargets, type Preference } from "../db/preferences";
 import { dateSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
@@ -21,13 +22,23 @@ export function registerContextTools(server: McpServer, db: Database): void {
         "Call this at the START of every conversation. Returns Philip's standing rules and style preferences (follow them exactly; user-facing text is Swedish), all day-type targets, and today's log with totals and remaining vs targets. Always use the server's numbers, never compute macros yourself.",
       inputSchema: { date: dateSchema.optional() },
     },
-    wrap(({ date }) =>
-      jsonResult({
+    wrap(({ date }) => {
+      const trend = getTrend(db);
+      return jsonResult({
         preferences: groupPreferences(listPreferences(db)),
         all_targets: getTargets(db),
         day: getDay(db, date),
-      }),
-    ),
+        ...(trend.latest && {
+          weight: {
+            latest: trend.latest,
+            rate_kg_week: trend.trend?.rate_kg_week ?? null,
+            est_tdee: trend.trend?.est_tdee ?? null,
+            uncertain: trend.trend?.uncertain ?? null,
+            stale: trend.stale,
+          },
+        }),
+      });
+    }),
   );
 
   server.registerTool(

--- a/kcal-assistant/src/tools/meals.ts
+++ b/kcal-assistant/src/tools/meals.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
-import { logMeal, editMeal, setDayType } from "../db/meals";
+import { logMeal, editMeal, setDayType, previewDay } from "../db/meals";
 import { setTargets } from "../db/preferences";
 import { dateSchema, dayTypeSchema, mealItemSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
@@ -36,6 +36,31 @@ export function registerMealTools(server: McpServer, db: Database): void {
       },
     },
     wrap((input) => jsonResult(editMeal(db, input))),
+  );
+
+  server.registerTool(
+    "preview_day",
+    {
+      description:
+        "Dry-run a day plan with EXACT server math — use this for ALL day planning instead of computing macros yourself. Saves nothing. Returns logged meals (already eaten today) separately from planned meals, combined totals, remaining vs targets, and floor checks. If a planned meal duplicates a logged one, drop it from the plan or set include_logged false.",
+      inputSchema: {
+        date: dateSchema.optional(),
+        meals: z
+          .array(
+            z.object({
+              name: z.string().min(1),
+              items: z.array(mealItemSchema).min(1),
+              post_gym_shake: z.boolean().optional(),
+            }),
+          )
+          .min(1),
+        include_logged: z
+          .boolean()
+          .optional()
+          .describe("Default true: today's logged meals count toward the totals"),
+      },
+    },
+    wrap((input) => jsonResult(previewDay(db, input))),
   );
 
   server.registerTool(

--- a/kcal-assistant/src/tools/products.ts
+++ b/kcal-assistant/src/tools/products.ts
@@ -2,7 +2,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
 import { getProduct, saveProduct, searchProducts } from "../db/products";
-import { macrosSchema, portionSchema } from "./schemas";
+import { computeBatch } from "../db/batch";
+import { macrosSchema, mealItemSchema, portionSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
 export function registerProductTools(server: McpServer, db: Database): void {
@@ -50,5 +51,30 @@ export function registerProductTools(server: McpServer, db: Database): void {
       },
     },
     wrap((input) => jsonResult(saveProduct(db, input))),
+  );
+
+  server.registerTool(
+    "compute_batch",
+    {
+      description:
+        "Recalculate a mealprep batch (e.g. köttfärsblandningen) with exact server math and optionally save it as a product. Enter ingredients AS THEY END UP IN THE BATCH (e.g. 'stekt färs efter fettavhällning' as its own entry with its macros). cooked_weight_g = weighed batch after cooking; defaults to the ingredient gram sum. save defaults to FALSE — set true (with product_id to update in place) once Philip confirms.",
+      inputSchema: {
+        name: z.string().min(1),
+        product_id: z.number().int().optional().describe("Update this product instead of creating"),
+        ingredients: z.array(mealItemSchema).min(1),
+        cooked_weight_g: z.number().positive().optional(),
+        portion: z
+          .object({
+            name: z.string().min(1).describe("E.g. 'låda'"),
+            grams: z.number().positive().optional(),
+            count: z.number().positive().optional().describe("Portions per batch, e.g. 7.5"),
+          })
+          .optional(),
+        aliases: z.array(z.string()).optional(),
+        notes: z.string().optional().describe("Recipe summary so it can be recomputed later"),
+        save: z.boolean().optional(),
+      },
+    },
+    wrap((input) => jsonResult(computeBatch(db, input))),
   );
 }

--- a/kcal-assistant/src/tools/weights.ts
+++ b/kcal-assistant/src/tools/weights.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { logWeight, getTrend } from "../db/weights";
+import { dateSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+export function registerWeightTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "log_weight",
+    {
+      description:
+        "Log a morning weight ('82.1 idag'). Upserts by date, so a correction is just re-logging the same date. Returns the computed trend: rate kg/week and backwards-computed TDEE (snittintag + viktförändring × 7700 / dagar, averaged over the same period as the weight delta). Present the trend numbers as-is, never recompute.",
+      inputSchema: {
+        weight_kg: z.number().positive().lt(500),
+        date: dateSchema.optional(),
+        note: z.string().optional().describe("E.g. 'efter flexhelg', 'kreatinladdning'"),
+      },
+    },
+    wrap((input) => jsonResult(logWeight(db, input))),
+  );
+
+  server.registerTool(
+    "get_trend",
+    {
+      description:
+        "Weight trend and real TDEE over a window ENDING AT THE LATEST WEIGHING (not today; stale:true means the latest weighing is over a week old). trend is null with a reason when data is too sparse; uncertain:true means under half the span days have logged intake. Use for 'hur går det?' and for calibrating targets.",
+      inputSchema: {
+        window_days: z.number().int().min(14).max(365).optional().describe("Default 28"),
+      },
+    },
+    wrap(({ window_days }) => jsonResult(getTrend(db, window_days ?? 28))),
+  );
+}

--- a/kcal-assistant/tests/batch.test.ts
+++ b/kcal-assistant/tests/batch.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { computeBatch } from "../src/db/batch";
+import { saveProduct, getProduct } from "../src/db/products";
+import { logMeal } from "../src/db/meals";
+
+let db: Database;
+let riceId: number;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  riceId = saveProduct(db, {
+    name: "Jasminris torrt",
+    per_100g: { kcal: 360, protein: 7, fat: 1, carbs: 79 },
+  }).id;
+});
+
+const MINCE = { description: "Stekt nötfärs avrunnen", grams: 800, macros: { kcal: 1600, protein: 160, fat: 96, carbs: 0 } };
+
+describe("computeBatch", () => {
+  test("computes totals, per-100g (plain 2-decimal rounding) and portion from count", () => {
+    const result = computeBatch(db, {
+      name: "Testbatch",
+      ingredients: [MINCE, { product_id: riceId, grams: 210 }],
+      cooked_weight_g: 1875,
+      portion: { name: "låda", count: 7.5 },
+    });
+    // rice 210g: kcal 756, protein 14.7, fat 2.1, carbs 165.9 (directional per resolveItem)
+    expect(result.total.kcal).toBe(2356);
+    expect(result.cooked_weight_g).toBe(1875);
+    // per-100g plain nearest, 2 decimals: 2356/18.75 = 125.65
+    expect(result.per_100g.kcal).toBe(125.65);
+    expect(result.portion!.grams).toBe(250);
+    expect(result.portion!.name).toBe("låda");
+    expect(result.saved_product).toBeUndefined(); // save defaults to false
+  });
+
+  test("cooked_weight_g defaults to ingredient gram sum", () => {
+    const result = computeBatch(db, {
+      name: "Testbatch",
+      ingredients: [MINCE, { product_id: riceId, grams: 200 }],
+    });
+    expect(result.cooked_weight_g).toBe(1000);
+  });
+
+  test("requires cooked_weight_g when an ingredient lacks grams", () => {
+    expect(() =>
+      computeBatch(db, {
+        name: "Testbatch",
+        ingredients: [{ description: "Sås", macros: { kcal: 100, protein: 1, fat: 10, carbs: 2 } }],
+      }),
+    ).toThrow(/cooked_weight_g/);
+  });
+
+  test("save:true creates the product; end-to-end log lands within ±2 kcal of hand-computed", () => {
+    const result = computeBatch(db, {
+      name: "Testbatch",
+      ingredients: [MINCE, { product_id: riceId, grams: 210 }],
+      cooked_weight_g: 1875,
+      portion: { name: "låda", count: 7.5 },
+      save: true,
+    });
+    const saved = result.saved_product!;
+    expect(getProduct(db, saved.id)!.portions[0]!.name).toBe("låda");
+
+    const { day } = logMeal(db, {
+      name: "Lunch",
+      date: "2026-07-08",
+      items: [{ product_id: saved.id, portion_name: "låda" }],
+    });
+    // hand-computed: total 2356 kcal / 1875g * 250g = 314.13 -> logged with one directional round
+    expect(Math.abs(day.totals.kcal - 314)).toBeLessThanOrEqual(2);
+  });
+
+  test("save with product_id updates in place (the köttfärs correction flow)", () => {
+    const first = computeBatch(db, {
+      name: "Testbatch",
+      ingredients: [MINCE],
+      cooked_weight_g: 800,
+      save: true,
+    });
+    const second = computeBatch(db, {
+      name: "Testbatch v2",
+      product_id: first.saved_product!.id,
+      ingredients: [MINCE, { product_id: riceId, grams: 210 }],
+      cooked_weight_g: 1875,
+      save: true,
+    });
+    expect(second.saved_product!.id).toBe(first.saved_product!.id);
+    expect(getProduct(db, first.saved_product!.id)!.name).toBe("Testbatch v2");
+  });
+});

--- a/kcal-assistant/tests/preview.test.ts
+++ b/kcal-assistant/tests/preview.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+import { logMeal, previewDay } from "../src/db/meals";
+import { setTargets } from "../src/db/preferences";
+
+const DATE = "2026-07-08";
+let db: Database;
+let chickenId: number;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  chickenId = saveProduct(db, {
+    name: "Kycklingfilé",
+    per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+  }).id;
+  setTargets(db, { day_type: "vilodag", kcal: 1400, protein_min: 150, fat_min: 50 });
+});
+
+describe("previewDay", () => {
+  test("computes planned meals and totals without writing anything", () => {
+    const preview = previewDay(db, {
+      date: DATE,
+      meals: [
+        { name: "Lunch", items: [{ product_id: chickenId, grams: 300 }] },
+        { name: "Middag", items: [{ product_id: chickenId, grams: 200 }] },
+      ],
+    });
+    expect(preview.planned_meals).toHaveLength(2);
+    expect(preview.planned_meals[0]!.kcal).toBe(318);
+    expect(preview.totals.kcal).toBe(530);
+    expect(preview.remaining.kcal).toBe(1400 - 530);
+    // nothing persisted — not even a days row
+    expect(db.query("SELECT 1 FROM meals").get()).toBeNull();
+    expect(db.query("SELECT 1 FROM days WHERE date = ?").get(DATE)).toBeNull();
+  });
+
+  test("lists logged meals separately and includes them in totals", () => {
+    logMeal(db, { name: "Frukost", date: DATE, items: [{ product_id: chickenId, grams: 100 }] });
+    const preview = previewDay(db, {
+      date: DATE,
+      meals: [{ name: "Lunch", items: [{ product_id: chickenId, grams: 300 }] }],
+    });
+    expect(preview.logged_meals).toHaveLength(1);
+    expect(preview.logged_meals[0]!.name).toBe("Frukost");
+    expect(preview.totals.kcal).toBe(106 + 318);
+  });
+
+  test("include_logged: false plans a clean slate", () => {
+    logMeal(db, { name: "Frukost", date: DATE, items: [{ product_id: chickenId, grams: 100 }] });
+    const preview = previewDay(db, {
+      date: DATE,
+      meals: [{ name: "Lunch", items: [{ product_id: chickenId, grams: 300 }] }],
+      include_logged: false,
+    });
+    expect(preview.logged_meals).toHaveLength(0);
+    expect(preview.totals.kcal).toBe(318);
+  });
+
+  test("floor checks: protein exactly at the floor passes", () => {
+    // 652.2g chicken = 150.0 protein exactly (23 * 6.522) — use grams that land exactly
+    const preview = previewDay(db, {
+      date: DATE,
+      meals: [{ name: "Protein", items: [{ description: "Exakt", macros: { kcal: 700, protein: 150, fat: 50, carbs: 0 } }] }],
+    });
+    expect(preview.checks.protein_floor_ok).toBe(true);
+    expect(preview.checks.fat_floor_ok).toBe(true);
+  });
+
+  test("floor checks fail below the floors", () => {
+    const preview = previewDay(db, {
+      date: DATE,
+      meals: [{ name: "Magert", items: [{ description: "Lite", macros: { kcal: 500, protein: 100, fat: 20, carbs: 10 } }] }],
+    });
+    expect(preview.checks.protein_floor_ok).toBe(false);
+    expect(preview.checks.fat_floor_ok).toBe(false);
+  });
+
+  test("unknown product id throws (surfaces as tool isError)", () => {
+    expect(() =>
+      previewDay(db, { date: DATE, meals: [{ name: "Fel", items: [{ product_id: 99999, grams: 100 }] }] }),
+    ).toThrow(/not found/);
+  });
+});

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -63,7 +63,7 @@ describe("http routing", () => {
 });
 
 describe("mcp over streamable http", () => {
-  test("lists all 14 tools", async () => {
+  test("lists all 18 tools", async () => {
     const client = await connect();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
@@ -83,8 +83,34 @@ describe("mcp over streamable http", () => {
         "save_preference",
         "delete_preference",
         "search_store",
+        "log_weight",
+        "get_trend",
+        "compute_batch",
+        "preview_day",
       ].sort(),
     );
+    await client.close();
+  });
+
+  test("preview_day round-trips through the MCP client", async () => {
+    const client = await connect();
+    const preview = parseResult(
+      await client.callTool({
+        name: "preview_day",
+        arguments: {
+          date: "2026-07-08",
+          meals: [
+            {
+              name: "Planerad lunch",
+              items: [{ description: "Testrätt", macros: { kcal: 700, protein: 190, fat: 65, carbs: 30 } }],
+            },
+          ],
+        },
+      }),
+    );
+    expect(preview.planned_meals).toHaveLength(1);
+    expect(preview.totals.kcal).toBe(700);
+    expect(preview.checks.protein_floor_ok).toBe(true);
     await client.close();
   });
 

--- a/kcal-assistant/tests/trend.test.ts
+++ b/kcal-assistant/tests/trend.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { computeTrend } from "../src/lib/trend";
+import { toEpochDays, addDays } from "../src/lib/dates";
+
+// All fixtures use obviously synthetic weights (100 kg range) — public repo.
+
+function intakeRange(start: string, end: string, kcal: number): Map<string, number> {
+  const map = new Map<string, number>();
+  for (let d = start; d <= end; d = addDays(d, 1)) map.set(d, kcal);
+  return map;
+}
+
+describe("date arithmetic", () => {
+  test("toEpochDays is monotonic across DST transition (2026-03-29 Europe)", () => {
+    expect(toEpochDays("2026-03-30") - toEpochDays("2026-03-29")).toBe(1);
+    expect(toEpochDays("2026-03-29") - toEpochDays("2026-03-28")).toBe(1);
+  });
+
+  test("addDays crosses month and DST boundaries cleanly", () => {
+    expect(addDays("2026-03-28", 2)).toBe("2026-03-30");
+    expect(addDays("2026-06-30", 1)).toBe("2026-07-01");
+    expect(addDays("2026-07-06", -6)).toBe("2026-06-30");
+  });
+});
+
+describe("computeTrend", () => {
+  const BASE = "2026-06-01"; // window day 0
+  const day = (n: number) => addDays(BASE, n);
+
+  // Hand-computed reference case:
+  // first half weights: day0 100.0, day3 99.6, day7 99.2 -> mean 99.6 at mean date 3.333
+  // second half:       day21 98.2, day24 98.0, day27 97.8 -> mean 98.0 at mean date 24
+  // span = 20.667 days, delta = 1.6 kg, rate = 0.54 kg/week
+  // intake 1500 kcal on every span day (4..24) -> est_tdee = 1500 + 1.6*7700/20.667 = 2096 -> 2100
+  const weights = [
+    { date: day(0), weight_kg: 100.0 },
+    { date: day(3), weight_kg: 99.6 },
+    { date: day(7), weight_kg: 99.2 },
+    { date: day(21), weight_kg: 98.2 },
+    { date: day(24), weight_kg: 98.0 },
+    { date: day(27), weight_kg: 97.8 },
+  ];
+
+  test("matches the hand-computed reference", () => {
+    const result = computeTrend({
+      weights,
+      intakeByDate: intakeRange(day(4), day(24), 1500),
+      windowDays: 28,
+      today: day(27),
+    });
+    expect(result.latest).toEqual({ date: day(27), weight_kg: 97.8 });
+    expect(result.stale).toBe(false);
+    const t = result.trend!;
+    expect(t.delta_kg).toBe(1.6);
+    expect(t.rate_kg_week).toBe(0.54);
+    expect(t.avg_intake).toBe(1500);
+    expect(t.est_tdee).toBe(2100);
+    expect(t.uncertain).toBe(false);
+  });
+
+  test("intake outside the weight-delta span is excluded", () => {
+    const intake = intakeRange(day(4), day(24), 1500);
+    intake.set(day(0), 9000); // flexday binge BEFORE the span must not contaminate TDEE
+    intake.set(day(27), 9000); // nor after
+    const t = computeTrend({ weights, intakeByDate: intake, windowDays: 28, today: day(27) }).trend!;
+    expect(t.avg_intake).toBe(1500);
+    expect(t.est_tdee).toBe(2100);
+  });
+
+  test("weight gain gives negative delta and TDEE below intake", () => {
+    const gaining = weights.map((w, i) => ({ date: w.date, weight_kg: 100 + i * 0.2 }));
+    const t = computeTrend({
+      weights: gaining,
+      intakeByDate: intakeRange(day(0), day(27), 2500),
+      windowDays: 28,
+      today: day(27),
+    }).trend!;
+    expect(t.delta_kg).toBeLessThan(0);
+    expect(t.est_tdee!).toBeLessThan(2500);
+  });
+
+  test("returns null trend with reason when a half has fewer than 2 weighings", () => {
+    const result = computeTrend({
+      weights: weights.slice(3), // only second-half weights
+      intakeByDate: new Map(),
+      windowDays: 28,
+      today: day(27),
+    });
+    expect(result.trend).toBeNull();
+    expect(result.reason).toContain("viktlogg");
+  });
+
+  test("returns null trend when weighings cluster at the half boundary (span < 7, 14-day window)", () => {
+    // 14-day window ending day13: first half [day0..day6], second [day7..day13].
+    // Weights at 4,5 | 7,13 -> half mean-dates 4.5 and 10 -> span 5.5 < 7.
+    const clustered = [
+      { date: day(4), weight_kg: 100.0 },
+      { date: day(5), weight_kg: 99.9 },
+      { date: day(7), weight_kg: 99.8 },
+      { date: day(13), weight_kg: 99.7 },
+    ];
+    const result = computeTrend({
+      weights: clustered,
+      intakeByDate: new Map(),
+      windowDays: 14,
+      today: day(13),
+    });
+    expect(result.trend).toBeNull();
+    expect(result.reason).toContain("spann");
+  });
+
+  test("empty and single-weight inputs", () => {
+    expect(computeTrend({ weights: [], intakeByDate: new Map(), today: day(0) }).latest).toBeNull();
+    const one = computeTrend({
+      weights: [{ date: day(0), weight_kg: 100 }],
+      intakeByDate: new Map(),
+      today: day(0),
+    });
+    expect(one.latest!.weight_kg).toBe(100);
+    expect(one.trend).toBeNull();
+  });
+
+  test("no logged intake in span -> est_tdee null but rate still computed", () => {
+    const t = computeTrend({ weights, intakeByDate: new Map(), windowDays: 28, today: day(27) }).trend!;
+    expect(t.est_tdee).toBeNull();
+    expect(t.rate_kg_week).toBe(0.54);
+  });
+
+  test("sparse intake logging in span sets uncertain", () => {
+    const sparse = new Map<string, number>([[day(10), 1500], [day(11), 1500]]); // 2 of 21 span days
+    const t = computeTrend({ weights, intakeByDate: sparse, windowDays: 28, today: day(27) }).trend!;
+    expect(t.uncertain).toBe(true);
+    expect(t.est_tdee).not.toBeNull();
+  });
+
+  test("stale when latest weighing is more than 7 days old", () => {
+    const result = computeTrend({
+      weights,
+      intakeByDate: new Map(),
+      windowDays: 28,
+      today: addDays(day(27), 10),
+    });
+    expect(result.stale).toBe(true);
+  });
+});

--- a/kcal-assistant/tests/weights.test.ts
+++ b/kcal-assistant/tests/weights.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { logWeight, getTrend } from "../src/db/weights";
+import { saveProduct } from "../src/db/products";
+import { logMeal } from "../src/db/meals";
+import { addDays } from "../src/lib/dates";
+
+let db: Database;
+beforeEach(() => {
+  db = openDb(":memory:");
+});
+
+describe("logWeight", () => {
+  test("saves and upserts by date, preserving note when re-logged without one", () => {
+    logWeight(db, { weight_kg: 100.0, date: "2026-06-01", note: "efter semester" });
+    logWeight(db, { weight_kg: 99.8, date: "2026-06-01" }); // correction, no note
+    const row = db
+      .query<{ weight_kg: number; note: string | null }, [string]>(
+        "SELECT weight_kg, note FROM weights WHERE date = ?",
+      )
+      .get("2026-06-01")!;
+    expect(row.weight_kg).toBe(99.8);
+    expect(row.note).toBe("efter semester");
+  });
+
+  test("rejects nonsense weights with a clean error, not an SQLite exception", () => {
+    expect(() => logWeight(db, { weight_kg: 0, date: "2026-06-01" })).toThrow(/vikt/i);
+    expect(() => logWeight(db, { weight_kg: 600, date: "2026-06-01" })).toThrow(/vikt/i);
+  });
+
+  test("returns the trend object", () => {
+    const result = logWeight(db, { weight_kg: 100, date: "2026-06-01" });
+    expect(result.latest!.weight_kg).toBe(100);
+    expect(result.trend).toBeNull(); // single weighing
+  });
+});
+
+describe("getTrend (integration with meal intake)", () => {
+  test("joins logged intake into TDEE over the weight-delta span", () => {
+    const pid = saveProduct(db, {
+      name: "Testmat",
+      per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 },
+    }).id;
+    const base = "2026-06-01";
+    // synthetic: 100.0 -> 98.0 over 4 weeks, 1500 kcal/day logged on every span day
+    for (const [offset, kg] of [[0, 100.0], [3, 99.6], [7, 99.2], [21, 98.2], [24, 98.0], [27, 97.8]] as const) {
+      logWeight(db, { weight_kg: kg, date: addDays(base, offset) });
+    }
+    for (let d = 4; d <= 24; d++) {
+      logMeal(db, { name: "Mat", date: addDays(base, d), items: [{ product_id: pid, grams: 1500 }] });
+    }
+    const result = getTrend(db, 28);
+    expect(result.trend!.avg_intake).toBe(1500);
+    expect(result.trend!.est_tdee).toBe(2100);
+    expect(result.weights.length).toBe(6);
+  });
+
+  test("empty state", () => {
+    const result = getTrend(db, 28);
+    expect(result.latest).toBeNull();
+    expect(result.weights).toHaveLength(0);
+    expect(result.trend).toBeNull();
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.2.0
+          image: rutbergphilip/kcal-assistant:v0.3.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
## v0.3.0 — the server owns all math

- **log_weight / get_trend**: weight log (upsert by date, note-preserving) + backwards-computed TDEE. Two-half window smoothing, intake averaged over exactly the weight-delta span, min-span guard, `stale`/`uncertain` flags instead of confident nonsense. Weight data lives only in the SQLite DB, never in this repo.
- **compute_batch**: mealprep recalculation; per-100g uses plain 2-decimal rounding so directional 'räkna högt' rounding applies exactly once (at logging). `save` defaults to false.
- **preview_day**: dry-run day planning — logged and planned meals listed separately (no silent double-count), floor checks, zero writes (not even a days row).
- get_context gains a compact conditional weight block. Migration 2 (weights table); rollback to v0.2 with user_version=2 is safe (migration loop no-ops, old code ignores the table).
- 81 tests green (hand-computed TDEE reference, DST-safe date math, end-to-end ±2 kcal batch check), tsc clean, container smoke-tested. First fully CI-driven release: merging builds and pushes v0.3.0.

Flux Local Test failures are the pre-existing repo issue (see #356).