### PR TITLE
fix(kcal-assistant): make save_product updates partial

### DIFF
--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/products.ts
+++ b/kcal-assistant/src/db/products.ts
@@ -126,8 +126,15 @@ export function saveProduct(db: Database, input: ProductInput): Product {
     let id = input.id;
     const m = input.per_100g;
     if (id) {
-      const exists = db.query("SELECT 1 FROM products WHERE id = ?").get(id);
-      if (!exists) throw new Error(`Product ${id} not found`);
+      const existing = db
+        .query<ProductRow, [number]>("SELECT * FROM products WHERE id = ?")
+        .get(id);
+      if (!existing) throw new Error(`Product ${id} not found`);
+      // PARTIAL update: omitted fields keep their current values so a
+      // "just update the note" call can never wipe macros. Empty string
+      // explicitly clears a text field.
+      const clearable = (value: string | null | undefined, current: string | null) =>
+        value === undefined ? current : value === "" ? null : value;
       db.run(
         `UPDATE products SET
            name = ?, brand = ?, kcal_100g = ?, protein_100g = ?, fat_100g = ?, carbs_100g = ?,
@@ -135,14 +142,14 @@ export function saveProduct(db: Database, input: ProductInput): Product {
          WHERE id = ?`,
         [
           input.name,
-          input.brand ?? null,
-          m?.kcal ?? null,
-          m?.protein ?? null,
-          m?.fat ?? null,
-          m?.carbs ?? null,
-          input.notes ?? null,
-          input.verified === false ? 0 : 1,
-          input.source ?? "manual",
+          clearable(input.brand, existing.brand),
+          m === undefined ? existing.kcal_100g : m?.kcal ?? null,
+          m === undefined ? existing.protein_100g : m?.protein ?? null,
+          m === undefined ? existing.fat_100g : m?.fat ?? null,
+          m === undefined ? existing.carbs_100g : m?.carbs ?? null,
+          clearable(input.notes, existing.notes),
+          input.verified === undefined ? existing.verified : input.verified ? 1 : 0,
+          input.source ?? existing.source,
           id,
         ],
       );

--- a/kcal-assistant/src/tools/products.ts
+++ b/kcal-assistant/src/tools/products.ts
@@ -37,7 +37,7 @@ export function registerProductTools(server: McpServer, db: Database): void {
     "save_product",
     {
       description:
-        "Create a product, or update one by passing id (THE single place to correct values when packaging/recipes change). aliases and portions replace the existing lists wholesale when provided. For estimated values set verified:false and round kcal/fat/carbs UP, protein DOWN. Store product-specific rules in notes (e.g. 'väg fryst').",
+        "Create a product, or update one by passing id (THE single place to correct values when packaging/recipes change). Updates are PARTIAL: omitted fields keep their current values, so updating notes never touches macros. Empty string clears a text field; aliases and portions replace the existing lists wholesale when provided. For estimated values set verified:false and round kcal/fat/carbs UP, protein DOWN. Store product-specific rules in notes (e.g. 'väg fryst', 'räknas styckvis').",
       inputSchema: {
         id: z.number().int().optional().describe("Set to update an existing product"),
         name: z.string().min(1),

--- a/kcal-assistant/tests/products.test.ts
+++ b/kcal-assistant/tests/products.test.ts
@@ -74,6 +74,41 @@ describe("saveProduct / getProduct", () => {
     expect(updated.portions[0]!.grams).toBeNull();
   });
 
+  test("update by id is PARTIAL: omitted fields are preserved", () => {
+    const p = saveProduct(db, {
+      name: "Kycklingspett",
+      brand: "Lönneberga",
+      per_100g: { kcal: 100, protein: 21, fat: 1.3, carbs: 1 },
+      aliases: ["spett"],
+      portions: [{ name: "spett", grams: 120 }],
+      notes: "Ursprunglig regel",
+      verified: false,
+      source: "estimate",
+    });
+    // The LLM's typical "just update the note" call must not destroy anything else
+    const updated = saveProduct(db, { id: p.id, name: "Kycklingspett", notes: "Räknas styckvis" });
+    expect(updated.notes).toBe("Räknas styckvis");
+    expect(updated.per_100g).toEqual({ kcal: 100, protein: 21, fat: 1.3, carbs: 1 });
+    expect(updated.brand).toBe("Lönneberga");
+    expect(updated.aliases).toEqual(["spett"]);
+    expect(updated.portions).toHaveLength(1);
+    expect(updated.verified).toBe(false);
+    expect(updated.source).toBe("estimate");
+  });
+
+  test("explicit empty string clears notes; explicit values still replace", () => {
+    const p = saveProduct(db, {
+      name: "X",
+      per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 2 },
+      notes: "gammal",
+      verified: false,
+    });
+    const updated = saveProduct(db, { id: p.id, name: "X", notes: "", verified: true });
+    expect(updated.notes).toBeNull();
+    expect(updated.verified).toBe(true);
+    expect(updated.per_100g!.kcal).toBe(100);
+  });
+
   test("unverified estimate keeps its source marker", () => {
     const p = saveProduct(db, {
       name: "Okänd sås",

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.3.0
+          image: rutbergphilip/kcal-assistant:v0.3.1
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
Updating a product by id previously replaced every column, so an
update that only set notes silently nulled the per-100g macros,
brand and verified flag. Updates now preserve omitted fields; an
explicit empty string clears a text field. Tool description updated
to state the partial-update contract.
