### PR TITLE
fix(kcal-assistant): local Authentik outpost (fix forward-auth loop)

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/ingress-outpost.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/ingress-outpost.yaml
@@ -1,0 +1,26 @@
+# Serves /outpost.goauthentik.io/* on kcal.rutberg.dev (login page, callback,
+# auth endpoint) by proxying to the Authentik embedded outpost. NO forward-auth
+# here — this IS the auth handshake. upstream-vhost keeps Host: kcal.rutberg.dev
+# so the outpost matches the kcal provider (external_host https://kcal.rutberg.dev).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kcal-assistant-outpost
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    nginx.ingress.kubernetes.io/upstream-vhost: "kcal.rutberg.dev"
+spec:
+  ingressClassName: external
+  rules:
+    - host: kcal.rutberg.dev
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-embedded-outpost
+                port:
+                  number: 80

--- a/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/ingress-ui.yaml
@@ -18,12 +18,12 @@ metadata:
     # proxy_set_header, which REPLACES any client-supplied value — so a browser
     # cannot forge X-authentik-email from outside. The server re-checks the
     # email as defense in depth.
-    # Domain-level forward auth (central outpost on auth.rutberg.dev protecting
-    # kcal.rutberg.dev). auth-signin MUST carry the full original URL incl. host
-    # ($scheme://$host$request_uri) so the outpost knows which app and where to
-    # return — a path-only rd yields "Not Found".
-    nginx.ingress.kubernetes.io/auth-url: "https://auth.rutberg.dev/outpost.goauthentik.io/auth/nginx"
-    nginx.ingress.kubernetes.io/auth-signin: "https://auth.rutberg.dev/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri"
+    # Single-application forward auth: everything runs on kcal.rutberg.dev so
+    # the session cookie and the auth check share one host (cross-subdomain
+    # cookies loop). auth-url is the in-cluster outpost (X-Forwarded-Host tells
+    # it which app); auth-signin + callback live on kcal via ingress-outpost.
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.security.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://kcal.rutberg.dev/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
     nginx.ingress.kubernetes.io/auth-snippet: |
       proxy_set_header X-Forwarded-Host $http_host;

--- a/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/kustomization.yaml
@@ -8,8 +8,10 @@ resources:
   - ./secret.sops.yaml
   - ./deployment.yaml
   - ./service.yaml
+  - ./service-outpost.yaml
   - ./ingress.yaml
   - ./ingress-ui.yaml
+  - ./ingress-outpost.yaml
   - ./networkpolicy.yaml
   - ./backup-cronjob.yaml
 

--- a/kubernetes/apps/home-automation/kcal-assistant/service-outpost.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/service-outpost.yaml
@@ -1,0 +1,15 @@
+# Lets the /outpost.goauthentik.io path be served ON kcal.rutberg.dev by
+# proxying to the Authentik embedded outpost (authentik-server, security ns).
+# ExternalName is a DNS alias, so it can cross namespaces where an Ingress
+# backend cannot. This keeps the whole forward-auth handshake (login redirect,
+# callback, session cookie) on kcal.rutberg.dev — no cross-subdomain cookie.
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-embedded-outpost
+spec:
+  type: ExternalName
+  externalName: authentik-server.security.svc.cluster.local
+  ports:
+    - name: http
+      port: 80


### PR DESCRIPTION
The forward-auth redirect looped: domain-level auth set the session cookie on auth.rutberg.dev, but the nginx auth check for host kcal.rutberg.dev never saw it (cross-subdomain cookie). Switch to Authentik's single-application pattern — proxy /outpost.goauthentik.io on kcal.rutberg.dev (ExternalName → authentik-server, upstream-vhost kcal.rutberg.dev), auth-signin+callback on kcal, auth-url the in-cluster outpost. Session cookie now host-only on kcal.rutberg.dev, same host as the auth check → no loop. flux-local 35 passed. Will browser-verify after deploy.