### PR TITLE
feat(kcal-assistant): NetworkPolicy hardening

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./service.yaml
   - ./ingress.yaml
   - ./ingress-ui.yaml
+  - ./networkpolicy.yaml
   - ./backup-cronjob.yaml
 
 configMapGenerator:

--- a/kubernetes/apps/home-automation/kcal-assistant/networkpolicy.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/networkpolicy.yaml
@@ -1,0 +1,24 @@
+# Restrict who can reach the kcal pod so the /ui X-authentik-email header
+# cannot be forged by a pod that bypasses nginx in-cluster. Allowed sources:
+#   - the external ingress-nginx controller (all real traffic — /mcp AND /ui
+#     arrive via nginx), and
+#   - host + remote-node entities (kubelet liveness/readiness probes come from
+#     the node; without this the probes would fail and the pod — which serves
+#     /mcp — would be killed).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kcal-assistant
+spec:
+  endpointSelector:
+    matchLabels:
+      app: kcal-assistant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            app.kubernetes.io/instance: external-ingress-nginx
+            app.kubernetes.io/component: controller
+    - fromEntities:
+        - host
+        - remote-node


### PR DESCRIPTION
Defense-in-depth for the Authentik cutover: a CiliumNetworkPolicy so only the external nginx controller and host/remote-node (kubelet probes) can reach the kcal pod. Closes the in-cluster X-authentik-email forgery gap. Uses fromEntities host+remote-node so health probes keep working (naive policies break them). Will verify pod stays Ready + /mcp 200 immediately after reconcile; revert if any degradation. flux-local 35 passed.