### PR TITLE
fix(authentik): raise worker probe timeouts to stop CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -119,6 +119,18 @@ spec:
     # Worker configuration
     worker:
       replicas: 1
+      # ak healthcheck (exec probe) regularly exceeds the chart-default 3s
+      # timeout under this worker's CPU limits; the liveness probe then kills
+      # a functionally healthy pod (CrashLoopBackOff). Helm deep-merges these
+      # over the chart defaults, so the exec command and other fields remain.
+      livenessProbe:
+        timeoutSeconds: 15
+        periodSeconds: 30
+      readinessProbe:
+        timeoutSeconds: 15
+        periodSeconds: 30
+      startupProbe:
+        timeoutSeconds: 15
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Problem

`authentik-worker` is in CrashLoopBackOff (10+ restarts). Events show:

```
Readiness probe failed: command timed out: "ak healthcheck" timed out after 3s
```

The worker is functionally healthy — logs show tasks processing and blueprints applying normally right up until the kubelet SIGTERMs it after 3 consecutive liveness failures. `ak healthcheck` boots a Django process, which regularly exceeds the chart-default 3s exec timeout under the worker's 300m CPU limit.

## Fix

Override only the timing fields in the HelmRelease `worker:` block — `timeoutSeconds` 3→15 on all three probes, liveness/readiness `periodSeconds` 10→30. Helm deep-merges over chart defaults, so the `exec: [ak, healthcheck]` command and thresholds are preserved (verified via flux-local diff: only these fields change in the rendered worker Deployment).

## Verification

- `flux-local test --enable-helm`: 35/35 pass
- flux-local diff: worker Deployment probe fields only
- Post-merge: watch worker restartCount stays 0 for 30+ min; auth.rutberg.dev + kcal /ui smoke

Phase 1 of the SSO hardening plan (worker stability is a prerequisite for the blueprints PR — the worker applies blueprints).

## Rollback

Revert → chart defaults return (and with them the pre-existing CrashLoop). No DB impact; server pods untouched.