### PR TITLE
feat(kcal-assistant): v0.5.0 - read-only web UI behind Cloudflare Access

### DIFF
--- a/kcal-assistant/README.md
+++ b/kcal-assistant/README.md
@@ -49,6 +49,22 @@ Release: bump `version` in `package.json`, bump the image tag in `deployment.yam
 
 The Deployment must keep `replicas: 1` and `strategy: Recreate` — SQLite on NFS tolerates exactly one writer process.
 
+## Web UI (`/ui`)
+
+Read-only database browser (KCAL·DB) at `https://kcal.rutberg.dev/ui`: dagar, måltider, produkter, recept, vikt/TDEE, regler. Editing stays in chat via MCP — the UI has zero mutation endpoints.
+
+**Security model (two independent layers):**
+1. **Cloudflare Access** (Zero Trust) gates the `/ui` path at the edge with real login. The `/mcp/<token>` path stays OUTSIDE the Access app so claude.ai keeps working.
+2. **Server-side JWT verification**: every `/ui*` request must carry `Cf-Access-Jwt-Assertion`, verified against the team's JWKS (RS256 pinned, issuer + AUD + email claim). LAN traffic that bypasses Cloudflare is refused. If `CF_ACCESS_*` env vars are unset, all `/ui*` requests get 503 — fail closed.
+
+**Cloudflare Access setup (one-time):**
+1. Cloudflare dashboard → Zero Trust (free plan) → note the team domain (`<team>.cloudflareaccess.com`).
+2. Access → Applications → Add self-hosted: domain `kcal.rutberg.dev`, path `ui`. Policy Allow: din e-post; login One-time PIN or Google; session ~1 week.
+3. Copy the application Audience (AUD) tag.
+4. Set env in `deployment.yaml`: `CF_ACCESS_TEAM_DOMAIN` (full host), `CF_ACCESS_AUD`, `CF_ACCESS_EMAIL` — plain values, not secrets (signature verification is the guard).
+
+Local dev: `UI_DEV_NO_AUTH=1 bun run src/index.ts` (refused when NODE_ENV=production).
+
 ## Rotate the token
 
 1. `openssl rand -hex 32`

--- a/kcal-assistant/bun.lock
+++ b/kcal-assistant/bun.lock
@@ -6,6 +6,7 @@
       "name": "kcal-assistant",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",
+        "jose": "^6.2.3",
         "zod": "^3.25.0",
       },
       "devDependencies": {

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",
+    "jose": "^6.2.3",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/kcal-assistant/src/config.ts
+++ b/kcal-assistant/src/config.ts
@@ -11,4 +11,9 @@ export const config = {
   dbPath: process.env.DB_PATH ?? "./kcal.db",
   port: Number(process.env.PORT ?? 3000),
   icaStoreId: process.env.ICA_STORE_ID ?? "1003421", // Maxi ICA Stormarknad Nynäshamn
+  cfAccessTeamDomain: process.env.CF_ACCESS_TEAM_DOMAIN,
+  cfAccessAud: process.env.CF_ACCESS_AUD,
+  cfAccessEmail: process.env.CF_ACCESS_EMAIL,
+  uiDevNoAuth: process.env.UI_DEV_NO_AUTH === "1",
+  nodeEnv: process.env.NODE_ENV,
 };

--- a/kcal-assistant/src/db/meals.ts
+++ b/kcal-assistant/src/db/meals.ts
@@ -177,21 +177,21 @@ function readMeals(db: Database, date: string): MealView[] {
   });
 }
 
