### PR TITLE
fix(authentik): ingress backend service name

### DIFF
--- a/kubernetes/apps/security/authentik/app/ingress.yaml
+++ b/kubernetes/apps/security/authentik/app/ingress.yaml
@@ -34,6 +34,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: authentik
+                name: authentik-server
                 port:
                   number: 80


### PR DESCRIPTION
Server pods are Ready and the TLS cert issued, but auth.rutberg.dev 503s: the ingress backend referenced service `authentik` while the chart creates `authentik-server`. Point the ingress at the real service. flux-local 35 passed.