### PR TITLE
fix(authentik): postgres PGDATA permission on local-path

### DIFF
--- a/kubernetes/apps/security/authentik/app/postgres.yaml
+++ b/kubernetes/apps/security/authentik/app/postgres.yaml
@@ -59,8 +59,13 @@ spec:
                 - pg_isready -U authentik -d authentik
             initialDelaySeconds: 5
             periodSeconds: 5
+      # postgres:16-alpine runs as uid/gid 70. Running directly as 70 (instead
+      # of root->gosu, which drops the fsGroup supplementary group) plus fsGroup
+      # 70 makes the local-path volume writable so initdb can create PGDATA.
       securityContext:
-        fsGroup: 999
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
   volumeClaimTemplates:
     - metadata:
         name: postgresql-data


### PR DESCRIPTION
Live boot reached Postgres, which CrashLooped: `mkdir: can't create directory '/var/lib/postgresql/data/pgdata': Permission denied`. The pod had `fsGroup: 999` but postgres:16-alpine runs as uid/gid 70; starting as root and dropping to the postgres user via gosu discards the fsGroup supplementary group. Fix: `runAsUser/runAsGroup/fsGroup: 70` so postgres runs directly as 70 and the local-path volume is group-writable. (Redis came up fine — different entrypoint.) flux-local 35 passed.