### PR TITLE
feat(kcal-assistant): v0.5.1 Authentik forward-auth mode

### DIFF
--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/config.ts
+++ b/kcal-assistant/src/config.ts
@@ -11,6 +11,7 @@ export const config = {
   dbPath: process.env.DB_PATH ?? "./kcal.db",
   port: Number(process.env.PORT ?? 3000),
   icaStoreId: process.env.ICA_STORE_ID ?? "1003421", // Maxi ICA Stormarknad Nynäshamn
+  authentikAllowedEmail: process.env.AUTHENTIK_ALLOWED_EMAIL,
   cfAccessTeamDomain: process.env.CF_ACCESS_TEAM_DOMAIN,
   cfAccessAud: process.env.CF_ACCESS_AUD,
   cfAccessEmail: process.env.CF_ACCESS_EMAIL,

--- a/kcal-assistant/src/index.ts
+++ b/kcal-assistant/src/index.ts
@@ -5,6 +5,7 @@ import { resolveUiAuthState } from "./ui/auth";
 
 const db = getDb(); // opens + migrates before we accept traffic
 const uiAuth = resolveUiAuthState({
+  authentikEmail: config.authentikAllowedEmail,
   teamDomain: config.cfAccessTeamDomain,
   aud: config.cfAccessAud,
   email: config.cfAccessEmail,

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -86,7 +86,8 @@ export function createHttpServer(opts: { token: string; db: Database; uiAuth: Ui
           return;
         }
         if (opts.uiAuth.mode === "configured") {
-          const header = req.headers["cf-access-jwt-assertion"];
+          const raw = req.headers[opts.uiAuth.header];
+          const header = Array.isArray(raw) ? raw[0] : raw;
           const result = await opts.uiAuth.verify(typeof header === "string" ? header : undefined);
           if (!result.ok) {
             uiJson(res, result.status, { error: result.message });

--- a/kcal-assistant/src/ui/auth.ts
+++ b/kcal-assistant/src/ui/auth.ts
@@ -1,21 +1,27 @@
 import { jwtVerify, createRemoteJWKSet, errors as joseErrors, type JWTVerifyGetKey } from "jose";
 
-// Cloudflare Access sits at the edge, but the server trusts nothing: every
-// /ui request must carry a Cf-Access-Jwt-Assertion JWT that we verify
-// cryptographically. Header only — never the CF_Authorization cookie.
+// The /ui surface is gated by an identity provider at the ingress, but the
+// server trusts nothing: it re-checks the provider's forwarded identity on
+// every request. Two providers are supported:
+//   - Cloudflare Access: verify the Cf-Access-Jwt-Assertion JWT cryptographically.
+//   - Authentik forward-auth: verify the X-authentik-email header equals the
+//     allowed identity. Safe because (a) nginx replaces any client-supplied
+//     X-authentik-* with the outpost's value via auth-response-headers, and
+//     (b) a NetworkPolicy restricts the pod to the ingress controller, so the
+//     header can't be forged by bypassing nginx in-cluster.
 
 export type UiAuthResult = { ok: true } | { ok: false; status: 403 | 503; message: string };
 
-export interface UiAuthOptions {
+export type UiVerify = (headerValue: string | undefined) => Promise<UiAuthResult>;
+
+export interface CfAuthOptions {
   getKey: JWTVerifyGetKey;
   issuer: string;
   audience: string;
   email: string;
 }
 
-export type UiVerify = (headerValue: string | undefined) => Promise<UiAuthResult>;
-
-export function createUiAuth(opts: UiAuthOptions): UiVerify {
+export function createCfAuth(opts: CfAuthOptions): UiVerify {
   return async (headerValue) => {
     if (!headerValue) return { ok: false, status: 403, message: "saknar autentisering" };
     try {
@@ -31,9 +37,6 @@ export function createUiAuth(opts: UiAuthOptions): UiVerify {
       }
       return { ok: true };
     } catch (e) {
-      // Token problems (signature, claims, format) => 403. Anything else —
-      // e.g. the JWKS fetch failing — is an infrastructure problem => 503,
-      // still closed but distinguishable from a forged token.
       if (e instanceof joseErrors.JOSEError) {
         return { ok: false, status: 403, message: "ogiltig autentisering" };
       }
@@ -42,12 +45,27 @@ export function createUiAuth(opts: UiAuthOptions): UiVerify {
   };
 }
 
+// Retained name for the existing CF test-suite.
+export const createUiAuth = createCfAuth;
+
+export function createAuthentikAuth(allowedEmail: string): UiVerify {
+  const wanted = allowedEmail.toLowerCase();
+  return async (headerValue) => {
+    if (!headerValue) return { ok: false, status: 403, message: "saknar autentisering" };
+    if (headerValue.trim().toLowerCase() !== wanted) {
+      return { ok: false, status: 403, message: "fel identitet" };
+    }
+    return { ok: true };
+  };
+}
+
 export type UiAuthState =
-  | { mode: "configured"; verify: UiVerify }
+  | { mode: "configured"; header: string; verify: UiVerify }
   | { mode: "unconfigured" }
   | { mode: "dev-bypass" };
 
 export function resolveUiAuthState(input: {
+  authentikEmail?: string;
   teamDomain?: string;
   aud?: string;
   email?: string;
@@ -62,20 +80,32 @@ export function resolveUiAuthState(input: {
     console.warn("UI auth DISABLED (UI_DEV_NO_AUTH=1) — dev only");
     return { mode: "dev-bypass" };
   }
-  if (!input.teamDomain || !input.aud || !input.email) return { mode: "unconfigured" };
-  if (!input.teamDomain.endsWith(".cloudflareaccess.com")) {
-    throw new Error(
-      `CF_ACCESS_TEAM_DOMAIN must be the full <team>.cloudflareaccess.com host, got: ${input.teamDomain}`,
-    );
+  // Authentik forward-auth takes precedence when configured.
+  if (input.authentikEmail) {
+    return {
+      mode: "configured",
+      header: "x-authentik-email",
+      verify: createAuthentikAuth(input.authentikEmail),
+    };
   }
-  const issuer = `https://${input.teamDomain}`;
-  return {
-    mode: "configured",
-    verify: createUiAuth({
-      getKey: createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`)),
-      issuer,
-      audience: input.aud,
-      email: input.email,
-    }),
-  };
+  // Cloudflare Access (legacy path, kept for portability).
+  if (input.teamDomain && input.aud && input.email) {
+    if (!input.teamDomain.endsWith(".cloudflareaccess.com")) {
+      throw new Error(
+        `CF_ACCESS_TEAM_DOMAIN must be the full <team>.cloudflareaccess.com host, got: ${input.teamDomain}`,
+      );
+    }
+    const issuer = `https://${input.teamDomain}`;
+    return {
+      mode: "configured",
+      header: "cf-access-jwt-assertion",
+      verify: createCfAuth({
+        getKey: createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`)),
+        issuer,
+        audience: input.aud,
+        email: input.email,
+      }),
+    };
+  }
+  return { mode: "unconfigured" };
 }

--- a/kcal-assistant/tests/ui-auth.test.ts
+++ b/kcal-assistant/tests/ui-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll } from "bun:test";
 import { generateKeyPair, exportJWK, SignJWT, createLocalJWKSet } from "jose";
-import { createUiAuth, resolveUiAuthState } from "../src/ui/auth";
+import { createUiAuth, createAuthentikAuth, resolveUiAuthState } from "../src/ui/auth";
 
 const ISSUER = "https://test.cloudflareaccess.com";
 const AUD = "test-aud-tag";
@@ -112,5 +112,39 @@ describe("resolveUiAuthState", () => {
   test("dev bypass works outside production, REFUSED in production", () => {
     expect(resolveUiAuthState({ devNoAuth: true, nodeEnv: "development" }).mode).toBe("dev-bypass");
     expect(resolveUiAuthState({ devNoAuth: true, nodeEnv: "production" }).mode).toBe("unconfigured");
+  });
+
+  test("CF configured state reads the CF header", () => {
+    const state = resolveUiAuthState({ ...env, devNoAuth: false, nodeEnv: "production" });
+    expect(state.mode).toBe("configured");
+    if (state.mode === "configured") expect(state.header).toBe("cf-access-jwt-assertion");
+  });
+
+  test("Authentik email takes precedence and reads the authentik header", () => {
+    const state = resolveUiAuthState({
+      ...env,
+      authentikEmail: "philip@rutberg.dev",
+      devNoAuth: false,
+      nodeEnv: "production",
+    });
+    expect(state.mode).toBe("configured");
+    if (state.mode === "configured") expect(state.header).toBe("x-authentik-email");
+  });
+});
+
+describe("createAuthentikAuth", () => {
+  const auth = createAuthentikAuth("Philip@Rutberg.dev");
+
+  test("accepts the allowed email case-insensitively", async () => {
+    expect((await auth("philip@rutberg.dev")).ok).toBe(true);
+    expect((await auth("PHILIP@RUTBERG.DEV ")).ok).toBe(true); // trims + folds case
+  });
+
+  test("rejects wrong or missing email with 403", async () => {
+    for (const bad of [undefined, "", "attacker@evil.com"]) {
+      const r = await auth(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.status).toBe(403);
+    }
   });
 });


### PR DESCRIPTION
Server-side support for gating /ui with Authentik forward-auth instead of Cloudflare Access. The UI auth state carries the header to read (x-authentik-email vs cf-access-jwt-assertion) and its verify fn; Authentik mode checks X-authentik-email == AUTHENTIK_ALLOWED_EMAIL and takes precedence when set. Fail-closed (503 unconfigured) and dev-bypass unchanged. 121 tests pass incl. new Authentik cases. App-only PR so CI builds v0.5.1 before the manifest cutover (keeps /mcp up).