### PR TITLE
feat(pihole): gate pihole.rutberg.dev behind Authentik forward-auth

### DIFF
--- a/docs/kcal-and-sso-status.md
+++ b/docs/kcal-and-sso-status.md
@@ -50,7 +50,15 @@ conversation.
 Self-hosted SSO at `https://auth.rutberg.dev` (namespace `security`). Chosen over
 Cloudflare Access. Resurrecting it also fixed the long-red flux-local CI.
 
-**Status: LIVE and protecting kcal `/ui`.** Login verified end-to-end.
+**Status: LIVE and protecting kcal `/ui`, homarr (dashboard.rutberg.dev) and
+pihole (pihole.rutberg.dev).** Login verified end-to-end. Provider/application/
+outpost config now lives in git as a blueprint (see below) — the "config only
+in DB" gap is closed.
+
+**Scope decisions (2026-07-09):** jellyfin, plex, home-assistant, jellyseerr,
+the arr-stack and qbittorrent get NO Authentik middleware (native auth,
+NAS-backed, client apps break under forward-auth). trilium skipped for now
+(Philip's call). market-monitor skipped (full native JWT+session auth).
 
 **How kcal /ui is protected (single-application forward auth):**
 - The whole auth handshake runs on `kcal.rutberg.dev` so the session cookie and
@@ -71,15 +79,14 @@ under `authentik.*` (it flattens to literal env). Secrets are injected via
 `global.env` with real `valueFrom.secretKeyRef`. Postgres/Redis are raw manifests
 on `local-path-provisioner`; postgres runs as uid 70.
 
-> **Robustness gap:** the Authentik provider / application / outpost config for
-> kcal was created via the API and lives ONLY in the postgres DB (PVC-persistent),
-> NOT in git. It survives restarts and normal deploys. If the DB is ever lost,
-> recreate: proxy provider `kcal` (mode forward_single, external_host
-> `https://kcal.rutberg.dev`, authz flow default-provider-authorization-implicit-consent,
-> invalidation default-provider-invalidation-flow), application slug `kcal`,
-> assign to the embedded outpost, and set the outpost `authentik_host` +
-> `authentik_host_browser` to `https://auth.rutberg.dev`. The GitOps-correct
-> fix is to capture this as Authentik **blueprints** in git (see "What's left").
+> **Robustness gap CLOSED (2026-07-09, PR #376):** all forward-auth providers/
+> applications and the embedded-outpost assignment are now a git blueprint at
+> `kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml`,
+> mounted via the chart's `blueprints.configMaps` and re-applied automatically.
+> **Do NOT edit these objects in the UI/API** — the blueprint overwrites drift.
+> To add an app: append provider+application entries AND the provider to the
+> outpost's cumulative `providers:` list (full-replacement semantics), plus the
+> per-app k8s manifests. Full recipe in `security/authentik/SETUP-GUIDE.md`.
 
 ---
 
@@ -96,23 +103,32 @@ on `local-path-provisioner`; postgres runs as uid 70.
 
 ## What's left (all optional / follow-ups)
 
-- **Authentik config as blueprints in git** — closes the "config only in DB" gap;
-  makes the kcal provider/app/outpost reproducible via GitOps.
-- **Personal Authentik user** instead of `akadmin` (then update `AUTHENTIK_ALLOWED_EMAIL`);
-  optionally bind the kcal Application to an only-Philip policy.
-- **Expand SSO** to other home-automation apps (each needs its own Authentik proxy
-  provider + application + a local /outpost path, same pattern as kcal). Grafana
-  OIDC (its `[auth.generic_oauth]` block + re-enable).
+- **Personal Authentik user** (email philiprutberg00@gmail.com): Philip creates
+  it in the UI (Directory → Users), then a one-line PR updates
+  `AUTHENTIK_ALLOWED_EMAIL` in kcal's deployment.yaml; optionally bind
+  applications to an only-Philip group policy via blueprint.
+- **trilium SSO** (skipped 2026-07-09) — if resurrected, pre-check desktop/
+  mobile sync clients first (exempt /etapi + sync paths), and clean up its
+  stale ingress-with-auth.yaml/ingress.yaml.backup in the same PR.
+- **Grafana OIDC** — blocked on resurrecting the observability stack first
+  (Grafana isn't deployed; orphaned `observability/prometheus` Kustomization).
 - **kcal get_week UX / preview_meal** and other product ideas as they come up.
-- **Move Authentik off the pinned 2025.12.4** when convenient (Renovate PRs exist).
+- **Move Authentik off the pinned 2025.12.4** (Renovate PR #257): only after
+  blueprints have soaked; take a postgres pg_dump first (no migration
+  downgrades — the dump IS the rollback), re-check worker probe overrides
+  against upstream changes.
 
 ## Known minor issues
 
-- `authentik-worker` readiness probe flaps (0/1) due to the pid-file startup-probe
-  timing; the worker is functionally healthy (processes tasks, `ak healthcheck`
-  passes) and nothing routes to it via a Service, so it's cosmetic.
+- ~~authentik-worker probe flap~~ **FIXED 2026-07-09 (PR #375):** `ak
+  healthcheck` exceeded the chart-default 3s exec-probe timeout and liveness
+  was killing the healthy worker (had escalated to CrashLoopBackOff);
+  timeoutSeconds now 15 via HelmRelease worker probe overrides.
 - Pre-existing unrelated drift: a red `observability/prometheus` Kustomization
   points at a repo path that doesn't exist (observability is disabled).
+- If a future ingress-nginx upgrade tightens `annotations-risk-level`, snippet
+  annotations (auth-snippet) break ALL forward-auth apps at once — browser-test
+  kcal /ui after any ingress-nginx bump.
 
 ## Operational notes / gotchas learned
 

--- a/kubernetes/apps/network/pihole/ingress-outpost.yaml
+++ b/kubernetes/apps/network/pihole/ingress-outpost.yaml
@@ -1,0 +1,32 @@
+# Serves /outpost.goauthentik.io/* on pihole.rutberg.dev (login redirect,
+# callback, auth endpoint) by proxying to the Authentik embedded outpost. NO
+# forward-auth here — this IS the auth handshake. upstream-vhost keeps
+# Host: pihole.rutberg.dev so the outpost matches the pihole provider.
+# The tls block reuses the pihole-tls secret; the cert-manager annotation
+# stays ONLY on the main ingress so a single Certificate owns the secret.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pihole-outpost
+  namespace: network
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.rutberg.dev"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/upstream-vhost: "pihole.rutberg.dev"
+spec:
+  ingressClassName: external
+  rules:
+    - host: pihole.rutberg.dev
+      http:
+        paths:
+          - path: /outpost.goauthentik.io
+            pathType: Prefix
+            backend:
+              service:
+                name: authentik-embedded-outpost
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - pihole.rutberg.dev
+      secretName: pihole-tls

--- a/kubernetes/apps/network/pihole/ingress.yaml
+++ b/kubernetes/apps/network/pihole/ingress.yaml
@@ -1,3 +1,10 @@
+# Gated by Authentik forward-auth (single-application pattern — see
+# kcal-assistant and SETUP-GUIDE.md in security/authentik). The auth handshake
+# itself is served on this same host by ingress-outpost.yaml.
+# NOTE: this gates only the WEB UI ingress. LAN DNS (port 53 on the pihole
+# LoadBalancer, 192.168.50.24) does not pass through nginx and is untouched.
+# Deliberately NO CiliumNetworkPolicy for pihole — a kcal-style policy on the
+# pod would also drop DNS traffic and black-hole the LAN.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -8,7 +15,13 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
-
+    nginx.ingress.kubernetes.io/auth-url: "http://authentik-server.security.svc.cluster.local/outpost.goauthentik.io/auth/nginx"
+    nginx.ingress.kubernetes.io/auth-signin: "https://pihole.rutberg.dev/outpost.goauthentik.io/start?rd=$scheme://$host$request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 spec:
   ingressClassName: external
   rules:

--- a/kubernetes/apps/network/pihole/kustomization.yaml
+++ b/kubernetes/apps/network/pihole/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - ingress-outpost.yaml
+  - service-outpost.yaml

--- a/kubernetes/apps/network/pihole/service-outpost.yaml
+++ b/kubernetes/apps/network/pihole/service-outpost.yaml
@@ -1,0 +1,14 @@
+# Lets the /outpost.goauthentik.io path be served ON pihole.rutberg.dev by
+# proxying to the Authentik embedded outpost (authentik-server, security ns).
+# ExternalName Services are namespace-scoped, so the network namespace needs
+# its own copy (home-automation has one in kcal-assistant/).
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentik-embedded-outpost
+spec:
+  type: ExternalName
+  externalName: authentik-server.security.svc.cluster.local
+  ports:
+    - name: http
+      port: 80

--- a/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/forward-auth.yaml
@@ -82,6 +82,38 @@ entries:
       provider: !KeyOf homarr-provider
       policy_engine_mode: any
 
+  # ------------------------------------------------------------- pihole ----
+  - model: authentik_providers_proxy.proxyprovider
+    state: present
+    id: pihole-provider
+    identifiers:
+      name: pihole
+    attrs:
+      mode: forward_single
+      external_host: https://pihole.rutberg.dev
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: hours=1
+      refresh_token_validity: days=30
+      intercept_header_auth: true
+      internal_host_ssl_validation: true
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-entitlements]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/proxy/scope-proxy]]
+
+  - model: authentik_core.application
+    state: present
+    id: pihole-app
+    identifiers:
+      slug: pihole
+    attrs:
+      name: Pi-hole
+      provider: !KeyOf pihole-provider
+      policy_engine_mode: any
+
   # --------------------------------------------------- embedded outpost ----
   # CAUTION: `providers` and `config` are FULL REPLACEMENTS on every apply.
   # Every provider that must stay assigned HAS to be listed, and the config
@@ -95,6 +127,7 @@ entries:
       providers:
         - !KeyOf kcal-provider
         - !KeyOf homarr-provider
+        - !KeyOf pihole-provider
       config:
         log_level: info
         docker_labels: null


### PR DESCRIPTION
## Change

Final wave-1 app on the single-application forward-auth pattern — the network-namespace variant:

- **`pihole/service-outpost.yaml`**: network namespace's own `authentik-embedded-outpost` ExternalName (namespace-scoped; home-automation's copy lives in kcal-assistant/).
- **`pihole/ingress-outpost.yaml`**: `/outpost.goauthentik.io` on pihole.rutberg.dev, `upstream-vhost` pinned. Reuses `pihole-tls` in its tls block but WITHOUT the cert-manager annotation — only the main ingress provisions the Certificate, avoiding dueling owners.
- **`pihole/ingress.yaml`**: forward-auth annotations on the web UI.
- **Blueprint**: `pihole` provider + application; outpost providers list now kcal + homarr + pihole (cumulative).
- **Docs**: refreshed `docs/kcal-and-sso-status.md` (worker fix, blueprints, scope decisions, upgrade preconditions).

## Deliberately NO NetworkPolicy

pihole's Service is the **LAN DNS LoadBalancer (192.168.50.24:53)** — a kcal-style CNP would black-hole home DNS. Port 53 never passes through nginx and is untouched.

## Verification (post-merge)

1. **`dig @192.168.50.24 example.com` — before AND after** (baseline captured: resolves)
2. Blueprint still Successful, providers [kcal, homarr, pihole], no dupes
3. `curl -sI https://pihole.rutberg.dev/` → 302 to own outpost /start; chain lands on auth.rutberg.dev
4. Browser render; kcal + homarr regression chains
5. Caveat for Philip: if a homarr widget polls pihole via the public hostname, repoint it to `http://192.168.50.24/` or cluster DNS

flux-local: 35/35 pass.