### PR TITLE
fix(authentik): pin sourceRef namespace (live reconcile blocker)

### DIFF
--- a/kubernetes/apps/security/authentik/ks.yaml
+++ b/kubernetes/apps/security/authentik/ks.yaml
@@ -11,6 +11,12 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+    # Required: the parent security/kustomization.yaml sets namespace: security,
+    # which forces this Kustomization CR into the security namespace. Without an
+    # explicit source namespace it looks for GitRepository in security and fails
+    # with "GitRepository flux-system not found". Every working app pins this.
+    namespace: flux-system
+  targetNamespace: security
   path: ./kubernetes/apps/security/authentik/app
   prune: true
   wait: true


### PR DESCRIPTION
Follow-up to #363. After merging the source/dependsOn/storage/secret fixes, live reconcile revealed the authentik Kustomization sits in the `security` namespace (the parent kustomization's `namespace: security` overrides the declared `flux-system`), and its `sourceRef` had no namespace → resolved GitRepository in `security` → 'GitRepository flux-system not found'. This was masked from flux-local (which doesn't model the override). Fix mirrors every working app: `sourceRef.namespace: flux-system` + `targetNamespace: security`. flux-local: 35 passed.