### PR TITLE
feat(kcal-assistant): Authentik forward-auth cutover

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.5.0
+          image: rutbergphilip/kcal-assistant:v0.5.1
           imagePullPolicy: IfNotPresent
 
           ports:
@@ -39,6 +39,11 @@ spec:
               value: "3000"
             - name: DB_PATH
               value: "/app/data/kcal.db"
+            # /ui is gated by Authentik forward-auth; the server re-checks the
+            # forwarded identity. Setting this switches UI auth from Cloudflare
+            # Access to Authentik. Unset => UI fails closed (503).
+            - name: AUTHENTIK_ALLOWED_EMAIL
+              value: "admin@rutberg.dev"
             - name: MCP_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
@@ -1,0 +1,41 @@
+# Second Ingress on the SAME host, scoped to /ui only, gated by Authentik
+# forward-auth. nginx longest-prefix routing sends /ui* here (authenticated)
+# while /mcp and /healthz stay on the open kcal-assistant Ingress (path /).
+# This split is load-bearing: nginx auth annotations are per-location, so
+# gating must never be applied to the / Ingress or the claude.ai MCP
+# connector (which cannot do interactive login) would break.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kcal-assistant-ui
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+
+    # Authentik forward-auth. On success the outpost returns X-authentik-*
+    # headers; auth-response-headers copies them onto the upstream request via
+    # proxy_set_header, which REPLACES any client-supplied value — so a browser
+    # cannot forge X-authentik-email from outside. The server re-checks the
+    # email as defense in depth.
+    nginx.ingress.kubernetes.io/auth-url: "https://auth.rutberg.dev/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.rutberg.dev/outpost.goauthentik.io/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+spec:
+  ingressClassName: external
+  rules:
+    - host: kcal.rutberg.dev
+      http:
+        paths:
+          - path: /ui
+            pathType: Prefix
+            backend:
+              service:
+                name: kcal-assistant
+                port:
+                  number: 3000

--- a/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./ingress-ui.yaml
   - ./backup-cronjob.yaml
 
 configMapGenerator:


### PR DESCRIPTION
Cuts /ui auth from Cloudflare Access to Authentik. Adds `kcal-assistant-ui` Ingress (path /ui, forward-auth to the Authentik outpost); the open `kcal-assistant` Ingress (path /) is untouched so /mcp + /healthz stay reachable for claude.ai. Sets AUTHENTIK_ALLOWED_EMAIL + image v0.5.1. Image already on Docker Hub so the Recreate is fast.

Go/no-go after deploy: /mcp/<token> still 200 (NOT redirected to login), /ui → Authentik login → served, /healthz open.