### PR TITLE
fix(authentik): 15m Helm timeout for first boot

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: security
 spec:
   interval: 1h
+  # Authentik's first boot runs hundreds of DB migrations + blueprint apply,
+  # which exceeds the default 5m. 15m gives it room so the release doesn't get
+  # marked Failed while it is in fact still coming up healthy.
+  timeout: 15m
   chart:
     spec:
       chart: authentik
@@ -16,9 +20,11 @@ spec:
         name: authentik
         namespace: flux-system
   install:
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     cleanupOnFail: true
     remediation:
       retries: 3


### PR DESCRIPTION
All five pods are 1/1 Ready and auth.rutberg.dev serves (302→login, health/admin/flow 200), but the HelmRelease is marked Failed: the install action hit the default 5m timeout during first boot (hundreds of DB migrations + blueprint application). Raise install/upgrade/spec timeout to 15m so Flux waits out first boot. On merge, remediation re-installs the helm-managed server/worker/service (fast now — DB already migrated); postgres/redis are raw manifests and untouched. flux-local 35 passed.