-export function getDay(db: Database, date?: string): DayView {
+// Non-mutating read: no ensureDay INSERT — missing day rows default to
+// vilodag. The UI's read-only guarantee depends on this.
+export function readDay(db: Database, date?: string): DayView {
   const resolved = resolveDate(date);
-  ensureDay(db, resolved);
   const day = db
-    .query<{ date: string; day_type: string }, [string]>(
-      "SELECT date, day_type FROM days WHERE date = ?",
-    )
-    .get(resolved)!;
-  const targets = getTargetsFor(db, day.day_type);
+    .query<{ day_type: string }, [string]>("SELECT day_type FROM days WHERE date = ?")
+    .get(resolved);
+  const dayType = day?.day_type ?? "vilodag";
+  const targets = getTargetsFor(db, dayType);
   const meals = readMeals(db, resolved);
   const totals = sumMacros(meals);
   const r1 = (x: number) => Math.round(x * 10) / 10;
   return {
     date: resolved,
-    day_type: day.day_type,
+    day_type: dayType,
     targets,
     meals,
     totals,
@@ -202,6 +202,45 @@ export function getDay(db: Database, date?: string): DayView {
       carbs: targets.carbs === null ? null : r1(targets.carbs - totals.carbs),
     },
   };
+}
+
+export function getDay(db: Database, date?: string): DayView {
+  const resolved = resolveDate(date);
+  ensureDay(db, resolved);
+  return readDay(db, resolved);
+}
+
+export interface DaySummary {
+  date: string;
+  day_type: string;
+  meal_count: number;
+  totals: Macros;
+}
+
+// Read-only list of days that actually have meals, newest first.
+export function listDays(
+  db: Database,
+  limit = 60,
+  offset = 0,
+): { total: number; days: DaySummary[] } {
+  const total = db
+    .query<{ n: number }, []>("SELECT count(DISTINCT day_date) AS n FROM meals")
+    .get()!.n;
+  const dates = db
+    .query<{ day_date: string }, [number, number]>(
+      "SELECT DISTINCT day_date FROM meals ORDER BY day_date DESC LIMIT ? OFFSET ?",
+    )
+    .all(limit, offset);
+  const days = dates.map(({ day_date }) => {
+    const day = readDay(db, day_date);
+    return {
+      date: day_date,
+      day_type: day.day_type,
+      meal_count: day.meals.length,
+      totals: day.totals,
+    };
+  });
+  return { total, days };
 }
 
 export function logMeal(
@@ -281,7 +320,7 @@ export function getWeek(db: Database, endDate?: string): WeekView {
   }
 
   const days = dates.map((date) => {
-    const day = getDay(db, date);
+    const day = readDay(db, date); // non-mutating: getWeek never creates day rows
     return {
       date,
       day_type: day.day_type,

--- a/kcal-assistant/src/db/products.ts
+++ b/kcal-assistant/src/db/products.ts
@@ -198,6 +198,13 @@ export function saveProduct(db: Database, input: ProductInput): Product {
   return getProduct(db, id)!;
 }
 
+export function listProducts(db: Database): Product[] {
+  return db
+    .query<{ id: number }, []>("SELECT id FROM products ORDER BY name COLLATE NOCASE")
+    .all()
+    .map(({ id }) => getProduct(db, id)!);
+}
+
 export function searchProducts(db: Database, query: string, limit = 8): Product[] {
   const tokens = query
     .trim()

--- a/kcal-assistant/src/db/weights.ts
+++ b/kcal-assistant/src/db/weights.ts
@@ -25,6 +25,14 @@ export function logWeight(
   return getTrend(db);
 }
 
+export function listWeights(db: Database): Array<WeightEntry & { note: string | null }> {
+  return db
+    .query<WeightEntry & { note: string | null }, []>(
+      "SELECT date, weight_kg, note FROM weights ORDER BY date DESC",
+    )
+    .all();
+}
+
 export function getTrend(db: Database, windowDays = 28): WeightTrendView {
   const allWeights = db
     .query<WeightEntry, []>("SELECT date, weight_kg FROM weights ORDER BY date")

--- a/kcal-assistant/src/index.ts
+++ b/kcal-assistant/src/index.ts
@@ -1,9 +1,18 @@
 import { config } from "./config";
 import { getDb } from "./db/index";
 import { createHttpServer } from "./server";
+import { resolveUiAuthState } from "./ui/auth";
 
 const db = getDb(); // opens + migrates before we accept traffic
-const server = createHttpServer({ token: config.token, db });
+const uiAuth = resolveUiAuthState({
+  teamDomain: config.cfAccessTeamDomain,
+  aud: config.cfAccessAud,
+  email: config.cfAccessEmail,
+  devNoAuth: config.uiDevNoAuth,
+  nodeEnv: config.nodeEnv,
+});
+console.log(`ui auth mode: ${uiAuth.mode}`);
+const server = createHttpServer({ token: config.token, db, uiAuth });
 
 server.listen(config.port, () => {
   console.log(`kcal-assistant listening on :${config.port} (db: ${config.dbPath})`);

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -1,8 +1,10 @@
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type ServerResponse } from "node:http";
 import { timingSafeEqual } from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { buildMcpServer } from "./mcp";
+import { handleUiApi } from "./ui/api";
+import type { UiAuthState } from "./ui/auth";
 
 function safeEqual(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
@@ -14,16 +16,49 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
-export function createHttpServer(opts: { token: string; db: Database }): Server {
+// Static assets: three hardcoded mappings — nothing filesystem-derived from
+// the URL, so traversal is impossible by construction.
+const STATIC_ROUTES: Record<string, { file: URL; type: string }> = {
+  "/ui": { file: new URL("./ui/static/index.html", import.meta.url), type: "text/html; charset=utf-8" },
+  "/ui/static/app.css": { file: new URL("./ui/static/app.css", import.meta.url), type: "text/css; charset=utf-8" },
+  "/ui/static/app.js": { file: new URL("./ui/static/app.js", import.meta.url), type: "text/javascript; charset=utf-8" },
+};
+
+const API_ROUTE = /^\/ui\/api\/[a-z]+(\/[A-Za-z0-9-]+)?$/;
+
+function uiHeaders(res: ServerResponse): void {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Content-Security-Policy", "default-src 'self'; img-src 'self' data:");
+}
+
+function uiJson(res: ServerResponse, status: number, body: unknown): void {
+  uiHeaders(res);
+  res.writeHead(status, { "content-type": "application/json" }).end(JSON.stringify(body));
+}
+
+export function createHttpServer(opts: { token: string; db: Database; uiAuth: UiAuthState }): Server {
   return createServer(async (req, res) => {
     try {
-      if (req.method === "GET" && req.url === "/healthz") {
+      const raw = req.url ?? "/";
+      // Global reject of raw-path tricks BEFORE any parsing/dispatch: nothing
+      // legitimate in this app uses these sequences. new URL() would silently
+      // normalize ".." — rejecting raw keeps CF's edge view and ours identical.
+      if (raw.includes("..") || raw.includes("%") || raw.includes("\\") || raw.includes("//")) {
+        res.writeHead(404, { "content-type": "application/json" }).end('{"error":"not found"}');
+        return;
+      }
+      const pathname = new URL(raw, "http://internal").pathname;
+
+      if (req.method === "GET" && pathname === "/healthz") {
         res.writeHead(200, { "content-type": "application/json" }).end('{"ok":true}');
         return;
       }
 
-      const match = req.url?.match(/^\/mcp\/([^/?#]+)$/);
-      if (match && safeEqual(decodeURIComponent(match[1]!), opts.token)) {
+      const mcpMatch = pathname.match(/^\/mcp\/([^/?#]+)$/);
+      if (mcpMatch && safeEqual(decodeURIComponent(mcpMatch[1]!), opts.token)) {
         if (req.method !== "POST") {
           res.writeHead(405, { allow: "POST" }).end();
           return;
@@ -41,6 +76,45 @@ export function createHttpServer(opts: { token: string; db: Database }): Server 
         });
         await mcp.connect(transport);
         await transport.handleRequest(req, res);
+        return;
+      }
+
+      if (pathname === "/ui" || pathname.startsWith("/ui/")) {
+        // Auth first: Cloudflare Access JWT verified server-side, fail closed.
+        if (opts.uiAuth.mode === "unconfigured") {
+          uiJson(res, 503, { error: "UI-autentisering är inte konfigurerad" });
+          return;
+        }
+        if (opts.uiAuth.mode === "configured") {
+          const header = req.headers["cf-access-jwt-assertion"];
+          const result = await opts.uiAuth.verify(typeof header === "string" ? header : undefined);
+          if (!result.ok) {
+            uiJson(res, result.status, { error: result.message });
+            return;
+          }
+        }
+        if (req.method !== "GET") {
+          uiHeaders(res);
+          res.writeHead(405, { allow: "GET" }).end();
+          return;
+        }
+        const staticRoute = STATIC_ROUTES[pathname];
+        if (staticRoute) {
+          uiHeaders(res);
+          res.writeHead(200, { "content-type": staticRoute.type });
+          res.end(await Bun.file(staticRoute.file).bytes());
+          return;
+        }
+        if (API_ROUTE.test(pathname)) {
+          const { status, body } = handleUiApi(
+            opts.db,
+            pathname,
+            new URL(raw, "http://internal").searchParams,
+          );
+          uiJson(res, status, body);
+          return;
+        }
+        uiJson(res, 404, { error: "finns inte" });
         return;
       }
 

--- a/kcal-assistant/src/ui/api.ts
+++ b/kcal-assistant/src/ui/api.ts
@@ -1,0 +1,92 @@
+import type { Database } from "bun:sqlite";
+import { readDay, listDays, getWeek } from "../db/meals";
+import { listProducts } from "../db/products";
+import { findRecipes, getRecipe } from "../db/recipes";
+import { getTrend, listWeights } from "../db/weights";
+import { listPreferences, getTargets } from "../db/preferences";
+import { isValidDate } from "../lib/dates";
+
+export interface UiApiResponse {
+  status: number;
+  body: unknown;
+}
+
+const NOT_FOUND: UiApiResponse = { status: 404, body: { error: "finns inte" } };
+
+// Read-only by construction: every handler calls only read functions.
+// Errors never echo internals — generic message, details go to the log.
+export function handleUiApi(db: Database, pathname: string, search: URLSearchParams): UiApiResponse {
+  try {
+    const segments = pathname.split("/").filter(Boolean); // ["ui","api",resource,param?]
+    const resource = segments[2];
+    const param = segments[3];
+
+    switch (resource) {
+      case "overview": {
+        if (param !== undefined) return NOT_FOUND;
+        const counts = {
+          products: count(db, "products"),
+          recipes: count(db, "recipes"),
+          days_logged: db.query<{ n: number }, []>("SELECT count(DISTINCT day_date) AS n FROM meals").get()!.n,
+          meals: count(db, "meals"),
+          weights: count(db, "weights"),
+        };
+        return {
+          status: 200,
+          body: {
+            day: readDay(db),
+            trend: getTrend(db, 28),
+            week: getWeek(db),
+            targets: getTargets(db),
+            counts,
+          },
+        };
+      }
+      case "days": {
+        if (param !== undefined) {
+          if (!isValidDate(param)) return { status: 400, body: { error: "ogiltigt datum" } };
+          return { status: 200, body: readDay(db, param) };
+        }
+        const limit = clampInt(search.get("limit"), 1, 200, 60);
+        const offset = clampInt(search.get("offset"), 0, 100_000, 0);
+        return { status: 200, body: listDays(db, limit, offset) };
+      }
+      case "products": {
+        if (param !== undefined) return NOT_FOUND;
+        return { status: 200, body: { products: listProducts(db) } };
+      }
+      case "recipes": {
+        if (param !== undefined) {
+          const id = Number(param);
+          if (!Number.isInteger(id)) return { status: 400, body: { error: "ogiltigt id" } };
+          const recipe = getRecipe(db, id);
+          return recipe ? { status: 200, body: recipe } : NOT_FOUND;
+        }
+        return { status: 200, body: { recipes: findRecipes(db) } };
+      }
+      case "weights": {
+        if (param !== undefined) return NOT_FOUND;
+        return { status: 200, body: { weights: listWeights(db), trend: getTrend(db, 28) } };
+      }
+      case "preferences": {
+        if (param !== undefined) return NOT_FOUND;
+        return { status: 200, body: { preferences: listPreferences(db), targets: getTargets(db) } };
+      }
+      default:
+        return NOT_FOUND;
+    }
+  } catch (e) {
+    console.error("ui api error:", e instanceof Error ? e.message : e);
+    return { status: 500, body: { error: "internal" } };
+  }
+}
+
+function count(db: Database, table: "products" | "recipes" | "meals" | "weights"): number {
+  return db.query<{ n: number }, []>(`SELECT count(*) AS n FROM ${table}`).get()!.n;
+}
+
+function clampInt(raw: string | null, min: number, max: number, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}

--- a/kcal-assistant/src/ui/auth.ts
+++ b/kcal-assistant/src/ui/auth.ts
@@ -1,0 +1,81 @@
+import { jwtVerify, createRemoteJWKSet, errors as joseErrors, type JWTVerifyGetKey } from "jose";
+
+// Cloudflare Access sits at the edge, but the server trusts nothing: every
+// /ui request must carry a Cf-Access-Jwt-Assertion JWT that we verify
+// cryptographically. Header only — never the CF_Authorization cookie.
+
+export type UiAuthResult = { ok: true } | { ok: false; status: 403 | 503; message: string };
+
+export interface UiAuthOptions {
+  getKey: JWTVerifyGetKey;
+  issuer: string;
+  audience: string;
+  email: string;
+}
+
+export type UiVerify = (headerValue: string | undefined) => Promise<UiAuthResult>;
+
+export function createUiAuth(opts: UiAuthOptions): UiVerify {
+  return async (headerValue) => {
+    if (!headerValue) return { ok: false, status: 403, message: "saknar autentisering" };
+    try {
+      const { payload } = await jwtVerify(headerValue, opts.getKey, {
+        algorithms: ["RS256"], // pinned — removes the alg-confusion class
+        issuer: opts.issuer,
+        audience: opts.audience,
+        clockTolerance: 60,
+      });
+      const email = typeof payload.email === "string" ? payload.email : "";
+      if (email.toLowerCase() !== opts.email.toLowerCase()) {
+        return { ok: false, status: 403, message: "fel identitet" };
+      }
+      return { ok: true };
+    } catch (e) {
+      // Token problems (signature, claims, format) => 403. Anything else —
+      // e.g. the JWKS fetch failing — is an infrastructure problem => 503,
+      // still closed but distinguishable from a forged token.
+      if (e instanceof joseErrors.JOSEError) {
+        return { ok: false, status: 403, message: "ogiltig autentisering" };
+      }
+      return { ok: false, status: 503, message: "autentisering otillgänglig" };
+    }
+  };
+}
+
+export type UiAuthState =
+  | { mode: "configured"; verify: UiVerify }
+  | { mode: "unconfigured" }
+  | { mode: "dev-bypass" };
+
+export function resolveUiAuthState(input: {
+  teamDomain?: string;
+  aud?: string;
+  email?: string;
+  devNoAuth: boolean;
+  nodeEnv?: string;
+}): UiAuthState {
+  if (input.devNoAuth) {
+    if (input.nodeEnv === "production") {
+      console.error("UI_DEV_NO_AUTH is REFUSED in production — UI stays fail-closed");
+      return { mode: "unconfigured" };
+    }
+    console.warn("UI auth DISABLED (UI_DEV_NO_AUTH=1) — dev only");
+    return { mode: "dev-bypass" };
+  }
+  if (!input.teamDomain || !input.aud || !input.email) return { mode: "unconfigured" };
+  if (!input.teamDomain.endsWith(".cloudflareaccess.com")) {
+    throw new Error(
+      `CF_ACCESS_TEAM_DOMAIN must be the full <team>.cloudflareaccess.com host, got: ${input.teamDomain}`,
+    );
+  }
+  const issuer = `https://${input.teamDomain}`;
+  return {
+    mode: "configured",
+    verify: createUiAuth({
+      getKey: createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`)),
+      issuer,
+      audience: input.aud,
+      email: input.email,
+    }),
+  };
+}

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -1,0 +1,453 @@
+/* KCAL·DB — labbkvitto: precise mono numerals, hairline rules, dotted leaders.
+   Dark-first; light theme via prefers-color-scheme. Strict CSP: no inline. */
+
+:root {
+  --bg: #131110;
+  --surface: #1b1815;
+  --surface-2: #221e1a;
+  --ink: #ece5d8;
+  --ink-2: #a89f90;
+  --ink-3: #6f685c;
+  --hair: #2f2a23;
+  --hair-2: #453e33;
+  --accent: #e0b84b;
+  --accent-dim: #8a7330;
+  --ok: #3fa486;
+  --under: #c4534a;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f4efe5;
+    --surface: #fbf8f1;
+    --surface-2: #efe9dc;
+    --ink: #27221a;
+    --ink-2: #6b6455;
+    --ink-3: #99917f;
+    --hair: #ddd5c4;
+    --hair-2: #c4bba6;
+    --accent: #9a7414;
+    --accent-dim: #c7a94e;
+    --ok: #1e7a60;
+    --under: #ab3f36;
+  }
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { background: var(--bg); }
+
+body {
+  font-family: var(--sans);
+  color: var(--ink);
+  background:
+    radial-gradient(1200px 500px at 50% -200px, color-mix(in oklab, var(--accent) 4%, transparent), transparent 70%),
+    var(--bg);
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- masthead ---------- */
+.masthead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 18px 16px 10px;
+  border-bottom: 3px double var(--hair-2);
+}
+.brand {
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+}
+.brand-sep { color: var(--accent); }
+.masthead-meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ---------- layout ---------- */
+.view {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 18px 16px calc(84px + env(safe-area-inset-bottom));
+}
+
+.view > * {
+  animation: rise 0.35s ease-out both;
+}
+.view > *:nth-child(2) { animation-delay: 0.04s; }
+.view > *:nth-child(3) { animation-delay: 0.08s; }
+.view > *:nth-child(4) { animation-delay: 0.12s; }
+.view > *:nth-child(5) { animation-delay: 0.16s; }
+.view > *:nth-child(n + 6) { animation-delay: 0.2s; }
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .view > * { animation: none; }
+}
+
+/* ---------- tabbar ---------- */
+.tabbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  background: color-mix(in oklab, var(--surface) 92%, transparent);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid var(--hair);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.tabbar a {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: center;
+  text-decoration: none;
+  color: var(--ink-3);
+  padding: 14px 2px 12px;
+  border-top: 2px solid transparent;
+  margin-top: -1px;
+}
+.tabbar a.active {
+  color: var(--accent);
+  border-top-color: var(--accent);
+}
+
+/* ---------- section headers ---------- */
+h2 {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  margin: 26px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+h2::after { content: ""; flex: 1; border-top: 1px solid var(--hair); }
+.view > h2:first-child { margin-top: 4px; }
+
+/* ---------- hero ---------- */
+.hero {
+  padding: 20px 0 6px;
+  text-align: center;
+}
+.hero .hero-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+.hero .hero-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(56px, 18vw, 84px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+.hero .hero-value.over { color: var(--under); }
+.hero .hero-sub {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-3);
+  margin-top: 2px;
+}
+
+/* ---------- chips ---------- */
+.chip {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 8px 2px;
+  border: 1px solid var(--hair-2);
+  border-radius: 2px;
+  color: var(--ink-2);
+}
+.chip.accent { border-color: var(--accent-dim); color: var(--accent); }
+.chip.ok { border-color: var(--ok); color: var(--ok); }
+.chip.under { border-color: var(--under); color: var(--under); }
+.chip-row { display: flex; gap: 6px; justify-content: center; margin-top: 12px; flex-wrap: wrap; }
+
+/* ---------- meters ---------- */
+.meter { margin: 14px 0; }
+.meter-head {
+  display: flex;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.meter-head .label {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  font-size: 10px;
+}
+.meter-head .leader { flex: 1; border-bottom: 1px dotted var(--hair-2); margin: 0 8px 3px; }
+.meter-head .value { font-variant-numeric: tabular-nums; }
+.meter-head .value .status { font-weight: 700; }
+.meter-head .value .ok { color: var(--ok); }
+.meter-head .value .under { color: var(--under); }
+.meter-track {
+  height: 4px;
+  background: var(--surface-2);
+  border-radius: 2px;
+  margin-top: 6px;
+  position: relative;
+  overflow: hidden;
+}
+.meter-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.5s ease-out;
+}
+.meter-fill.ok { background: var(--ok); }
+.meter-fill.under { background: var(--under); }
+.meter-fill.neutral { background: var(--accent); }
+
+/* ---------- kvitto (receipt rows) ---------- */
+.kvitto {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+  padding: 12px 14px;
+  margin: 10px 0;
+}
+.kvitto .k-title {
+  display: flex;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+}
+.kvitto .k-title .leader { flex: 1; border-bottom: 1px dotted var(--hair-2); margin: 0 8px 3px; }
+.kvitto .k-title .amount { font-variant-numeric: tabular-nums; }
+.kvitto .k-sub {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  margin-top: 1px;
+}
+.k-row {
+  display: flex;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-2);
+  margin-top: 6px;
+}
+.k-row .leader { flex: 1; border-bottom: 1px dotted var(--hair); margin: 0 8px 3px; }
+.k-row .amount { font-variant-numeric: tabular-nums; color: var(--ink); }
+.k-total {
+  border-top: 1px solid var(--hair-2);
+  margin-top: 10px;
+  padding-top: 8px;
+  font-weight: 700;
+}
+.macro-line {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- lists / rows (dagar) ---------- */
+.rowlink {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--hair);
+  padding: 12px 2px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink);
+  cursor: pointer;
+}
+.rowlink:hover { background: var(--surface); }
+.rowlink .grow { flex: 1; border-bottom: 1px dotted var(--hair); margin: 0 4px 3px; }
+.rowlink .dim { color: var(--ink-3); font-size: 11px; }
+.rowlink .num { font-variant-numeric: tabular-nums; }
+
+/* ---------- search ---------- */
+.search {
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--hair-2);
+  border-radius: 2px;
+  padding: 10px 12px;
+  margin: 4px 0 12px;
+}
+.search:focus { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+.search::placeholder { color: var(--ink-3); }
+
+/* ---------- details (produkter/recept) ---------- */
+details.card {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+  margin: 6px 0;
+}
+details.card summary {
+  list-style: none;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 11px 12px;
+  font-family: var(--mono);
+  font-size: 13px;
+  cursor: pointer;
+}
+details.card summary::-webkit-details-marker { display: none; }
+details.card summary .leader { flex: 1; border-bottom: 1px dotted var(--hair-2); margin: 0 4px 3px; }
+details.card summary .num { font-variant-numeric: tabular-nums; }
+details.card[open] summary { border-bottom: 1px solid var(--hair); }
+details.card .body { padding: 10px 12px 12px; }
+.note {
+  font-size: 12px;
+  color: var(--ink-2);
+  border-left: 2px solid var(--accent-dim);
+  padding: 4px 0 4px 10px;
+  margin-top: 10px;
+}
+.alias { color: var(--ink-3); font-size: 11px; font-family: var(--mono); }
+
+/* ---------- tables ---------- */
+.tablewrap { overflow-x: auto; margin: 8px 0; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+th {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  font-weight: 600;
+  text-align: right;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--hair-2);
+}
+th:first-child { text-align: left; padding-left: 2px; }
+td {
+  text-align: right;
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--hair);
+  color: var(--ink);
+  white-space: nowrap;
+}
+td:first-child { text-align: left; color: var(--ink-2); padding-left: 2px; }
+
+/* ---------- chart ---------- */
+.chart-frame { margin: 8px 0 4px; }
+.chart-frame svg { display: block; width: 100%; height: auto; }
+.gridline { stroke: var(--hair); stroke-width: 1; }
+.axis-label { fill: var(--ink-3); font-family: var(--mono); font-size: 10px; }
+.trend-line { stroke: var(--accent); stroke-width: 2; fill: none; stroke-linejoin: round; stroke-linecap: round; }
+.trend-dot { fill: var(--bg); stroke: var(--accent); stroke-width: 2; }
+.trend-dot.last { fill: var(--accent); }
+.point-label { fill: var(--ink); font-family: var(--mono); font-size: 11px; font-weight: 700; }
+
+/* ---------- stat tiles ---------- */
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; margin: 10px 0; }
+.tile {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 2px;
+  padding: 12px;
+}
+.tile .t-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.tile .t-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 22px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+.tile .t-sub { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+
+/* ---------- misc ---------- */
+.backlink {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+  margin-bottom: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.empty {
+  text-align: center;
+  color: var(--ink-3);
+  font-size: 13px;
+  padding: 40px 20px;
+  border: 1px dashed var(--hair-2);
+  border-radius: 2px;
+  margin-top: 14px;
+}
+.error-banner {
+  background: color-mix(in oklab, var(--under) 14%, var(--surface));
+  border: 1px solid var(--under);
+  border-radius: 2px;
+  color: var(--ink);
+  font-size: 13px;
+  padding: 12px 14px;
+  margin: 14px 0;
+}
+.loadmore {
+  display: block;
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: none;
+  border: 1px solid var(--hair-2);
+  border-radius: 2px;
+  padding: 11px;
+  margin-top: 12px;
+  cursor: pointer;
+}
+.pill-flags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -1,0 +1,559 @@
+"use strict";
+
+/* KCAL·DB — read-only viewer. Vanilla JS, hash routing, strict CSP. */
+
+const viewHost = document.getElementById("view");
+const mastheadMeta = document.getElementById("masthead-meta");
+// Renderers append to `view`; navigate() points it at a detached staging node
+// per navigation and swaps in atomically, so overlapping async renders can
+// never interleave into the live DOM.
+let view = viewHost;
+
+/* ---------- helpers ---------- */
+
+const sv = (n, dec = 1) =>
+  Number(n).toLocaleString("sv-SE", { minimumFractionDigits: 0, maximumFractionDigits: dec });
+
+const el = (tag, cls, text) => {
+  const node = document.createElement(tag);
+  if (cls) node.className = cls;
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+
+async function api(path) {
+  const res = await fetch(path, { headers: { accept: "application/json" } });
+  const type = res.headers.get("content-type") || "";
+  if (!type.includes("application/json")) {
+    // CF Access session expired: fetch followed the login redirect and got
+    // HTML. A full reload lets the top-level navigation re-trigger login.
+    location.reload();
+    throw new Error("session expired");
+  }
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);
+  return body;
+}
+
+function tableHead(...titles) {
+  const thead = el("thead");
+  const tr = el("tr");
+  for (const title of titles) tr.append(el("th", "", title));
+  thead.append(tr);
+  return thead;
+}
+
+function macroLine(m) {
+  return `${sv(m.kcal, 0)} kcal · P ${sv(m.protein)} · F ${sv(m.fat)} · K ${sv(m.carbs)}`;
+}
+
+function leaderRow(cls, label, amount, sub) {
+  const row = el("div", cls);
+  row.append(el("span", "label", label), el("span", "leader"), el("span", "amount", amount));
+  if (sub) row.append(el("div", "k-sub", sub));
+  return row;
+}
+
+function meter(label, value, target, opts = {}) {
+  const wrap = el("div", "meter");
+  const head = el("div", "meter-head");
+  const val = el("span", "value");
+  const pct = target > 0 ? Math.min(100, (value / target) * 100) : 0;
+  let cls = "neutral";
+  if (opts.floor) {
+    const met = value >= target;
+    cls = met ? "ok" : "under";
+    val.append(el("span", `status ${cls}`, `${sv(value)} `), el("span", "", `/ ${sv(target)} ${opts.unit || "g"}`));
+  } else {
+    val.textContent = `${sv(value)} / ${sv(target)} ${opts.unit || "g"}`;
+  }
+  head.append(el("span", "label", label), el("span", "leader"), val);
+  const track = el("div", "meter-track");
+  const fill = el("div", `meter-fill ${cls}`);
+  fill.style.width = `${pct}%`;
+  track.append(fill);
+  wrap.append(head, track);
+  return wrap;
+}
+
+function mealKvitto(meal) {
+  const card = el("div", "kvitto");
+  const title = el("div", "k-title");
+  title.append(
+    el("span", "", meal.post_gym_shake ? `${meal.name} ⚡` : meal.name),
+    el("span", "leader"),
+    el("span", "amount", `${sv(meal.kcal, 0)} kcal`),
+  );
+  card.append(title, el("div", "k-sub", `P ${sv(meal.protein)} · F ${sv(meal.fat)} · K ${sv(meal.carbs)}`));
+  for (const item of meal.items || []) {
+    const qty = item.grams ? `${sv(item.grams, 0)} g` : item.quantity ? `${sv(item.quantity)} st` : "";
+    card.append(leaderRow("k-row", `${item.description}${qty ? ` · ${qty}` : ""}`, `${sv(item.kcal, 0)}`));
+  }
+  return card;
+}
+
+function dayBlock(day, { heading } = {}) {
+  const frag = document.createDocumentFragment();
+  if (heading) frag.append(el("h2", "", heading));
+
+  const hero = el("div", "hero");
+  const left = day.remaining.kcal;
+  hero.append(el("div", "hero-label", left >= 0 ? "kvar idag" : "över målet"));
+  const heroVal = el("div", `hero-value${left < 0 ? " over" : ""}`, sv(Math.abs(left), 0));
+  hero.append(heroVal, el("div", "hero-sub", `${sv(day.totals.kcal, 0)} / ${sv(day.targets.kcal, 0)} kcal`));
+  const chips = el("div", "chip-row");
+  chips.append(el("span", "chip accent", day.day_type));
+  chips.append(el("span", "chip", day.date));
+  hero.append(chips);
+  frag.append(hero);
+
+  const meters = el("div");
+  meters.append(
+    meter("Protein", day.totals.protein, day.targets.protein_min, { floor: true }),
+    meter("Fett", day.totals.fat, day.targets.fat_min, { floor: true }),
+  );
+  if (day.targets.carbs !== null) {
+    meters.append(meter("Kolhydrater · riktnivå", day.totals.carbs, day.targets.carbs));
+  }
+  frag.append(meters);
+
+  frag.append(el("h2", "", `Måltider · ${day.meals.length}`));
+  if (day.meals.length === 0) {
+    frag.append(el("div", "empty", "Inget loggat den här dagen."));
+  } else {
+    for (const meal of day.meals) frag.append(mealKvitto(meal));
+    const total = el("div", "kvitto");
+    const row = el("div", "k-title k-total");
+    row.append(el("span", "", "SUMMA"), el("span", "leader"), el("span", "amount", macroLine(day.totals)));
+    total.append(row);
+    frag.append(total);
+  }
+  return frag;
+}
+
+/* ---------- views ---------- */
+
+async function renderIdag() {
+  const data = await api("/ui/api/overview");
+  view.append(dayBlock(data.day));
+
+  if (data.trend.latest) {
+    view.append(el("h2", "", "Vikt"));
+    const tiles = el("div", "tiles");
+    tiles.append(tile("Senast", `${sv(data.trend.latest.weight_kg)} kg`, data.trend.latest.date));
+    if (data.trend.trend) {
+      tiles.append(tile("Takt", `${sv(data.trend.trend.rate_kg_week)} kg/v`, `${sv(data.trend.trend.delta_kg)} kg på ${sv(data.trend.trend.span_days, 0)} d`));
+      if (data.trend.trend.est_tdee !== null) {
+        tiles.append(tile("TDEE", `${sv(data.trend.trend.est_tdee, 0)}`, data.trend.trend.uncertain ? "osäker (gles logg)" : "baklängesräknad"));
+      }
+    }
+    view.append(tiles);
+  }
+
+  view.append(el("h2", "", "Veckosnitt"));
+  const week = data.week;
+  const tiles = el("div", "tiles");
+  tiles.append(tile("Dagar loggade", `${week.days_logged} / 7`, `${week.start_date} – ${week.end_date}`));
+  if (week.avg_logged) {
+    tiles.append(tile("Snitt kcal", sv(week.avg_logged.kcal, 0), `mål ${sv(week.avg_target_kcal, 0)}`));
+    tiles.append(tile("Snitt protein", `${sv(week.avg_logged.protein)} g`, "över loggade dagar"));
+  }
+  view.append(tiles);
+}
+
+function tile(label, value, sub) {
+  const box = el("div", "tile");
+  box.append(el("div", "t-label", label), el("div", "t-value", value));
+  if (sub) box.append(el("div", "t-sub", sub));
+  return box;
+}
+
+async function renderDagar() {
+  view.append(el("h2", "", "Loggade dagar"));
+  const list = el("div");
+  view.append(list);
+  let offset = 0;
+  const LIMIT = 30;
+
+  async function loadPage() {
+    const data = await api(`/ui/api/days?limit=${LIMIT}&offset=${offset}`);
+    for (const day of data.days) {
+      const row = el("button", "rowlink");
+      row.append(
+        el("span", "num", day.date),
+        el("span", "dim", day.day_type),
+        el("span", "grow"),
+        el("span", "dim", `${day.meal_count} mål`),
+        el("span", "num", `${sv(day.totals.kcal, 0)} kcal`),
+      );
+      row.addEventListener("click", () => {
+        location.hash = `#/dagar/${day.date}`;
+      });
+      list.append(row);
+    }
+    offset += data.days.length;
+    if (offset < data.total && data.days.length > 0) {
+      more.hidden = false;
+    } else {
+      more.hidden = true;
+      if (data.total === 0) list.append(el("div", "empty", "Inga dagar loggade ännu."));
+    }
+  }
+
+  const more = el("button", "loadmore", "Visa fler");
+  more.hidden = true;
+  more.addEventListener("click", loadPage);
+  view.append(more);
+  await loadPage();
+}
+
+async function renderDagDetalj(date) {
+  const back = el("button", "backlink", "← Alla dagar");
+  back.addEventListener("click", () => {
+    location.hash = "#/dagar";
+  });
+  view.append(back);
+  const day = await api(`/ui/api/days/${date}`);
+  view.append(dayBlock(day));
+}
+
+async function renderProdukter() {
+  const data = await api("/ui/api/products");
+  view.append(el("h2", "", `Produkter · ${data.products.length}`));
+  const search = el("input", "search");
+  search.type = "search";
+  search.placeholder = "Sök produkt, alias, märke …";
+  view.append(search);
+  const list = el("div");
+  view.append(list);
+
+  function draw(filter) {
+    list.replaceChildren();
+    const q = (filter || "").toLowerCase();
+    const hits = data.products.filter(
+      (p) =>
+        !q ||
+        p.name.toLowerCase().includes(q) ||
+        (p.brand || "").toLowerCase().includes(q) ||
+        p.aliases.some((a) => a.toLowerCase().includes(q)),
+    );
+    if (hits.length === 0) {
+      list.append(el("div", "empty", "Ingen träff."));
+      return;
+    }
+    for (const p of hits) {
+      const card = el("details", "card");
+      const summary = el("summary");
+      summary.append(
+        el("span", "", p.name),
+        el("span", "leader"),
+        el("span", "num", p.per_100g ? `${sv(p.per_100g.kcal, 0)} kcal · P ${sv(p.per_100g.protein)}` : "—"),
+      );
+      card.append(summary);
+      const body = el("div", "body");
+      if (p.brand) body.append(el("div", "alias", p.brand));
+      if (p.per_100g) {
+        body.append(el("div", "macro-line", `per 100 g: ${macroLine(p.per_100g)}`));
+      }
+      for (const portion of p.portions) {
+        body.append(
+          el(
+            "div",
+            "macro-line",
+            portion.grams !== null
+              ? `${portion.name}: ${sv(portion.grams, 0)} g`
+              : `${portion.name}: ${sv(portion.kcal, 0)} kcal · P ${sv(portion.protein)} · F ${sv(portion.fat)} · K ${sv(portion.carbs)}`,
+          ),
+        );
+      }
+      if (p.aliases.length) body.append(el("div", "alias", `alias: ${p.aliases.join(", ")}`));
+      if (p.notes) body.append(el("div", "note", p.notes));
+      const flags = el("div", "pill-flags");
+      flags.append(el("span", `chip ${p.verified ? "ok" : "under"}`, p.verified ? "verifierad" : "overifierad"));
+      flags.append(el("span", "chip", p.source));
+      body.append(flags);
+      card.append(body);
+      list.append(card);
+    }
+  }
+
+  search.addEventListener("input", () => draw(search.value));
+  draw("");
+}
+
+async function renderRecept() {
+  const data = await api("/ui/api/recipes");
+  view.append(el("h2", "", `Recept · ${data.recipes.length}`));
+  if (data.recipes.length === 0) {
+    view.append(el("div", "empty", "Inga recept ännu. Säg åt assistenten: 'spara som recept'."));
+    return;
+  }
+  for (const r of data.recipes) {
+    const row = el("button", "rowlink");
+    row.append(
+      el("span", "", r.name),
+      el("span", "grow"),
+      el("span", "dim", r.tags || ""),
+      el("span", "num", r.kcal_per_serving !== null ? `${sv(r.kcal_per_serving, 0)} kcal/port` : "—"),
+    );
+    row.addEventListener("click", () => {
+      location.hash = `#/recept/${r.id}`;
+    });
+    view.append(row);
+  }
+}
+
+async function renderReceptDetalj(id) {
+  const back = el("button", "backlink", "← Alla recept");
+  back.addEventListener("click", () => {
+    location.hash = "#/recept";
+  });
+  view.append(back);
+  const r = await api(`/ui/api/recipes/${id}`);
+  view.append(el("h2", "", r.name));
+
+  const card = el("div", "kvitto");
+  for (const ing of r.ingredients) {
+    if (ing.unresolved) {
+      card.append(leaderRow("k-row", `${ing.description} · ${ing.reason}`, "—"));
+    } else {
+      const qty = ing.grams ? `${sv(ing.grams, 0)} g` : ing.quantity ? `${sv(ing.quantity)} st` : "";
+      card.append(leaderRow("k-row", `${ing.description}${qty ? ` · ${qty}` : ""}`, sv(ing.kcal, 0)));
+    }
+  }
+  const total = el("div", "k-title k-total");
+  total.append(el("span", "", "SUMMA"), el("span", "leader"), el("span", "amount", macroLine(r.totals)));
+  card.append(total);
+  if (r.totals_incomplete) card.append(el("div", "k-sub", "⚠ ofullständig: någon ingrediens kan inte beräknas"));
+  view.append(card);
+
+  const tiles = el("div", "tiles");
+  if (r.servings) tiles.append(tile("Portioner", sv(r.servings), null));
+  if (r.per_serving) tiles.append(tile("Per portion", `${sv(r.per_serving.kcal, 0)} kcal`, `P ${sv(r.per_serving.protein)} · F ${sv(r.per_serving.fat)} · K ${sv(r.per_serving.carbs)}`));
+  view.append(tiles);
+
+  if (r.instructions) {
+    view.append(el("h2", "", "Gör så här"));
+    const instr = el("div", "kvitto");
+    instr.append(el("div", "k-sub", ""));
+    instr.lastChild.style.whiteSpace = "pre-wrap";
+    instr.lastChild.style.fontSize = "13px";
+    instr.lastChild.textContent = r.instructions;
+    view.append(instr);
+  }
+  if (r.notes) view.append(el("div", "note", r.notes));
+  if (r.tags) {
+    const flags = el("div", "pill-flags");
+    for (const tag of r.tags.split(",")) flags.append(el("span", "chip", tag.trim()));
+    view.append(flags);
+  }
+}
+
+async function renderVikt() {
+  const data = await api("/ui/api/weights");
+  view.append(el("h2", "", "Vikt"));
+  if (data.weights.length === 0) {
+    view.append(el("div", "empty", "Inga viktloggar ännu. Säg '82,1 idag' till assistenten."));
+    return;
+  }
+
+  const series = [...data.weights].reverse(); // ascending by date
+  if (series.length >= 2) view.append(weightChart(series));
+
+  const tiles = el("div", "tiles");
+  tiles.append(tile("Senast", `${sv(data.trend.latest.weight_kg)} kg`, data.trend.latest.date + (data.trend.stale ? " · gammal" : "")));
+  if (data.trend.trend) {
+    tiles.append(tile("Takt", `${sv(data.trend.trend.rate_kg_week)} kg/v`, `${sv(data.trend.trend.delta_kg)} kg / ${sv(data.trend.trend.span_days, 0)} d`));
+    tiles.append(
+      tile(
+        "TDEE",
+        data.trend.trend.est_tdee !== null ? sv(data.trend.trend.est_tdee, 0) : "—",
+        data.trend.trend.est_tdee === null ? "ingen intagsdata" : data.trend.trend.uncertain ? "osäker (gles logg)" : `${data.trend.trend.intake_days} intagsdagar`,
+      ),
+    );
+  } else if (data.trend.reason) {
+    tiles.append(tile("Trend", "—", data.trend.reason));
+  }
+  view.append(tiles);
+
+  view.append(el("h2", "", "Alla vägningar"));
+  const wrap = el("div", "tablewrap");
+  const table = el("table");
+  table.append(tableHead("Datum", "kg", "Anteckning"));
+  const tbody = el("tbody");
+  for (const w of data.weights) {
+    const tr = el("tr");
+    tr.append(el("td", "", w.date), el("td", "", sv(w.weight_kg)), el("td", "", w.note || ""));
+    tbody.append(tr);
+  }
+  table.append(tbody);
+  wrap.append(table);
+  view.append(wrap);
+}
+
+function weightChart(series) {
+  const NS = "http://www.w3.org/2000/svg";
+  const W = 640, H = 240, M = { top: 16, right: 52, bottom: 24, left: 10 };
+  const frame = el("div", "chart-frame");
+  const svg = document.createElementNS(NS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "Viktutveckling, kg över tid");
+
+  const days = series.map((w) => Date.parse(w.date));
+  const kgs = series.map((w) => w.weight_kg);
+  const x0 = Math.min(...days), x1 = Math.max(...days);
+  const pad = Math.max(0.4, (Math.max(...kgs) - Math.min(...kgs)) * 0.15);
+  const y0 = Math.min(...kgs) - pad, y1 = Math.max(...kgs) + pad;
+  const X = (t) => M.left + ((t - x0) / Math.max(1, x1 - x0)) * (W - M.left - M.right);
+  const Y = (kg) => H - M.bottom - ((kg - y0) / (y1 - y0)) * (H - M.top - M.bottom);
+
+  // 3 recessive gridlines with right-side labels
+  for (let i = 0; i <= 2; i++) {
+    const kg = y0 + ((y1 - y0) * i) / 2;
+    const line = document.createElementNS(NS, "line");
+    line.setAttribute("class", "gridline");
+    line.setAttribute("x1", M.left);
+    line.setAttribute("x2", W - M.right);
+    line.setAttribute("y1", Y(kg));
+    line.setAttribute("y2", Y(kg));
+    svg.append(line);
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", W - M.right + 6);
+    label.setAttribute("y", Y(kg) + 3);
+    label.textContent = sv(kg, 1);
+    svg.append(label);
+  }
+  // x labels: first + last date
+  for (const [t, anchor] of [[x0, "start"], [x1, "end"]]) {
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", X(t));
+    label.setAttribute("y", H - 6);
+    label.setAttribute("text-anchor", anchor);
+    label.textContent = new Date(t).toISOString().slice(5, 10);
+    svg.append(label);
+  }
+
+  const path = document.createElementNS(NS, "path");
+  path.setAttribute("class", "trend-line");
+  path.setAttribute("d", series.map((w, i) => `${i === 0 ? "M" : "L"}${X(days[i]).toFixed(1)},${Y(kgs[i]).toFixed(1)}`).join(""));
+  svg.append(path);
+
+  series.forEach((w, i) => {
+    const dot = document.createElementNS(NS, "circle");
+    dot.setAttribute("class", `trend-dot${i === series.length - 1 ? " last" : ""}`);
+    dot.setAttribute("cx", X(days[i]));
+    dot.setAttribute("cy", Y(kgs[i]));
+    dot.setAttribute("r", i === series.length - 1 ? 5 : 3.5);
+    const tip = document.createElementNS(NS, "title");
+    tip.textContent = `${w.date}: ${sv(w.weight_kg)} kg`;
+    dot.append(tip);
+    svg.append(dot);
+  });
+
+  // selective direct label: last point only
+  const last = series[series.length - 1];
+  const label = document.createElementNS(NS, "text");
+  label.setAttribute("class", "point-label");
+  const lx = X(days[days.length - 1]);
+  label.setAttribute("x", Math.min(lx, W - M.right - 4));
+  label.setAttribute("y", Y(last.weight_kg) - 10);
+  label.setAttribute("text-anchor", "end");
+  label.textContent = `${sv(last.weight_kg)} kg`;
+  svg.append(label);
+
+  frame.append(svg);
+  return frame;
+}
+
+async function renderRegler() {
+  const data = await api("/ui/api/preferences");
+  view.append(el("h2", "", "Mål per dagstyp"));
+  const wrap = el("div", "tablewrap");
+  const table = el("table");
+  table.append(tableHead("Dagstyp", "kcal", "Protein golv", "Fett golv", "Kolh. riktnivå"));
+  const tbody = el("tbody");
+  for (const t of data.targets) {
+    const tr = el("tr");
+    tr.append(
+      el("td", "", t.day_type),
+      el("td", "", sv(t.kcal, 0)),
+      el("td", "", sv(t.protein_min, 0)),
+      el("td", "", sv(t.fat_min, 0)),
+      el("td", "", t.carbs !== null ? sv(t.carbs, 0) : "—"),
+    );
+    tbody.append(tr);
+  }
+  table.append(tbody);
+  wrap.append(table);
+  view.append(wrap);
+
+  const groups = { stil: "Stil", regel: "Regler", mål: "Mål" };
+  for (const [key, title] of Object.entries(groups)) {
+    const prefs = data.preferences.filter((p) => p.category === key);
+    if (!prefs.length) continue;
+    view.append(el("h2", "", `${title} · ${prefs.length}`));
+    const card = el("div", "kvitto");
+    for (const p of prefs) {
+      const row = el("div", "k-row");
+      row.style.alignItems = "flex-start";
+      row.append(el("span", "amount", `${p.id}`), el("span", "", "  "), el("span", "", p.content));
+      row.lastChild.style.color = "var(--ink)";
+      row.lastChild.style.flex = "1";
+      card.append(row);
+    }
+    view.append(card);
+  }
+}
+
+/* ---------- router ---------- */
+
+const routes = [
+  { match: /^#\/idag$/, render: renderIdag, tab: "idag" },
+  { match: /^#\/dagar$/, render: renderDagar, tab: "dagar" },
+  { match: /^#\/dagar\/(\d{4}-\d{2}-\d{2})$/, render: (m) => renderDagDetalj(m[1]), tab: "dagar" },
+  { match: /^#\/produkter$/, render: renderProdukter, tab: "produkter" },
+  { match: /^#\/recept$/, render: renderRecept, tab: "recept" },
+  { match: /^#\/recept\/(\d+)$/, render: (m) => renderReceptDetalj(m[1]), tab: "recept" },
+  { match: /^#\/vikt$/, render: renderVikt, tab: "vikt" },
+  { match: /^#\/regler$/, render: renderRegler, tab: "regler" },
+];
+
+let navSeq = 0;
+
+async function navigate() {
+  const seq = ++navSeq;
+  const hash = location.hash || "#/idag";
+  const route = routes.find((r) => r.match.test(hash));
+  if (!route) {
+    location.hash = "#/idag";
+    return;
+  }
+  document.querySelectorAll(".tabbar a").forEach((a) => {
+    a.classList.toggle("active", a.dataset.tab === route.tab);
+  });
+  const stage = el("div");
+  view = stage;
+  try {
+    await route.render(hash.match(route.match));
+    if (seq !== navSeq) return; // a newer navigation won
+    viewHost.replaceChildren(...stage.childNodes);
+  } catch (e) {
+    if (seq !== navSeq) return;
+    if (e.message !== "session expired") {
+      viewHost.replaceChildren(el("div", "error-banner", `Kunde inte hämta data: ${e.message}`));
+    }
+  }
+  window.scrollTo(0, 0);
+}
+
+mastheadMeta.textContent = new Date().toLocaleDateString("sv-SE", {
+  weekday: "short",
+  day: "numeric",
+  month: "short",
+});
+
+window.addEventListener("hashchange", navigate);
+navigate();

--- a/kcal-assistant/src/ui/static/index.html
+++ b/kcal-assistant/src/ui/static/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="color-scheme" content="dark light">
+  <meta name="robots" content="noindex, nofollow">
+  <title>KCAL·DB</title>
+  <link rel="stylesheet" href="/ui/static/app.css">
+</head>
+<body>
+  <header class="masthead">
+    <span class="brand">KCAL<span class="brand-sep">·</span>DB</span>
+    <span class="masthead-meta" id="masthead-meta"></span>
+  </header>
+  <main id="view" class="view" aria-live="polite"></main>
+  <nav class="tabbar" aria-label="Vyer">
+    <a href="#/idag" data-tab="idag">Idag</a>
+    <a href="#/dagar" data-tab="dagar">Dagar</a>
+    <a href="#/produkter" data-tab="produkter">Produkter</a>
+    <a href="#/recept" data-tab="recept">Recept</a>
+    <a href="#/vikt" data-tab="vikt">Vikt</a>
+    <a href="#/regler" data-tab="regler">Regler</a>
+  </nav>
+  <script src="/ui/static/app.js"></script>
+</body>
+</html>

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -14,7 +14,7 @@ let baseUrl: string;
 
 beforeAll(async () => {
   db = openDb(":memory:");
-  httpServer = createHttpServer({ token: TOKEN, db });
+  httpServer = createHttpServer({ token: TOKEN, db, uiAuth: { mode: "unconfigured" } });
   await new Promise<void>((resolve) => httpServer.listen(0, resolve));
   const { port } = httpServer.address() as AddressInfo;
   baseUrl = `http://127.0.0.1:${port}`;

--- a/kcal-assistant/tests/ui-api.test.ts
+++ b/kcal-assistant/tests/ui-api.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import net, { type AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { createHttpServer } from "../src/server";
+import { saveProduct } from "../src/db/products";
+import { logMeal } from "../src/db/meals";
+import { logWeight } from "../src/db/weights";
+import { saveRecipe } from "../src/db/recipes";
+
+const TOKEN = "test-token";
+let httpServer: Server;
+let db: Database;
+let base: string;
+
+const TABLES = ["products", "meals", "meal_items", "weights", "recipes", "recipe_ingredients", "preferences", "days"];
+function rowCounts(): Record<string, number> {
+  return Object.fromEntries(
+    TABLES.map((t) => [t, (db.query<{ n: number }, []>(`SELECT count(*) AS n FROM ${t}`).get()!).n]),
+  );
+}
+
+beforeAll(async () => {
+  db = openDb(":memory:");
+  const p = saveProduct(db, { name: "Uiprodukt", per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 } });
+  logMeal(db, { name: "Uilunch", date: "2026-07-08", items: [{ product_id: p.id, grams: 200 }] });
+  logWeight(db, { weight_kg: 100, date: "2026-07-08" });
+  saveRecipe(db, { name: "Uirecept", servings: 2, ingredients: [{ product_id: p.id, grams: 400 }] });
+  // dev-bypass auth state: pure API-shape tests (auth matrix lives in ui-auth.test.ts)
+  httpServer = createHttpServer({ token: TOKEN, db, uiAuth: { mode: "dev-bypass" } });
+  await new Promise<void>((r) => httpServer.listen(0, r));
+  base = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((r) => httpServer.close(r));
+});
+
+const get = (path: string) => fetch(`${base}${path}`);
+
+// fetch() normalizes ".." and percent-encodes non-ASCII before sending, so
+// raw-path attacks must go over a raw socket exactly as an attacker would.
+function rawStatus(path: string, method = "GET"): Promise<number> {
+  const { port } = httpServer.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write(`${method} ${path} HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n`);
+    });
+    let buf = "";
+    socket.on("data", (chunk) => (buf += chunk.toString()));
+    socket.on("end", () => resolve(Number(buf.split(" ")[1])));
+    socket.on("error", reject);
+  });
+}
+
+describe("read-only UI API", () => {
+  test("overview returns today, trend, week, targets and counts", async () => {
+    const res = await get("/ui/api/overview");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.day.day_type).toBeDefined();
+    expect(body.trend.latest.weight_kg).toBe(100);
+    expect(body.week.days).toHaveLength(7);
+    expect(body.counts.products).toBe(1);
+    expect(body.counts.recipes).toBe(1);
+  });
+
+  test("days list and day detail", async () => {
+    const list = await (await get("/ui/api/days?limit=10&offset=0")).json();
+    expect(list.total).toBe(1);
+    expect(list.days[0]!.date).toBe("2026-07-08");
+    expect(list.days[0]!.totals.kcal).toBe(200);
+    const day = await (await get("/ui/api/days/2026-07-08")).json();
+    expect(day.meals).toHaveLength(1);
+  });
+
+  test("products, recipes, weights, preferences endpoints", async () => {
+    const products = await (await get("/ui/api/products")).json();
+    expect(products.products.map((p: any) => p.name)).toContain("Uiprodukt");
+    const recipes = await (await get("/ui/api/recipes")).json();
+    expect(recipes.recipes).toHaveLength(1);
+    const recipe = await (await get(`/ui/api/recipes/${recipes.recipes[0].id}`)).json();
+    expect(recipe.totals.kcal).toBe(400);
+    const weights = await (await get("/ui/api/weights")).json();
+    expect(weights.weights).toHaveLength(1);
+    const prefs = await (await get("/ui/api/preferences")).json();
+    expect(prefs.preferences.length).toBeGreaterThan(3);
+    expect(prefs.targets).toHaveLength(3);
+  });
+
+  test("static routes serve with security headers", async () => {
+    const res = await get("/ui");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+    expect(res.headers.get("content-security-policy")).toBe("default-src 'self'; img-src 'self' data:");
+    expect((await get("/ui/static/app.js")).headers.get("content-type")).toContain("javascript");
+    expect((await get("/ui/static/app.css")).headers.get("content-type")).toContain("text/css");
+  });
+
+  test("invalid date 400 with fixed message; unknown API path 404; unknown recipe 404", async () => {
+    const bad = await get("/ui/api/days/2026-13-45");
+    expect(bad.status).toBe(400);
+    expect((await bad.json()).error).toBe("ogiltigt datum");
+    expect((await get("/ui/api/nonsense")).status).toBe(404);
+    expect((await get("/ui/api/recipes/9999")).status).toBe(404);
+  });
+
+  test("non-GET methods rejected with Allow: GET", async () => {
+    for (const method of ["POST", "PUT", "DELETE", "PATCH"]) {
+      const res = await fetch(`${base}/ui/api/products`, { method });
+      expect(res.status).toBe(405);
+      expect(res.headers.get("allow")).toBe("GET");
+    }
+  });
+
+  test("path tricks die safely (raw request-targets, no client normalization)", async () => {
+    expect(await rawStatus(`/ui/../mcp/${TOKEN}`, "POST")).toBe(404);
+    expect(await rawStatus("/UI")).toBe(404);
+    expect(await rawStatus("//ui")).toBe(404);
+    expect(await rawStatus("/ui%2fapi/products")).toBe(404);
+    expect(await rawStatus("/ui/static/../auth.ts")).toBe(404);
+    expect(await rawStatus("/ui/static/app.js.map")).toBe(404);
+    expect(await rawStatus("/ui/api/days/ig%C3%A5r")).toBe(404); // encoded non-ASCII dies at the % reject
+  });
+
+  test("NO endpoint mutates ANY table, including days", async () => {
+    const before = rowCounts();
+    await get("/ui/api/overview");
+    await get("/ui/api/days?limit=10&offset=0");
+    await get("/ui/api/days/2099-01-01"); // unlogged future date must NOT create a row
+    await get("/ui/api/products");
+    await get("/ui/api/recipes");
+    await get("/ui/api/weights");
+    await get("/ui/api/preferences");
+    expect(rowCounts()).toEqual(before);
+  });
+
+  test("unconfigured auth fails closed with 503", async () => {
+    const closed = createHttpServer({ token: TOKEN, db, uiAuth: { mode: "unconfigured" } });
+    await new Promise<void>((r) => closed.listen(0, r));
+    const port = (closed.address() as AddressInfo).port;
+    expect((await fetch(`http://127.0.0.1:${port}/ui`)).status).toBe(503);
+    expect((await fetch(`http://127.0.0.1:${port}/ui/api/overview`)).status).toBe(503);
+    // MCP and healthz unaffected
+    expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
+    await new Promise((r) => closed.close(r));
+  });
+});

--- a/kcal-assistant/tests/ui-auth.test.ts
+++ b/kcal-assistant/tests/ui-auth.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet } from "jose";
+import { createUiAuth, resolveUiAuthState } from "../src/ui/auth";
+
+const ISSUER = "https://test.cloudflareaccess.com";
+const AUD = "test-aud-tag";
+const EMAIL = "test@example.com";
+
+let signKey: CryptoKey;
+let getKey: ReturnType<typeof createLocalJWKSet>;
+let foreignKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair("RS256");
+  signKey = pair.privateKey as CryptoKey;
+  getKey = createLocalJWKSet({ keys: [{ ...(await exportJWK(pair.publicKey)), alg: "RS256" }] });
+  const foreign = await generateKeyPair("RS256");
+  foreignKey = foreign.privateKey as CryptoKey;
+});
+
+function token(overrides: { email?: string; aud?: string | string[]; iss?: string; exp?: string; key?: CryptoKey } = {}) {
+  return new SignJWT({ email: overrides.email ?? EMAIL })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(overrides.iss ?? ISSUER)
+    .setAudience(overrides.aud ?? AUD)
+    .setIssuedAt()
+    .setExpirationTime(overrides.exp ?? "5m")
+    .sign(overrides.key ?? signKey);
+}
+
+function auth() {
+  return createUiAuth({ getKey, issuer: ISSUER, audience: AUD, email: EMAIL });
+}
+
+describe("createUiAuth", () => {
+  test("valid token passes", async () => {
+    expect((await auth()(await token())).ok).toBe(true);
+  });
+
+  test("email matching is case-insensitive", async () => {
+    expect((await auth()(await token({ email: "TEST@Example.com" }))).ok).toBe(true);
+  });
+
+  test("multi-audience token containing the right AUD passes", async () => {
+    expect((await auth()(await token({ aud: [AUD, "other-app"] }))).ok).toBe(true);
+  });
+
+  test("wrong email, wrong aud, wrong issuer, expired all fail 403", async () => {
+    const verify = auth();
+    for (const bad of [
+      await token({ email: "attacker@example.com" }),
+      await token({ aud: "other-aud" }),
+      await token({ iss: "https://evil.cloudflareaccess.com" }),
+      await token({ exp: "-5m" }),
+    ]) {
+      const result = await verify(bad);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.status).toBe(403);
+    }
+  });
+
+  test("missing header, garbage, foreign key, alg:none all fail 403", async () => {
+    const verify = auth();
+    const algNone = `${btoa(JSON.stringify({ alg: "none" }))}.${btoa(
+      JSON.stringify({ email: EMAIL, iss: ISSUER, aud: AUD, exp: Math.floor(Date.now() / 1000) + 300 }),
+    )}.`;
+    for (const bad of [undefined, "garbage", await token({ key: foreignKey }), algNone]) {
+      const result = await verify(bad);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.status).toBe(403);
+    }
+  });
+
+  test("JWKS network failure yields 503, not 403", async () => {
+    const verify = createUiAuth({
+      getKey: () => {
+        throw new TypeError("fetch failed");
+      },
+      issuer: ISSUER,
+      audience: AUD,
+      email: EMAIL,
+    });
+    const result = await verify(await token());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(503);
+  });
+});
+
+describe("resolveUiAuthState", () => {
+  const env = {
+    teamDomain: "test.cloudflareaccess.com",
+    aud: AUD,
+    email: EMAIL,
+  };
+
+  test("all envs set yields configured state", () => {
+    const state = resolveUiAuthState({ ...env, devNoAuth: false, nodeEnv: "production" });
+    expect(state.mode).toBe("configured");
+  });
+
+  test("missing envs yield unconfigured (fail closed)", () => {
+    const state = resolveUiAuthState({ devNoAuth: false, nodeEnv: "production" });
+    expect(state.mode).toBe("unconfigured");
+  });
+
+  test("bad team domain refused", () => {
+    expect(() =>
+      resolveUiAuthState({ ...env, teamDomain: "evil.example.com", devNoAuth: false, nodeEnv: "production" }),
+    ).toThrow(/cloudflareaccess/);
+  });
+
+  test("dev bypass works outside production, REFUSED in production", () => {
+    expect(resolveUiAuthState({ devNoAuth: true, nodeEnv: "development" }).mode).toBe("dev-bypass");
+    expect(resolveUiAuthState({ devNoAuth: true, nodeEnv: "production" }).mode).toBe("unconfigured");
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.4.0
+          image: rutbergphilip/kcal-assistant:v0.5.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
## v0.5.0 — KCAL·DB

Read-only web UI at `/ui`: dagar/måltider, produkter (sök), recept, vikt (SVG-trend + TDEE), regler/mål. Same container, three self-contained static files, strict CSP, Swedish, mobile-first, dark/light.

**Security (adversarially reviewed design):**
- Cloudflare Access at the edge (path-scoped to /ui; /mcp unchanged) + server-side JWT verification of every /ui request (RS256 pinned, issuer/AUD/email, JWKS-outage 503 ≠ forged 403). Fail-closed 503 until CF_ACCESS_* envs are set — this PR deploys safely BEFORE the Access app exists.
- Exact route whitelist, raw request-target trick rejection (tested over raw sockets: ../, %2f, //, /UI), zero mutation endpoints, no-mutation regression across all tables, generic error bodies, no-store/CSP/XFO headers.
- 117 tests green (JWT matrix incl. alg:none/foreign key/multi-aud), tsc clean, all views visually verified.

Flux Local Test failures are the pre-existing repo issue (see #356).