### PR TITLE
fix(kcal-assistant): Authentik domain forward-auth redirect

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
@@ -18,8 +18,12 @@ metadata:
     # proxy_set_header, which REPLACES any client-supplied value — so a browser
     # cannot forge X-authentik-email from outside. The server re-checks the
     # email as defense in depth.
+    # Domain-level forward auth (central outpost on auth.rutberg.dev protecting
+    # kcal.rutberg.dev). auth-signin MUST carry the full original URL incl. host
+    # ($scheme://$host$request_uri) so the outpost knows which app and where to
+    # return — a path-only rd yields "Not Found".
     nginx.ingress.kubernetes.io/auth-url: "https://auth.rutberg.dev/outpost.goauthentik.io/auth/nginx"
-    nginx.ingress.kubernetes.io/auth-signin: "https://auth.rutberg.dev/outpost.goauthentik.io/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://auth.rutberg.dev/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
     nginx.ingress.kubernetes.io/auth-snippet: |
       proxy_set_header X-Forwarded-Host $http_host;


### PR DESCRIPTION
The /ui redirect reached Authentik but showed 'Not Found': the provider was forward_single and the auth-signin rd was path-only. Fixed: provider switched to forward_domain + cookie_domain rutberg.dev (via API), and auth-signin now sends the full URL `rd=$scheme://$host$request_uri` so the central outpost resolves the app and return URL. Verified the outpost /start now 302s to login and /auth/nginx 401s. flux-local 35 passed.