### PR TITLE
feat(kcal-assistant): allow personal Authentik user for /ui

### DIFF
--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             # forwarded identity. Setting this switches UI auth from Cloudflare
             # Access to Authentik. Unset => UI fails closed (503).
             - name: AUTHENTIK_ALLOWED_EMAIL
-              value: "admin@rutberg.dev"
+              value: "philiprutberg00@gmail.com"
             - name: MCP_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Phase 3 of the SSO plan: `AUTHENTIK_ALLOWED_EMAIL` admin@rutberg.dev → philiprutberg00@gmail.com (personal user `rutbergphilip`, created by Philip in the UI, existence + exact email verified via API).

After this: /ui works for the personal user, akadmin gets 403 at the app layer (expected), /mcp unaffected (token auth, open ingress). Recreate rollout = a few seconds of /mcp downtime.

Rollback: revert (gate returns to admin@rutberg.dev).

flux-local: 35/35 pass.