### PR TITLE
feat(homarr): gate dashboard.rutberg.dev behind Authentik forward-auth

### DIFF
--- a/kubernetes/apps/home-automation/homarr/ingress-outpost.yaml
+++ b/kubernetes/apps/home-automation/homarr/ingress-outpost.yaml
@@ -1,0 +1,30 @@
+# Serves /outpost.goauthentik.io/* on dashboard.rutberg.dev (login redirect,
+# callback, auth endpoint) by proxying to the Authentik embedded outpost. NO
+# forward-auth here — this IS the auth handshake. upstream-vhost keeps
+# Host: dashboard.rutberg.dev so the outpost matches the homarr provider
+# (external_host https://dashboard.rutberg.dev).
+# Backend: the authentik-embedded-outpost ExternalName Service defined in
+# ../kcal-assistant/service-outpost.yaml (namespace-wide, shared by all
+# forward-auth apps in home-automation).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homarr-outpost
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    nginx.ingress.kubernetes.io/upstream-vhost: "dashboard.rutberg.dev"
+spec:
+  ingressClassName: external
+  rules:
+    - host: dashboard.rutberg.dev
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-embedded-outpost
+                port:
+                  number: 80

--- a/kubernetes/apps/home-automation/homarr/ingress.yaml
+++ b/kubernetes/apps/home-automation/homarr/ingress.yaml
@@ -1,3 +1,6 @@
+# Gated by Authentik forward-auth (single-application pattern — see
+# kcal-assistant and SETUP-GUIDE.md in security/authentik). The auth handshake
+# itself is served on this same host by ingress-outpost.yaml.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,7 +9,13 @@ metadata:
     external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
-
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.security.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://dashboard.rutberg.dev/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 spec:
   ingressClassName: external
   rules:

--- a/kubernetes/apps/home-automation/homarr/kustomization.yaml
+++ b/kubernetes/apps/home-automation/homarr/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - ingress-outpost.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/home-automation/homarr/networkpolicy.yaml
+++ b/kubernetes/apps/home-automation/homarr/networkpolicy.yaml
@@ -1,0 +1,22 @@
+# Restrict who can reach the homarr pod so the X-authentik-* headers cannot
+# be forged by a pod that bypasses nginx in-cluster. Ingress-only policy —
+# homarr's own outbound widget/integration calls are unaffected. Allowed:
+#   - the external ingress-nginx controller (all real traffic), and
+#   - host + remote-node entities (kubelet probes come from the node).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: homarr
+spec:
+  endpointSelector:
+    matchLabels:
+      app: homarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            app.kubernetes.io/instance: external-ingress-nginx
+            app.kubernetes.io/component: controller
+    - fromEntities:
+        - host
+        - remote-node

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -50,6 +50,38 @@ entries:
       provider: !KeyOf kcal-provider
       policy_engine_mode: any
 
+  # ------------------------------------------------------------- homarr ----
+  - model: authentik_providers_proxy.proxyprovider
+    state: present
+    id: homarr-provider
+    identifiers:
+      name: homarr
+    attrs:
+      mode: forward_single
+      external_host: https://dashboard.rutberg.dev
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: hours=1
+      refresh_token_validity: days=30
+      intercept_header_auth: true
+      internal_host_ssl_validation: true
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-entitlements]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/proxy/scope-proxy]]
+
+  - model: authentik_core.application
+    state: present
+    id: homarr-app
+    identifiers:
+      slug: homarr
+    attrs:
+      name: Homarr
+      provider: !KeyOf homarr-provider
+      policy_engine_mode: any
+
   # --------------------------------------------------- embedded outpost ----
   # CAUTION: `providers` and `config` are FULL REPLACEMENTS on every apply.
   # Every provider that must stay assigned HAS to be listed, and the config
@@ -62,6 +94,7 @@ entries:
     attrs:
       providers:
         - !KeyOf kcal-provider
+        - !KeyOf homarr-provider
       config:
         log_level: info
         docker_labels: null


### PR DESCRIPTION
## Change

Third app on the proven kcal single-application forward-auth pattern (Phase 4 of the SSO plan):

- **Blueprint** (`security/authentik/app/blueprints/forward-auth.yaml`): `homarr` proxy provider + application, provider appended to the embedded outpost's **cumulative** providers list (kcal entry untouched).
- **`homarr/ingress-outpost.yaml`**: no-auth ingress serving `/outpost.goauthentik.io` on dashboard.rutberg.dev → shared `authentik-embedded-outpost` ExternalName service (lives in `kcal-assistant/` — cross-app coupling noted here and in the file comment).
- **`homarr/ingress.yaml`**: forward-auth annotations on `/` (whole host gated).
- **`homarr/networkpolicy.yaml`**: ingress-only CNP (external ingress-nginx + host/remote-node), same as kcal — blocks in-cluster header forgery, does not affect homarr's outbound widget calls.

Homarr's own login remains behind Authentik (defense in depth).

## Verification (post-merge)

1. Blueprints instance still **Successful**; no duplicate provider/app (identifier match)
2. `curl -sI https://dashboard.rutberg.dev/` → 302 to its own `/outpost.goauthentik.io/start`
3. Full redirect chain lands on auth.rutberg.dev login for "Homarr"
4. Browser round-trip + widget walk (baseline screenshot taken pre-merge)
5. Regression: kcal /ui chain unchanged

## Rollback

Revert restores the open ingress. Provider/app objects would remain as unassigned orphans (harmless; removable via `state: absent` or UI).

flux-local: 35/35 pass.