### PR TITLE
fix(authentik): distribute sops-age to security namespace

### DIFF
--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -4,7 +4,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: security
 
+# common distributes sops-age (needed so the authentik child Kustomization,
+# which runs in this namespace, can decrypt secrets.sops.yaml), cluster-secrets,
+# and the namespace itself (renamed from not-used to security). Mirrors the
+# network namespace. Its namespace.yaml replaces the local one.
+components:
+  - ../../components/common
+
 resources:
-  - ./namespace.yaml
   - ./storage.yaml
   - ./authentik/ks.yaml


### PR DESCRIPTION
Follow-up to #364. Live reconcile now gets past source resolution and hits 'secrets sops-age not found': the authentik child Kustomization runs in the `security` namespace but `security/kustomization.yaml` never included `components/common` (which distributes sops-age + cluster-secrets + the namespace). Every Pattern-B namespace (e.g. network) includes it. Add it; its namespace.yaml replaces the local one so there's no duplicate Namespace/security. Verified: `kustomize build` yields one namespace + sops-age; flux-local 35 passed.