### PR TITLE
feat(kcal-assistant): v0.6.0 — tillagningstid + viktprognos

### DIFF
--- a/docs/superpowers/plans/2026-07-09-kcal-v0.6-time-and-forecast.md
+++ b/docs/superpowers/plans/2026-07-09-kcal-v0.6-time-and-forecast.md
@@ -1,0 +1,1651 @@
+# kcal-assistant v0.6.0: Tillagningstid + Viktprognos Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add recipe cooking-time fields (Claude estimates, server stores) and a calibrated weight-forecast engine (profile + Mifflin-St Jeor simulation) with two new MCP tools and a projection UI on the Vikt page.
+
+**Architecture:** Migration 4 adds `recipes.active_minutes`/`total_minutes` and a single-row `profile` table. A pure simulation lib (`src/lib/forecast.ts`, same pattern as `lib/trend.ts`) runs a daily Euler step on Mifflin-St Jeor TDEE, calibrated against the measured backwards-TDEE; `src/db/forecast.ts` assembles inputs (profile, weigh-ins, intake source, trend). Exposed via MCP tools `set_profile`/`get_forecast` and a read-only UI endpoint feeding the Vikt page's projection chart.
+
+**Tech Stack:** Bun + TypeScript, bun:sqlite, zod, @modelcontextprotocol/sdk, vanilla-JS UI (strict CSP, no frameworks).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-kcal-time-and-forecast-design.md`
+
+## Global Constraints
+
+- Working directory for all commands: `kcal-assistant/` inside the homelab repo.
+- Run tests with `bun test` (all), or `bun test tests/<file>.test.ts` (one file).
+- No new npm dependencies.
+- User-facing strings (errors, notes, UI) are Swedish; code and comments are English.
+- Migrations are append-only; migration 4 is the only schema change.
+- Weight data never appears in the repo — test fixtures use obviously synthetic values.
+- UI is read-only and CSP-strict: no inline event handlers, `el()`/`addEventListener` only.
+- Tool errors are thrown as plain `Error` with Swedish messages; `wrap()` converts them.
+- Constants fixed by the spec: 7700 kcal/kg, ±150 kcal band, ±500 kcal calibration clamp, 365-day horizon, 40 kg sanity floor, 28-day windows, 7-day start smoothing.
+
+---
+
+### Task 1: Migration 4 + profile storage
+
+**Files:**
+- Modify: `kcal-assistant/src/db/migrations.ts` (append migration 4)
+- Create: `kcal-assistant/src/db/profile.ts`
+- Test: `kcal-assistant/tests/profile.test.ts`
+
+**Interfaces:**
+- Consumes: `openDb` from `src/db/index.ts`, `isValidDate` from `src/lib/dates.ts`.
+- Produces:
+  - `interface Profile { birth_date: string; sex: "man" | "kvinna"; height_cm: number; activity_factor: number; goal_weight_kg: number | null; goal_date: string | null; updated_at: string }`
+  - `getProfile(db: Database): Profile | null`
+  - `setProfile(db: Database, input: ProfileInput): Profile` where `interface ProfileInput { birth_date?: string; sex?: "man" | "kvinna"; height_cm?: number; activity_factor?: number; goal_weight_kg?: number | null; goal_date?: string | null }`
+  - Migration 4 also adds `recipes.active_minutes INTEGER` and `recipes.total_minutes INTEGER` (used by Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `kcal-assistant/tests/profile.test.ts`:
+
+```ts
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { getProfile, setProfile } from "../src/db/profile";
+
+let db: Database;
+beforeEach(() => {
+  db = openDb(":memory:");
+});
+
+describe("profile", () => {
+  test("getProfile is null before first set", () => {
+    expect(getProfile(db)).toBeNull();
+  });
+
+  test("first set requires the physiological fields", () => {
+    expect(() => setProfile(db, { goal_weight_kg: 80 })).toThrow(/birth_date/);
+  });
+
+  test("insert, partial update, clear goals", () => {
+    const p = setProfile(db, {
+      birth_date: "2000-01-15",
+      sex: "man",
+      height_cm: 180,
+      activity_factor: 1.5,
+      goal_weight_kg: 80,
+      goal_date: "2026-10-01",
+    });
+    expect(p.goal_weight_kg).toBe(80);
+    const upd = setProfile(db, { activity_factor: 1.6 });
+    expect(upd.activity_factor).toBe(1.6);
+    expect(upd.birth_date).toBe("2000-01-15");
+    expect(upd.goal_date).toBe("2026-10-01");
+    const cleared = setProfile(db, { goal_weight_kg: null, goal_date: null });
+    expect(cleared.goal_weight_kg).toBeNull();
+    expect(cleared.goal_date).toBeNull();
+  });
+
+  test("rejects malformed dates", () => {
+    expect(() =>
+      setProfile(db, { birth_date: "15/01/2000", sex: "man", height_cm: 180, activity_factor: 1.5 }),
+    ).toThrow(/datum/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/profile.test.ts`
+Expected: FAIL — cannot resolve `../src/db/profile`.
+
+- [ ] **Step 3: Append migration 4 and write src/db/profile.ts**
+
+In `kcal-assistant/src/db/migrations.ts`, append a fourth entry to the `MIGRATIONS` array (after the migration-3 string, before the closing `];`):
+
+```ts
+  // 4: recipe cooking times (Claude estimates, server stores) + single-row
+  // physiological profile used by the weight forecast
+  `
+  ALTER TABLE recipes ADD COLUMN active_minutes INTEGER;
+  ALTER TABLE recipes ADD COLUMN total_minutes INTEGER;
+
+  CREATE TABLE profile (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    birth_date      TEXT NOT NULL,
+    sex             TEXT NOT NULL CHECK (sex IN ('man','kvinna')),
+    height_cm       REAL NOT NULL CHECK (height_cm > 0),
+    activity_factor REAL NOT NULL CHECK (activity_factor >= 1.2 AND activity_factor <= 2.5),
+    goal_weight_kg  REAL CHECK (goal_weight_kg > 0),
+    goal_date       TEXT,
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  `,
+```
+
+Create `kcal-assistant/src/db/profile.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import { isValidDate } from "../lib/dates";
+
+export interface Profile {
+  birth_date: string;
+  sex: "man" | "kvinna";
+  height_cm: number;
+  activity_factor: number;
+  goal_weight_kg: number | null;
+  goal_date: string | null;
+  updated_at: string;
+}
+
+export interface ProfileInput {
+  birth_date?: string;
+  sex?: "man" | "kvinna";
+  height_cm?: number;
+  activity_factor?: number;
+  goal_weight_kg?: number | null;
+  goal_date?: string | null;
+}
+
+export function getProfile(db: Database): Profile | null {
+  return (
+    db
+      .query<Profile, []>(
+        "SELECT birth_date, sex, height_cm, activity_factor, goal_weight_kg, goal_date, updated_at FROM profile WHERE id = 1",
+      )
+      .get() ?? null
+  );
+}
+
+// Partial upsert: omitted fields keep their values; explicit null clears the
+// goal fields. The four physiological fields are required on first insert.
+export function setProfile(db: Database, input: ProfileInput): Profile {
+  for (const [field, value] of [
+    ["birth_date", input.birth_date],
+    ["goal_date", input.goal_date],
+  ] as const) {
+    if (typeof value === "string" && !isValidDate(value)) {
+      throw new Error(`Ogiltigt datum för ${field}: ${value} (YYYY-MM-DD)`);
+    }
+  }
+  const existing = getProfile(db);
+  if (!existing) {
+    if (
+      input.birth_date === undefined ||
+      input.sex === undefined ||
+      input.height_cm === undefined ||
+      input.activity_factor === undefined
+    ) {
+      throw new Error("Första anropet kräver birth_date, sex, height_cm och activity_factor");
+    }
+    db.run(
+      "INSERT INTO profile (id, birth_date, sex, height_cm, activity_factor, goal_weight_kg, goal_date) VALUES (1, ?, ?, ?, ?, ?, ?)",
+      [
+        input.birth_date,
+        input.sex,
+        input.height_cm,
+        input.activity_factor,
+        input.goal_weight_kg ?? null,
+        input.goal_date ?? null,
+      ],
+    );
+  } else {
+    db.run(
+      `UPDATE profile SET
+         birth_date = ?, sex = ?, height_cm = ?, activity_factor = ?,
+         goal_weight_kg = ?, goal_date = ?, updated_at = datetime('now')
+       WHERE id = 1`,
+      [
+        input.birth_date ?? existing.birth_date,
+        input.sex ?? existing.sex,
+        input.height_cm ?? existing.height_cm,
+        input.activity_factor ?? existing.activity_factor,
+        input.goal_weight_kg === undefined ? existing.goal_weight_kg : input.goal_weight_kg,
+        input.goal_date === undefined ? existing.goal_date : input.goal_date,
+      ],
+    );
+  }
+  return getProfile(db)!;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/profile.test.ts`
+Expected: PASS (4 tests). Then run `bun test` — the full suite must stay green (migration 4 must not break existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kcal-assistant/src/db/migrations.ts kcal-assistant/src/db/profile.ts kcal-assistant/tests/profile.test.ts
+git commit -m "feat(kcal-assistant): migration 4 — profile table + recipe time columns"
+```
+
+---
+
+### Task 2: Recipe cooking time end-to-end (db + tool + UI)
+
+**Files:**
+- Modify: `kcal-assistant/src/db/recipes.ts`
+- Modify: `kcal-assistant/src/tools/recipes.ts` (save_recipe schema + description)
+- Modify: `kcal-assistant/src/ui/static/app.js` (`renderRecept`, `renderReceptDetalj`)
+- Test: `kcal-assistant/tests/recipes.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: migration 4 columns from Task 1.
+- Produces: `RecipeInput`/`RecipeView` gain `active_minutes?: number | null` and `total_minutes?: number | null`; `RecipeSummary` gains `total_minutes: number | null`. Partial-update semantics match `servings` (omitted = preserved, null = cleared).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `kcal-assistant/tests/recipes.test.ts`, at the end of the file, a new describe (it uses the file's existing `db`, `chickenId` and `beforeEach`):
+
+```ts
+describe("cooking times", () => {
+  function timeRecipe(extra: object) {
+    return saveRecipe(db, {
+      name: "Tidsrecept",
+      ingredients: [{ product_id: chickenId, grams: 100 }],
+      ...extra,
+    });
+  }
+
+  test("saves, partially updates and clears times", () => {
+    const r = timeRecipe({ active_minutes: 15, total_minutes: 45 });
+    expect(r.active_minutes).toBe(15);
+    expect(r.total_minutes).toBe(45);
+    const upd = saveRecipe(db, { id: r.id, name: r.name, total_minutes: 50 });
+    expect(upd.active_minutes).toBe(15);
+    expect(upd.total_minutes).toBe(50);
+    const cleared = saveRecipe(db, { id: r.id, name: r.name, active_minutes: null });
+    expect(cleared.active_minutes).toBeNull();
+    expect(cleared.total_minutes).toBe(50);
+  });
+
+  test("rejects invalid times, also after a partial merge", () => {
+    expect(() => timeRecipe({ active_minutes: -5 })).toThrow(/heltal/);
+    expect(() => timeRecipe({ total_minutes: 2.5 })).toThrow(/heltal/);
+    expect(() => timeRecipe({ active_minutes: 40, total_minutes: 30 })).toThrow(/total_minutes/);
+    const r = timeRecipe({ active_minutes: 20, total_minutes: 30 });
+    expect(() => saveRecipe(db, { id: r.id, name: r.name, total_minutes: 10 })).toThrow(/total_minutes/);
+  });
+
+  test("summaries include total_minutes", () => {
+    timeRecipe({ active_minutes: 10, total_minutes: 35 });
+    const summary = findRecipes(db, "Tidsrecept")[0]!;
+    expect(summary.total_minutes).toBe(35);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/recipes.test.ts`
+Expected: FAIL — `active_minutes` does not exist on `RecipeInput` (type error) / values undefined.
+
+- [ ] **Step 3: Implement in src/db/recipes.ts**
+
+Add the fields to the interfaces (`RecipeInput`, `RecipeView`, `RecipeSummary`, `RecipeRow`):
+
+```ts
+// in RecipeInput, after servings:
+  active_minutes?: number | null;
+  total_minutes?: number | null;
+
+// in RecipeView, after servings:
+  active_minutes: number | null;
+  total_minutes: number | null;
+
+// in RecipeSummary, after servings:
+  total_minutes: number | null;
+
+// in RecipeRow, after servings:
+  active_minutes: number | null;
+  total_minutes: number | null;
+```
+
+Add a validator above `saveRecipe`:
+
+```ts
+function validateTimes(active: number | null, total: number | null): void {
+  for (const [label, v] of [
+    ["active_minutes", active],
+    ["total_minutes", total],
+  ] as const) {
+    if (v !== null && (!Number.isInteger(v) || v <= 0)) {
+      throw new Error(`${label} måste vara ett positivt heltal (minuter)`);
+    }
+  }
+  if (active !== null && total !== null && total < active) {
+    throw new Error("total_minutes kan inte vara mindre än active_minutes");
+  }
+}
+```
+
+In `saveRecipe`, update path — merge, validate, persist (replace the existing UPDATE statement):
+
+```ts
+      const active =
+        input.active_minutes === undefined ? existing.active_minutes : input.active_minutes;
+      const total =
+        input.total_minutes === undefined ? existing.total_minutes : input.total_minutes;
+      validateTimes(active, total);
+      db.run(
+        `UPDATE recipes SET
+           name = ?, instructions = ?, notes = ?, tags = ?, servings = ?, product_id = ?,
+           active_minutes = ?, total_minutes = ?,
+           updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          input.name,
+          clearable(input.instructions, existing.instructions),
+          clearable(input.notes, existing.notes),
+          clearable(input.tags, existing.tags),
+          input.servings === undefined ? existing.servings : input.servings,
+          input.product_id === undefined ? existing.product_id : input.product_id,
+          active,
+          total,
+          id,
+        ],
+      );
+```
+
+Insert path — validate and persist (replace the existing INSERT):
+
+```ts
+      const active = input.active_minutes ?? null;
+      const total = input.total_minutes ?? null;
+      validateTimes(active, total);
+      const result = db.run(
+        "INSERT INTO recipes (name, instructions, notes, tags, servings, product_id, active_minutes, total_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+          input.name,
+          input.instructions ?? null,
+          input.notes ?? null,
+          input.tags ?? null,
+          input.servings ?? null,
+          input.product_id ?? null,
+          active,
+          total,
+        ],
+      );
+```
+
+In `getRecipe`'s return object, after `servings: row.servings,` add:
+
+```ts
+    active_minutes: row.active_minutes,
+    total_minutes: row.total_minutes,
+```
+
+In `findRecipes`' returned summary, after `servings: row.servings,` add:
+
+```ts
+      total_minutes: row.total_minutes,
+```
+
+- [ ] **Step 4: Update the save_recipe tool schema**
+
+In `kcal-assistant/src/tools/recipes.ts`, in `save_recipe`'s `inputSchema` after `servings`, add:
+
+```ts
+        active_minutes: z.number().int().positive().nullable().optional()
+          .describe("Hands-on-tid i minuter; null rensar"),
+        total_minutes: z.number().int().positive().nullable().optional()
+          .describe("Total tid start till klart, inkl ugn/koktid; null rensar"),
+```
+
+Replace the `save_recipe` description string with:
+
+```ts
+      description:
+        "Create a recipe, or update by id (PARTIAL: omitted fields keep their values; empty string clears text; explicit null clears servings/times or unlinks product_id; ingredients replace wholesale). ALWAYS estimate active_minutes (hands-on) and total_minutes (start to done, incl oven/simmer time) from the ingredients and instructions when the user does not state them. Ingredients use the same format as log_meal and resolve LIVE at every read, so product corrections propagate into the recipe automatically. After computing a batch with compute_batch (save:true), link it here via product_id.",
+```
+
+- [ ] **Step 5: UI display**
+
+In `kcal-assistant/src/ui/static/app.js`:
+
+In `renderRecept`, inside the `for (const r of data.recipes)` loop, after the tags span (`el("span", "dim", r.tags || "")`) and before the kcal span, add:
+
+```js
+    if (r.total_minutes !== null) row.append(el("span", "dim", `~${sv(r.total_minutes, 0)} min`));
+```
+
+Note the existing `row.append(...)` call lists all spans in one call — restructure into separate `row.append` calls so the conditional fits, keeping the order: name, grow, tags, time, kcal.
+
+In `renderReceptDetalj`, in the tiles section after the `if (r.servings)` line, add:
+
+```js
+  if (r.total_minutes !== null) {
+    tiles.append(
+      tile("Tid", `${sv(r.total_minutes, 0)} min`, r.active_minutes !== null ? `${sv(r.active_minutes, 0)} min aktiv` : null),
+    );
+  }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bun test tests/recipes.test.ts` — Expected: PASS.
+Run: `bun test` — full suite green (ui-api recipe test unaffected: additive fields).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add kcal-assistant/src/db/recipes.ts kcal-assistant/src/tools/recipes.ts kcal-assistant/src/ui/static/app.js kcal-assistant/tests/recipes.test.ts
+git commit -m "feat(kcal-assistant): recipe cooking times (active/total), estimated by Claude at save"
+```
+
+---
+
+### Task 3: Pure forecast simulation (`lib/forecast.ts`)
+
+**Files:**
+- Create: `kcal-assistant/src/lib/forecast.ts`
+- Test: `kcal-assistant/tests/forecast.test.ts`
+
+**Interfaces:**
+- Consumes: `toEpochDays`, `addDays` from `src/lib/dates.ts`.
+- Produces (used verbatim by Tasks 4–7):
+
+```ts
+export interface ForecastProfile {
+  birth_date: string;
+  sex: "man" | "kvinna";
+  height_cm: number;
+  activity_factor: number;
+  goal_weight_kg: number | null;
+  goal_date: string | null;
+}
+export interface ForecastWeightEntry { date: string; weight_kg: number }
+export interface ForecastInput {
+  profile: ForecastProfile;
+  weights: ForecastWeightEntry[];            // non-empty; any order
+  intake_kcal: number;
+  intake_source: "targets" | "recent" | "explicit";
+  measured_tdee: number | null;              // trend est_tdee when uncertain=false
+  today: string;
+  target_date?: string;
+  goal_weight_override?: number;
+  horizon_days?: number;                     // default 365
+}
+export interface ForecastPoint { date: string; kg: number; low: number; high: number }
+export interface ForecastResult {
+  start: { date: string; weight_kg: number; weighins_smoothed: number; stale: boolean };
+  assumptions: {
+    intake_kcal: number;
+    intake_source: "targets" | "recent" | "explicit";
+    tdee_start: number;                      // incl. offset, rounded to 10
+    calibration: "mätdata" | "formel";
+    calibration_offset: number;              // whole kcal; 0 when formel
+    kcal_per_kg: number;                     // 7700
+  };
+  curve: ForecastPoint[];                    // daily, start date → horizon end (or 40 kg floor)
+  weight_at_target: ForecastPoint | null;    // for target_date (clamped to horizon)
+  weight_at_goal_date: ForecastPoint | null; // for profile goal_date
+  goal: { weight_kg: number; eta: string | null; reached: boolean; reason?: string } | null;
+  notes: string[];
+}
+export function computeForecast(input: ForecastInput): ForecastResult; // throws on empty weights / past target_date
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `kcal-assistant/tests/forecast.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+import { addDays } from "../src/lib/dates";
+
+// Synthetic fixtures only — public repo.
+//
+// Reference profile chosen so TDEE(w) = 15w + 1500 exactly:
+//   BMR = 10w + 6.25·180 − 5·26 + 5 = 10w + 1000 (man, 180 cm, age 26)
+//   × activity 1.5 → 15w + 1500.
+// With intake 1500 the daily deficit is exactly 15w, so the discrete curve is
+//   w_n = 82·(1 − 15/7700)^n
+// which is hand-checkable: w_1 = 81.84026, w_12 = 80.10 > 80, w_13 = 79.95 ≤ 80.
+const PROFILE: ForecastProfile = {
+  birth_date: "2000-01-15",
+  sex: "man",
+  height_cm: 180,
+  activity_factor: 1.5,
+  goal_weight_kg: 80,
+  goal_date: null,
+};
+const TODAY = "2026-07-09";
+const W = (date: string, kg: number) => ({ date, weight_kg: kg });
+
+function run(overrides: object = {}) {
+  return computeForecast({
+    profile: PROFILE,
+    weights: [W(TODAY, 82)],
+    intake_kcal: 1500,
+    intake_source: "explicit",
+    measured_tdee: null,
+    today: TODAY,
+    ...overrides,
+  });
+}
+
+describe("computeForecast", () => {
+  test("first step and adaptive flattening match the hand calculation", () => {
+    const f = run();
+    expect(f.curve[0]).toMatchObject({ date: TODAY, kg: 82 });
+    expect(f.curve[1]!.kg).toBe(81.84); // 82 − (2730−1500)/7700
+    expect(f.assumptions.tdee_start).toBe(2730);
+    expect(f.assumptions.calibration).toBe("formel");
+    const early = f.curve[1]!.kg - f.curve[31]!.kg;
+    const late = f.curve[301]!.kg - f.curve[331]!.kg;
+    expect(early).toBeGreaterThan(late); // deficit shrinks as weight falls
+  });
+
+  test("goal 80 kg is reached on day 13", () => {
+    const f = run();
+    expect(f.goal!.weight_kg).toBe(80);
+    expect(f.goal!.reached).toBe(false);
+    expect(f.goal!.eta).toBe(addDays(TODAY, 13));
+  });
+
+  test("calibration offsets the TDEE and clamps at ±500", () => {
+    const f = run({ measured_tdee: 2500 });
+    expect(f.assumptions.calibration).toBe("mätdata");
+    expect(f.assumptions.calibration_offset).toBe(-230);
+    expect(f.assumptions.tdee_start).toBe(2500);
+    expect(f.curve[1]!.kg).toBe(81.87); // 82 − 1000/7700
+    const clamped = run({ measured_tdee: 3500 });
+    expect(clamped.assumptions.calibration_offset).toBe(500);
+    expect(clamped.notes.join(" ")).toContain("±500");
+  });
+
+  test("band brackets the main curve", () => {
+    const f = run();
+    expect(f.curve[10]!.low).toBeLessThan(f.curve[10]!.kg);
+    expect(f.curve[10]!.high).toBeGreaterThan(f.curve[10]!.kg);
+  });
+
+  test("start smooths weigh-ins within 7 days of the latest", () => {
+    const f = run({ weights: [W("2026-07-02", 82.4), W("2026-07-06", 82.0), W(TODAY, 81.6)] });
+    expect(f.start.weight_kg).toBe(82);
+    expect(f.start.weighins_smoothed).toBe(3);
+  });
+
+  test("a stale log starts the simulation at the weigh-in date", () => {
+    const f = run({ weights: [W("2026-06-29", 82)], target_date: "2026-07-20" });
+    expect(f.start.stale).toBe(true);
+    expect(f.curve[0]!.date).toBe("2026-06-29");
+    expect(f.weight_at_target!.date).toBe("2026-07-20");
+  });
+
+  test("target date validation and horizon clamping", () => {
+    expect(() => run({ target_date: "2026-07-01" })).toThrow(/passerat/);
+    const f = run({ target_date: addDays(TODAY, 400) });
+    expect(f.weight_at_target!.date).toBe(addDays(TODAY, 365));
+    expect(f.notes.join(" ")).toContain("horisonten");
+  });
+
+  test("moving away from the goal yields no eta and a reason", () => {
+    const f = run({ intake_kcal: 2800 }); // above TDEE 2730 → gaining
+    expect(f.goal!.eta).toBeNull();
+    expect(f.goal!.reason).toContain("bort");
+  });
+
+  test("a passed goal_date is ignored with a note", () => {
+    const f = run({ profile: { ...PROFILE, goal_date: "2026-07-01" } });
+    expect(f.weight_at_goal_date).toBeNull();
+    expect(f.notes.join(" ")).toContain("passerat");
+  });
+
+  test("sanity floor stops the curve at 40 kg", () => {
+    const f = run({
+      weights: [W(TODAY, 41)],
+      intake_kcal: 500,
+      profile: { ...PROFILE, goal_weight_kg: null },
+    });
+    expect(f.goal).toBeNull();
+    expect(f.curve.at(-1)!.kg).toBeGreaterThanOrEqual(40);
+    expect(f.curve.length).toBeLessThan(365);
+    expect(f.notes.join(" ")).toContain("40 kg");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — cannot resolve `../src/lib/forecast`.
+
+- [ ] **Step 3: Implement src/lib/forecast.ts**
+
+```ts
+import { toEpochDays, addDays } from "./dates";
+
+// Forward weight simulation ("riktig formel"):
+//   BMR (Mifflin-St Jeor) is recomputed every simulated day on the simulated
+//   weight, TDEE = BMR × activity factor + a constant calibration offset
+//   against the measured backwards-TDEE (lib/trend.ts) when that is reliable.
+//   Daily Euler step: w −= (TDEE(w) − intake) / 7700.
+// The curve therefore flattens naturally as weight drops. A ±150 kcal/day
+// re-run gives an honest low/high envelope instead of fake precision.
+
+export interface ForecastProfile {
+  birth_date: string;
+  sex: "man" | "kvinna";
+  height_cm: number;
+  activity_factor: number;
+  goal_weight_kg: number | null;
+  goal_date: string | null;
+}
+
+export interface ForecastWeightEntry {
+  date: string;
+  weight_kg: number;
+}
+
+export interface ForecastInput {
+  profile: ForecastProfile;
+  weights: ForecastWeightEntry[];
+  intake_kcal: number;
+  intake_source: "targets" | "recent" | "explicit";
+  measured_tdee: number | null;
+  today: string;
+  target_date?: string;
+  goal_weight_override?: number;
+  horizon_days?: number;
+}
+
+export interface ForecastPoint {
+  date: string;
+  kg: number;
+  low: number;
+  high: number;
+}
+
+export interface ForecastResult {
+  start: { date: string; weight_kg: number; weighins_smoothed: number; stale: boolean };
+  assumptions: {
+    intake_kcal: number;
+    intake_source: "targets" | "recent" | "explicit";
+    tdee_start: number;
+    calibration: "mätdata" | "formel";
+    calibration_offset: number;
+    kcal_per_kg: number;
+  };
+  curve: ForecastPoint[];
+  weight_at_target: ForecastPoint | null;
+  weight_at_goal_date: ForecastPoint | null;
+  goal: { weight_kg: number; eta: string | null; reached: boolean; reason?: string } | null;
+  notes: string[];
+}
+
+const KCAL_PER_KG = 7700;
+const BAND_KCAL = 150;
+const OFFSET_CLAMP = 500;
+const FLOOR_KG = 40;
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+function ageAt(birthDate: string, date: string): number {
+  return Math.floor((toEpochDays(date) - toEpochDays(birthDate)) / 365.25);
+}
+
+function bmr(profile: ForecastProfile, weightKg: number, date: string): number {
+  const base = 10 * weightKg + 6.25 * profile.height_cm - 5 * ageAt(profile.birth_date, date);
+  return base + (profile.sex === "man" ? 5 : -161);
+}
+
+function simulate(
+  profile: ForecastProfile,
+  startDate: string,
+  startKg: number,
+  intake: number,
+  offset: number,
+  horizonEnd: string,
+): Array<{ date: string; kg: number }> {
+  const points = [{ date: startDate, kg: startKg }];
+  let w = startKg;
+  let date = startDate;
+  const end = toEpochDays(horizonEnd);
+  while (toEpochDays(date) < end) {
+    const tdee = bmr(profile, w, date) * profile.activity_factor + offset;
+    w -= (tdee - intake) / KCAL_PER_KG;
+    date = addDays(date, 1);
+    if (w < FLOOR_KG) break;
+    points.push({ date, kg: w });
+  }
+  return points;
+}
+
+export function computeForecast(input: ForecastInput): ForecastResult {
+  const notes: string[] = [];
+  const sorted = [...input.weights].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const latest = sorted.at(-1);
+  if (!latest) throw new Error("inga viktloggar");
+
+  const horizonDays = input.horizon_days ?? 365;
+  const horizonEnd = addDays(input.today, horizonDays);
+
+  // Start = mean of weigh-ins within 7 days of the latest (noise smoothing);
+  // simulation starts at the latest weigh-in date so a stale log gets its
+  // elapsed days simulated too.
+  const recent = sorted.filter((w) => toEpochDays(latest.date) - toEpochDays(w.date) <= 7);
+  const startKg = recent.reduce((s, w) => s + w.weight_kg, 0) / recent.length;
+  const stale = toEpochDays(input.today) - toEpochDays(latest.date) > 7;
+  if (stale) notes.push("senaste vägningen är över en vecka gammal");
+
+  const formulaTdeeStart = bmr(input.profile, startKg, latest.date) * input.profile.activity_factor;
+  let offset = 0;
+  let calibration: "mätdata" | "formel" = "formel";
+  if (input.measured_tdee !== null) {
+    const raw = input.measured_tdee - formulaTdeeStart;
+    offset = Math.max(-OFFSET_CLAMP, Math.min(OFFSET_CLAMP, raw));
+    calibration = "mätdata";
+    if (Math.abs(raw) > OFFSET_CLAMP) notes.push("kalibreringen begränsades till ±500 kcal");
+  }
+  const tdeeStart = formulaTdeeStart + offset;
+
+  const main = simulate(input.profile, latest.date, startKg, input.intake_kcal, offset, horizonEnd);
+  const lowSim = simulate(input.profile, latest.date, startKg, input.intake_kcal - BAND_KCAL, offset, horizonEnd);
+  const highSim = simulate(input.profile, latest.date, startKg, input.intake_kcal + BAND_KCAL, offset, horizonEnd);
+  if (main.at(-1)!.date !== horizonEnd) notes.push("kurvan stoppades vid 40 kg (orimliga antaganden)");
+
+  const curve: ForecastPoint[] = main.map((p, i) => ({
+    date: p.date,
+    kg: round2(p.kg),
+    low: round2((lowSim[i] ?? lowSim.at(-1)!).kg),
+    high: round2((highSim[i] ?? highSim.at(-1)!).kg),
+  }));
+  const byDate = new Map(curve.map((p) => [p.date, p]));
+
+  let weightAtTarget: ForecastPoint | null = null;
+  if (input.target_date !== undefined) {
+    if (toEpochDays(input.target_date) <= toEpochDays(input.today)) {
+      throw new Error(`target_date ${input.target_date} har redan passerat`);
+    }
+    let t = input.target_date;
+    if (toEpochDays(t) > toEpochDays(horizonEnd)) {
+      t = horizonEnd;
+      notes.push(`target_date ligger bortom horisonten och klipptes till ${horizonEnd}`);
+    }
+    weightAtTarget = byDate.get(t) ?? null;
+  }
+
+  let weightAtGoalDate: ForecastPoint | null = null;
+  if (input.profile.goal_date !== null) {
+    if (toEpochDays(input.profile.goal_date) <= toEpochDays(input.today)) {
+      notes.push("goal_date har passerat och ignorerades");
+    } else {
+      weightAtGoalDate = byDate.get(input.profile.goal_date) ?? null;
+      if (!weightAtGoalDate) notes.push("goal_date ligger bortom horisonten");
+    }
+  }
+
+  // Goal ETA: direction of travel comes from the energy balance, not from the
+  // goal's position — so an overshoot or a surplus reads as "moving away".
+  const losing = input.intake_kcal < tdeeStart;
+  const goalWeight = input.goal_weight_override ?? input.profile.goal_weight_kg;
+  let goal: ForecastResult["goal"] = null;
+  if (goalWeight !== null && goalWeight !== undefined) {
+    const delta = goalWeight - startKg;
+    if (Math.abs(delta) < 0.05) {
+      goal = { weight_kg: goalWeight, eta: null, reached: true };
+    } else {
+      const movingToward = delta < 0 ? losing : !losing;
+      const hit = (kg: number): boolean => (delta < 0 ? kg <= goalWeight : kg >= goalWeight);
+      const eta = movingToward ? (curve.find((p) => hit(p.kg))?.date ?? null) : null;
+      goal = {
+        weight_kg: goalWeight,
+        eta,
+        reached: false,
+        ...(eta === null && {
+          reason: movingToward
+            ? `nås inte inom ${horizonDays} dagar med nuvarande intag`
+            : "med nuvarande intag rör sig vikten bort från målet",
+        }),
+      };
+    }
+  }
+
+  return {
+    start: {
+      date: latest.date,
+      weight_kg: round2(startKg),
+      weighins_smoothed: recent.length,
+      stale,
+    },
+    assumptions: {
+      intake_kcal: input.intake_kcal,
+      intake_source: input.intake_source,
+      tdee_start: Math.round(tdeeStart / 10) * 10,
+      calibration,
+      calibration_offset: Math.round(offset),
+      kcal_per_kg: KCAL_PER_KG,
+    },
+    curve,
+    weight_at_target: weightAtTarget,
+    weight_at_goal_date: weightAtGoalDate,
+    goal,
+    notes,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kcal-assistant/src/lib/forecast.ts kcal-assistant/tests/forecast.test.ts
+git commit -m "feat(kcal-assistant): calibrated adaptive weight-forecast simulation"
+```
+
+---
+
+### Task 4: Forecast input assembly (`db/forecast.ts`)
+
+**Files:**
+- Create: `kcal-assistant/src/db/forecast.ts`
+- Test: `kcal-assistant/tests/forecast.test.ts` (append a describe)
+
+**Interfaces:**
+- Consumes: `computeForecast` (Task 3), `getProfile` (Task 1), `getTrend` from `src/db/weights.ts`, `getTargetsFor` from `src/db/preferences.ts`, `todayStockholm`/`addDays` from `src/lib/dates.ts`.
+- Produces (used by Tasks 5–6):
+
+```ts
+export type IntakeSource = "targets" | "recent";
+export interface ForecastView { forecast: ForecastResult | null; reason?: string }
+export function buildForecast(db: Database, opts?: {
+  target_date?: string;
+  goal_weight?: number;
+  intake_kcal?: number;
+  intake_source?: IntakeSource;
+  today?: string; // test injection
+}): ForecastView;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `kcal-assistant/tests/forecast.test.ts` (add the new imports at the top of the file):
+
+```ts
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { setProfile } from "../src/db/profile";
+import { logWeight } from "../src/db/weights";
+import { logMeal } from "../src/db/meals";
+import { buildForecast } from "../src/db/forecast";
+```
+
+```ts
+describe("buildForecast", () => {
+  const TODAY = "2026-07-09";
+
+  function seededDb(): Database {
+    const db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5 });
+    logWeight(db, { weight_kg: 82, date: TODAY });
+    return db;
+  }
+
+  test("missing profile and missing weights give reasons", () => {
+    const db = openDb(":memory:");
+    expect(buildForecast(db, { today: TODAY }).reason).toContain("profil");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5 });
+    expect(buildForecast(db, { today: TODAY }).reason).toContain("viktloggar");
+  });
+
+  test("targets mix weights the day targets by observed day types", () => {
+    const db = seededDb();
+    for (let i = 0; i < 14; i++) {
+      db.run("INSERT OR IGNORE INTO days (date, day_type) VALUES (?, ?)", [
+        addDays(TODAY, -i),
+        i % 2 === 0 ? "vilodag" : "gymdag",
+      ]);
+    }
+    const f = buildForecast(db, { today: TODAY }).forecast!;
+    expect(f.assumptions.intake_source).toBe("targets");
+    expect(f.assumptions.intake_kcal).toBe(2200); // (7·2000 + 7·2400) / 14, seeded targets
+  });
+
+  test("targets mix falls back to vilodag under 7 logged days", () => {
+    const f = buildForecast(seededDb(), { today: TODAY }).forecast!;
+    expect(f.assumptions.intake_kcal).toBe(2000); // seeded vilodag target
+    expect(f.notes.join(" ")).toContain("vilodag");
+  });
+
+  test("recent averages logged kcal and falls back to targets when empty", () => {
+    const db = seededDb();
+    const item = (kcal: number) => [{ description: "x", macros: { kcal, protein: 100, fat: 50, carbs: 100 } }];
+    logMeal(db, { name: "A", date: addDays(TODAY, -1), items: item(1600) });
+    logMeal(db, { name: "B", date: addDays(TODAY, -2), items: item(2000) });
+    const f = buildForecast(db, { today: TODAY, intake_source: "recent" }).forecast!;
+    expect(f.assumptions.intake_source).toBe("recent");
+    expect(f.assumptions.intake_kcal).toBe(1800);
+
+    const empty = seededDb();
+    const g = buildForecast(empty, { today: TODAY, intake_source: "recent" }).forecast!;
+    expect(g.assumptions.intake_source).toBe("targets");
+    expect(g.notes.join(" ")).toContain("intagsdata");
+  });
+
+  test("explicit intake wins over any source", () => {
+    const f = buildForecast(seededDb(), { today: TODAY, intake_kcal: 1234, intake_source: "recent" }).forecast!;
+    expect(f.assumptions.intake_source).toBe("explicit");
+    expect(f.assumptions.intake_kcal).toBe(1234);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — cannot resolve `../src/db/forecast`.
+
+- [ ] **Step 3: Implement src/db/forecast.ts**
+
+```ts
+import type { Database } from "bun:sqlite";
+import { computeForecast, type ForecastResult } from "../lib/forecast";
+import { getProfile } from "./profile";
+import { getTrend } from "./weights";
+import { getTargetsFor } from "./preferences";
+import { todayStockholm, addDays } from "../lib/dates";
+
+export type IntakeSource = "targets" | "recent";
+
+export interface ForecastView {
+  forecast: ForecastResult | null;
+  reason?: string;
+}
+
+// Resolves the daily intake assumption:
+//   targets — day targets weighted by the observed day-type mix (28 days)
+//   recent  — actual logged average (28 days), falling back to targets
+// An explicit intake_kcal in buildForecast bypasses this entirely.
+function resolveIntake(
+  db: Database,
+  source: IntakeSource,
+  today: string,
+): { kcal: number; source: "targets" | "recent"; notes: string[] } {
+  const notes: string[] = [];
+  const since = addDays(today, -27);
+
+  if (source === "recent") {
+    const row = db
+      .query<{ avg_kcal: number | null; n: number }, [string, string]>(
+        `SELECT AVG(day_kcal) AS avg_kcal, COUNT(*) AS n FROM (
+           SELECT m.day_date, SUM(mi.kcal) AS day_kcal
+           FROM meals m JOIN meal_items mi ON mi.meal_id = m.id
+           WHERE m.day_date >= ? AND m.day_date <= ?
+           GROUP BY m.day_date)`,
+      )
+      .get(since, today)!;
+    if (row.n > 0 && row.avg_kcal !== null) {
+      return { kcal: Math.round(row.avg_kcal), source: "recent", notes };
+    }
+    notes.push("ingen intagsdata senaste 28 dagarna — planmålen användes i stället");
+  }
+
+  const mix = db
+    .query<{ day_type: string; n: number }, [string, string]>(
+      "SELECT day_type, COUNT(*) AS n FROM days WHERE date >= ? AND date <= ? GROUP BY day_type",
+    )
+    .all(since, today);
+  const total = mix.reduce((s, r) => s + r.n, 0);
+  if (total < 7) {
+    notes.push("för få loggade dagar för dagstypsmix — vilodagsmålet användes");
+    return { kcal: getTargetsFor(db, "vilodag").kcal, source: "targets", notes };
+  }
+  const weighted = mix.reduce((s, r) => s + getTargetsFor(db, r.day_type).kcal * r.n, 0) / total;
+  return { kcal: Math.round(weighted), source: "targets", notes };
+}
+
+export function buildForecast(
+  db: Database,
+  opts: {
+    target_date?: string;
+    goal_weight?: number;
+    intake_kcal?: number;
+    intake_source?: IntakeSource;
+    today?: string;
+  } = {},
+): ForecastView {
+  const profile = getProfile(db);
+  if (!profile) return { forecast: null, reason: "ingen profil — sätt via set_profile i chatten" };
+
+  const weights = db
+    .query<{ date: string; weight_kg: number }, []>(
+      "SELECT date, weight_kg FROM weights ORDER BY date",
+    )
+    .all();
+  if (weights.length === 0) return { forecast: null, reason: "inga viktloggar ännu" };
+
+  const today = opts.today ?? todayStockholm();
+  const resolved =
+    opts.intake_kcal !== undefined
+      ? { kcal: opts.intake_kcal, source: "explicit" as const, notes: [] }
+      : resolveIntake(db, opts.intake_source ?? "targets", today);
+
+  const trend = getTrend(db, 28);
+  const measured = trend.trend && !trend.trend.uncertain ? trend.trend.est_tdee : null;
+
+  const forecast = computeForecast({
+    profile,
+    weights,
+    intake_kcal: resolved.kcal,
+    intake_source: resolved.source,
+    measured_tdee: measured,
+    today,
+    target_date: opts.target_date,
+    goal_weight_override: opts.goal_weight,
+  });
+  forecast.notes.unshift(...resolved.notes);
+  return { forecast };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/forecast.test.ts` — Expected: PASS (15 tests total in file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kcal-assistant/src/db/forecast.ts kcal-assistant/tests/forecast.test.ts
+git commit -m "feat(kcal-assistant): forecast input assembly — intake sources + TDEE calibration wiring"
+```
+
+---
+
+### Task 5: MCP tools `set_profile` + `get_forecast`, profile in get_context
+
+**Files:**
+- Create: `kcal-assistant/src/tools/profile.ts`
+- Modify: `kcal-assistant/src/mcp.ts`
+- Modify: `kcal-assistant/src/tools/context.ts`
+- Test: `kcal-assistant/tests/server.test.ts` (tool list 22 → 24 + round-trip)
+
+**Interfaces:**
+- Consumes: `setProfile`/`getProfile` (Task 1), `buildForecast` (Task 4), `dateSchema` from `src/tools/schemas.ts`, `jsonResult`/`wrap` from `src/tools/util.ts`.
+- Produces: MCP tools `set_profile`, `get_forecast` (weekly curve); `get_context` response gains an optional `profile` key.
+
+- [ ] **Step 1: Update the failing server test first**
+
+In `kcal-assistant/tests/server.test.ts`, rename the test `"lists all 22 tools"` to `"lists all 24 tools"` and add `"set_profile",` and `"get_forecast",` to the names array (order irrelevant — the assertion sorts).
+
+Then append inside the same `describe("mcp over streamable http", ...)`:
+
+```ts
+  test("set_profile -> get_forecast round-trips", async () => {
+    const client = await connect();
+    await client.callTool({
+      name: "set_profile",
+      arguments: { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 },
+    });
+    await client.callTool({ name: "log_weight", arguments: { weight_kg: 82 } });
+    const res = await client.callTool({ name: "get_forecast", arguments: {} });
+    const body = JSON.parse((res.content as Array<{ text: string }>)[0]!.text);
+    expect(body.forecast.goal.weight_kg).toBe(80);
+    expect(body.forecast.curve.length).toBeGreaterThan(40); // weekly points over 365 days
+    expect(body.forecast.curve.length).toBeLessThan(60);
+    await client.close();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/server.test.ts`
+Expected: FAIL — tool list mismatch (22 ≠ 24) and unknown tool `set_profile`.
+
+- [ ] **Step 3: Create src/tools/profile.ts**
+
+```ts
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { setProfile } from "../db/profile";
+import { buildForecast } from "../db/forecast";
+import { dateSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+export function registerProfileTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "set_profile",
+    {
+      description:
+        "Set or update the physiological profile and goals used by get_forecast (PARTIAL: omitted fields keep their values; explicit null clears goal_weight_kg or goal_date). First call must include birth_date, sex, height_cm and activity_factor. Activity factor guide: 1.2 stillasittande, 1.375 lätt aktiv, 1.55 måttligt aktiv, 1.725 mycket aktiv, 1.9 extremt aktiv.",
+      inputSchema: {
+        birth_date: dateSchema.optional(),
+        sex: z.enum(["man", "kvinna"]).optional(),
+        height_cm: z.number().positive().optional(),
+        activity_factor: z.number().min(1.2).max(2.5).optional(),
+        goal_weight_kg: z.number().positive().nullable().optional().describe("Målvikt i kg; null rensar"),
+        goal_date: dateSchema.nullable().optional().describe("Datum då målet ska vara nått; null rensar"),
+      },
+    },
+    wrap((input) => jsonResult(setProfile(db, input))),
+  );
+
+  server.registerTool(
+    "get_forecast",
+    {
+      description:
+        "Weight forecast from profile + weight log. Simulates day by day: Mifflin-St Jeor BMR on the moving weight × activity factor, calibrated against the measured backwards-TDEE when reliable. Returns predicted weight at target_date and at the profile's goal_date, the date the goal weight is reached (goal.eta), an uncertainty band (±150 kcal/dag), and weekly curve points. intake_source: 'targets' (default; day targets weighted by the recent day-type mix) or 'recent' (actual 28-day average); intake_kcal overrides both. Present the numbers as-is, never recompute.",
+      inputSchema: {
+        target_date: dateSchema.optional().describe("Datum att förutsäga vikten för"),
+        goal_weight: z.number().positive().optional().describe("Överskuggar profilens målvikt"),
+        intake_kcal: z.number().positive().optional(),
+        intake_source: z.enum(["targets", "recent"]).optional(),
+      },
+    },
+    wrap((input) => {
+      const view = buildForecast(db, input);
+      if (!view.forecast) return jsonResult(view);
+      // Token-lean for the chat: weekly points instead of the daily curve.
+      const { curve, ...rest } = view.forecast;
+      const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+      return jsonResult({ forecast: { ...rest, curve: weekly } });
+    }),
+  );
+}
+```
+
+- [ ] **Step 4: Register in src/mcp.ts and extend get_context**
+
+In `kcal-assistant/src/mcp.ts` add the import and registration (after `registerRecipeTools`):
+
+```ts
+import { registerProfileTools } from "./tools/profile";
+// ...inside buildMcpServer, after registerRecipeTools(server, db):
+  registerProfileTools(server, db);
+```
+
+In `kcal-assistant/src/tools/context.ts`:
+
+```ts
+import { getProfile } from "../db/profile";
+```
+
+Inside the `get_context` handler, before the `return jsonResult({...})`, add `const profile = getProfile(db);` and add to the returned object (after `all_targets`):
+
+```ts
+        ...(profile && { profile }),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test tests/server.test.ts` — Expected: PASS.
+Run: `bun test` — full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add kcal-assistant/src/tools/profile.ts kcal-assistant/src/mcp.ts kcal-assistant/src/tools/context.ts kcal-assistant/tests/server.test.ts
+git commit -m "feat(kcal-assistant): set_profile + get_forecast MCP tools (24 tools)"
+```
+
+---
+
+### Task 6: UI API forecast endpoint
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/api.ts`
+- Test: `kcal-assistant/tests/ui-api.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `buildForecast` (Task 4).
+- Produces: `GET /ui/api/forecast?source=targets|recent` → `ForecastView` with the FULL daily curve (the client answers any date instantly without re-fetching). Unknown source → 400. Read-only: `buildForecast` performs no writes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append at the END of the `describe("read-only UI API", ...)` block in `kcal-assistant/tests/ui-api.test.ts` (order matters — the no-profile test must run before `setProfile`), and add the import:
+
+```ts
+import { setProfile } from "../src/db/profile";
+```
+
+```ts
+  test("forecast without profile returns a reason", async () => {
+    const body = await (await get("/ui/api/forecast")).json();
+    expect(body.forecast).toBeNull();
+    expect(body.reason).toContain("profil");
+  });
+
+  test("forecast with profile returns the full daily curve", async () => {
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    const res = await get("/ui/api/forecast?source=targets");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.forecast.curve.length).toBeGreaterThan(300);
+    expect(body.forecast.assumptions.intake_source).toBe("targets");
+    expect(body.forecast.goal.weight_kg).toBe(80);
+  });
+
+  test("forecast rejects an unknown source", async () => {
+    expect((await get("/ui/api/forecast?source=x")).status).toBe(400);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/ui-api.test.ts`
+Expected: FAIL — forecast route returns 404.
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `kcal-assistant/src/ui/api.ts` add the import:
+
+```ts
+import { buildForecast, type IntakeSource } from "../db/forecast";
+```
+
+Add a case in the `switch (resource)` (after `case "weights"`):
+
+```ts
+      case "forecast": {
+        if (param !== undefined) return NOT_FOUND;
+        const raw = search.get("source");
+        if (raw !== null && raw !== "targets" && raw !== "recent") {
+          return { status: 400, body: { error: "ogiltig källa" } };
+        }
+        // raw is typed string|null — literal comparisons don't narrow it,
+        // so pick the union value explicitly.
+        const source: IntakeSource = raw === "recent" ? "recent" : "targets";
+        return { status: 200, body: buildForecast(db, { intake_source: source }) };
+      }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/ui-api.test.ts` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kcal-assistant/src/ui/api.ts kcal-assistant/tests/ui-api.test.ts
+git commit -m "feat(kcal-assistant): read-only /ui/api/forecast endpoint with daily curve"
+```
+
+---
+
+### Task 7: Vikt page — projection chart, goals, real-time date picker
+
+> **Invoke the frontend-design skill before this task's UI work.** The code below is the working baseline embodying the agreed design (actual weight full opacity, projection dashed at low opacity, translucent band, goal markers, labbkvitto aesthetic). The skill may refine visual constants (opacities, dashes, spacing, copy) but must not change structure, data flow, or the read-only contract.
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/static/app.js` (`renderVikt`, `weightChart`, new `loadPrognos`)
+- Modify: `kcal-assistant/src/ui/static/app.css`
+
+**Interfaces:**
+- Consumes: `GET /ui/api/forecast?source=...` (Task 6) — `ForecastView` shape from Task 3/4.
+- Produces: UI only; no exports.
+
+- [ ] **Step 1: Replace renderVikt and weightChart, add loadPrognos**
+
+Replace the whole `renderVikt` function in `kcal-assistant/src/ui/static/app.js` with:
+
+```js
+async function renderVikt() {
+  const data = await api("/ui/api/weights");
+  view.append(el("h2", "", "Vikt"));
+  if (data.weights.length === 0) {
+    view.append(el("div", "empty", "Inga viktloggar ännu. Säg '82,1 idag' till assistenten."));
+    return;
+  }
+
+  const series = [...data.weights].reverse(); // ascending by date
+  const chartHost = el("div");
+  view.append(chartHost);
+
+  const tiles = el("div", "tiles");
+  tiles.append(tile("Senast", `${sv(data.trend.latest.weight_kg)} kg`, data.trend.latest.date + (data.trend.stale ? " · gammal" : "")));
+  if (data.trend.trend) {
+    tiles.append(tile("Takt", `${sv(data.trend.trend.rate_kg_week)} kg/v`, `${sv(data.trend.trend.delta_kg)} kg / ${sv(data.trend.trend.span_days, 0)} d`));
+    tiles.append(
+      tile(
+        "TDEE",
+        data.trend.trend.est_tdee !== null ? sv(data.trend.trend.est_tdee, 0) : "—",
+        data.trend.trend.est_tdee === null ? "ingen intagsdata" : data.trend.trend.uncertain ? "osäker (gles logg)" : `${data.trend.trend.intake_days} intagsdagar`,
+      ),
+    );
+  } else if (data.trend.reason) {
+    tiles.append(tile("Trend", "—", data.trend.reason));
+  }
+  view.append(tiles);
+
+  view.append(el("h2", "", "Prognos"));
+  const prognosHost = el("div");
+  view.append(prognosHost);
+  await loadPrognos(chartHost, prognosHost, series, "targets");
+
+  view.append(el("h2", "", "Alla vägningar"));
+  const wrap = el("div", "tablewrap");
+  const table = el("table");
+  table.append(tableHead("Datum", "kg", "Anteckning"));
+  const tbody = el("tbody");
+  for (const w of data.weights) {
+    const tr = el("tr");
+    tr.append(el("td", "", w.date), el("td", "", sv(w.weight_kg)), el("td", "", w.note || ""));
+    tbody.append(tr);
+  }
+  table.append(tbody);
+  wrap.append(table);
+  view.append(wrap);
+}
+
+async function loadPrognos(chartHost, prognosHost, series, source) {
+  let fc;
+  try {
+    fc = await api(`/ui/api/forecast?source=${source}`);
+  } catch (e) {
+    fc = { forecast: null, reason: "kunde inte hämtas" };
+  }
+  chartHost.replaceChildren();
+  if (series.length >= 2 || fc.forecast) chartHost.append(weightChart(series, fc.forecast));
+  prognosHost.replaceChildren();
+
+  if (!fc.forecast) {
+    prognosHost.append(el("div", "empty", `Ingen prognos: ${fc.reason}`));
+    return;
+  }
+  const f = fc.forecast;
+
+  const tiles = el("div", "tiles");
+  if (f.goal) {
+    tiles.append(
+      tile("Målvikt", `${sv(f.goal.weight_kg)} kg`, f.goal.reached ? "uppnådd" : f.goal.eta ? `nås ≈ ${f.goal.eta}` : f.goal.reason),
+    );
+  }
+  if (f.weight_at_goal_date) {
+    tiles.append(tile("Vid måldatum", `≈ ${sv(f.weight_at_goal_date.kg)} kg`, f.weight_at_goal_date.date));
+  }
+  tiles.append(
+    tile("TDEE i kalkylen", sv(f.assumptions.tdee_start, 0), f.assumptions.calibration === "mätdata" ? "kalibrerad mot mätdata" : "formel (Mifflin-St Jeor)"),
+  );
+  tiles.append(
+    tile(
+      "Intag i kalkylen",
+      sv(f.assumptions.intake_kcal, 0),
+      f.assumptions.intake_source === "targets" ? "planmål (dagstypsmix)" : f.assumptions.intake_source === "recent" ? "snitt senaste 28 d" : "angivet",
+    ),
+  );
+  prognosHost.append(tiles);
+
+  // Real-time lookup: the daily curve is already here — no network per date.
+  const byDate = new Map(f.curve.map((p) => [p.date, p]));
+  const picker = el("div", "forecast-picker");
+  const input = el("input");
+  input.type = "date";
+  input.min = f.curve[0].date;
+  input.max = f.curve[f.curve.length - 1].date;
+  input.value = f.weight_at_goal_date ? f.weight_at_goal_date.date : f.curve[Math.min(30, f.curve.length - 1)].date;
+  const out = el("span", "num");
+  const show = () => {
+    const p = byDate.get(input.value);
+    out.textContent = p ? `≈ ${sv(p.kg)} kg (${sv(p.low)}–${sv(p.high)})` : "—";
+  };
+  input.addEventListener("input", show);
+  picker.append(el("span", "label", "Uppskattad vikt"), input, out);
+  prognosHost.append(picker);
+
+  const toggle = el("div", "chip-row");
+  for (const [key, label] of [["targets", "planmål"], ["recent", "senaste 28 d"]]) {
+    const chip = el("button", `chip${key === source ? " accent" : ""}`, label);
+    chip.addEventListener("click", () => {
+      if (key !== source) loadPrognos(chartHost, prognosHost, series, key);
+    });
+    toggle.append(chip);
+  }
+  prognosHost.append(toggle);
+
+  if (f.notes.length) prognosHost.append(el("div", "note", f.notes.join(" · ")));
+  show();
+}
+```
+
+Replace the whole `weightChart` function with (signature gains an optional `forecast`):
+
+```js
+function weightChart(series, forecast) {
+  const NS = "http://www.w3.org/2000/svg";
+  const W = 640, H = 240, M = { top: 16, right: 52, bottom: 24, left: 10 };
+  const frame = el("div", "chart-frame");
+  const svg = document.createElementNS(NS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "Viktutveckling och prognos, kg över tid");
+
+  // Draw the projection only to just past the goal anchors (or 60 days) so
+  // the history is not compressed into a sliver by a 365-day tail.
+  const proj = forecast ? forecast.curve : [];
+  const DAY = 86400000;
+  const anchors = forecast
+    ? [forecast.goal && forecast.goal.eta, forecast.weight_at_goal_date && forecast.weight_at_goal_date.date]
+        .filter(Boolean)
+        .map((d) => Date.parse(d))
+    : [];
+  const horizon = proj.length
+    ? (anchors.length ? Math.max(...anchors) + 7 * DAY : Date.parse(proj[0].date) + 60 * DAY)
+    : 0;
+  const drawn = proj.filter((p) => Date.parse(p.date) <= horizon);
+  const goalKg = forecast && forecast.goal ? forecast.goal.weight_kg : null;
+
+  const days = series.map((w) => Date.parse(w.date));
+  const kgs = series.map((w) => w.weight_kg);
+  const allDays = [...days, ...drawn.map((p) => Date.parse(p.date))];
+  const allKgs = [...kgs, ...drawn.flatMap((p) => [p.low, p.high]), ...(goalKg !== null ? [goalKg] : [])];
+  const x0 = Math.min(...allDays), x1 = Math.max(...allDays);
+  const pad = Math.max(0.4, (Math.max(...allKgs) - Math.min(...allKgs)) * 0.15);
+  const y0 = Math.min(...allKgs) - pad, y1 = Math.max(...allKgs) + pad;
+  const X = (t) => M.left + ((t - x0) / Math.max(1, x1 - x0)) * (W - M.left - M.right);
+  const Y = (kg) => H - M.bottom - ((kg - y0) / (y1 - y0)) * (H - M.top - M.bottom);
+
+  // 3 recessive gridlines with right-side labels
+  for (let i = 0; i <= 2; i++) {
+    const kg = y0 + ((y1 - y0) * i) / 2;
+    const line = document.createElementNS(NS, "line");
+    line.setAttribute("class", "gridline");
+    line.setAttribute("x1", M.left);
+    line.setAttribute("x2", W - M.right);
+    line.setAttribute("y1", Y(kg));
+    line.setAttribute("y2", Y(kg));
+    svg.append(line);
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", W - M.right + 6);
+    label.setAttribute("y", Y(kg) + 3);
+    label.textContent = sv(kg, 1);
+    svg.append(label);
+  }
+  // x labels: first + last date of the drawn domain
+  for (const [t, anchor] of [[x0, "start"], [x1, "end"]]) {
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", X(t));
+    label.setAttribute("y", H - 6);
+    label.setAttribute("text-anchor", anchor);
+    label.textContent = new Date(t).toISOString().slice(5, 10);
+    svg.append(label);
+  }
+
+  // uncertainty band (under everything else)
+  if (drawn.length >= 2) {
+    const band = document.createElementNS(NS, "path");
+    band.setAttribute("class", "forecast-band");
+    const top = drawn.map((p, i) => `${i === 0 ? "M" : "L"}${X(Date.parse(p.date)).toFixed(1)},${Y(p.high).toFixed(1)}`).join("");
+    const bottom = [...drawn].reverse().map((p) => `L${X(Date.parse(p.date)).toFixed(1)},${Y(p.low).toFixed(1)}`).join("");
+    band.setAttribute("d", `${top}${bottom}Z`);
+    svg.append(band);
+  }
+
+  // goal weight line + vertical markers (eta, goal date)
+  if (goalKg !== null) {
+    const gl = document.createElementNS(NS, "line");
+    gl.setAttribute("class", "goal-line");
+    gl.setAttribute("x1", M.left);
+    gl.setAttribute("x2", W - M.right);
+    gl.setAttribute("y1", Y(goalKg));
+    gl.setAttribute("y2", Y(goalKg));
+    svg.append(gl);
+  }
+  const markers = [];
+  if (forecast && forecast.goal && forecast.goal.eta) markers.push([forecast.goal.eta, "mål"]);
+  if (forecast && forecast.weight_at_goal_date) markers.push([forecast.weight_at_goal_date.date, "måldatum"]);
+  for (const [date, text] of markers) {
+    const t = Date.parse(date);
+    if (t < x0 || t > x1) continue;
+    const ml = document.createElementNS(NS, "line");
+    ml.setAttribute("class", "marker-line");
+    ml.setAttribute("x1", X(t));
+    ml.setAttribute("x2", X(t));
+    ml.setAttribute("y1", M.top);
+    ml.setAttribute("y2", H - M.bottom);
+    svg.append(ml);
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", X(t) + 3);
+    label.setAttribute("y", M.top + 8);
+    label.textContent = text;
+    svg.append(label);
+  }
+
+  // projection: dashed, low opacity — clearly an estimate
+  if (drawn.length >= 1 && series.length >= 1) {
+    const lastT = days[days.length - 1];
+    const lastKg = kgs[kgs.length - 1];
+    const fp = document.createElementNS(NS, "path");
+    fp.setAttribute("class", "forecast-line");
+    const d =
+      `M${X(lastT).toFixed(1)},${Y(lastKg).toFixed(1)}` +
+      drawn.map((p) => `L${X(Date.parse(p.date)).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("");
+    fp.setAttribute("d", d);
+    svg.append(fp);
+  }
+
+  // actual weigh-ins: full opacity line + dots (drawn last, on top)
+  if (series.length >= 2) {
+    const path = document.createElementNS(NS, "path");
+    path.setAttribute("class", "trend-line");
+    path.setAttribute("d", series.map((w, i) => `${i === 0 ? "M" : "L"}${X(days[i]).toFixed(1)},${Y(kgs[i]).toFixed(1)}`).join(""));
+    svg.append(path);
+  }
+  series.forEach((w, i) => {
+    const dot = document.createElementNS(NS, "circle");
+    dot.setAttribute("class", `trend-dot${i === series.length - 1 ? " last" : ""}`);
+    dot.setAttribute("cx", X(days[i]));
+    dot.setAttribute("cy", Y(kgs[i]));
+    dot.setAttribute("r", i === series.length - 1 ? 5 : 3.5);
+    const tip = document.createElementNS(NS, "title");
+    tip.textContent = `${w.date}: ${sv(w.weight_kg)} kg`;
+    dot.append(tip);
+    svg.append(dot);
+  });
+
+  // selective direct label: last actual point only
+  const last = series[series.length - 1];
+  const label = document.createElementNS(NS, "text");
+  label.setAttribute("class", "point-label");
+  const lx = X(days[days.length - 1]);
+  label.setAttribute("x", Math.min(lx, W - M.right - 4));
+  label.setAttribute("y", Y(last.weight_kg) - 10);
+  label.setAttribute("text-anchor", "end");
+  label.textContent = `${sv(last.weight_kg)} kg`;
+  svg.append(label);
+
+  frame.append(svg);
+  return frame;
+}
+```
+
+Also update the `renderIdag` call site: it calls `weightChart` nowhere — no change. The only other caller of `weightChart` was `renderVikt` (already replaced).
+
+- [ ] **Step 2: Add CSS**
+
+Append to `kcal-assistant/src/ui/static/app.css` (after the existing `.point-label` rule):
+
+```css
+/* forecast (v0.6) */
+.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .35; stroke-dasharray: 5 4; stroke-linejoin: round; }
+.forecast-band { fill: var(--accent); opacity: .08; }
+.goal-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.marker-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.forecast-picker { display: flex; align-items: center; gap: 10px; margin: 10px 0; flex-wrap: wrap; }
+.forecast-picker input[type="date"] { font: inherit; background: var(--bg); color: var(--ink); border: 1px solid var(--hair); border-radius: 4px; padding: 4px 8px; }
+button.chip { font: inherit; cursor: pointer; }
+```
+
+- [ ] **Step 3: Verify manually with the dev server**
+
+Run from `kcal-assistant/` (env names verified against `src/config.ts`):
+
+```bash
+rm -f /tmp/kcal-dev.sqlite
+UI_DEV_NO_AUTH=1 MCP_TOKEN=dev DB_PATH=/tmp/kcal-dev.sqlite bun run src/index.ts
+```
+
+Seed synthetic data (separate terminal, from `kcal-assistant/`; synthetic 100-kg-range values only — never real weights, this plan lives in the repo):
+
+```bash
+bun -e '
+import { openDb } from "./src/db/index";
+import { setProfile } from "./src/db/profile";
+import { logWeight } from "./src/db/weights";
+const db = openDb("/tmp/kcal-dev.sqlite");
+setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 97, goal_date: "2026-10-15" });
+const entries = [["2026-06-15", 101.2], ["2026-06-22", 100.7], ["2026-06-29", 100.3], ["2026-07-06", 100.0], ["2026-07-09", 99.8]];
+for (const [date, kg] of entries) logWeight(db, { weight_kg: kg, date });
+'
+```
+
+Then open `http://localhost:3000/ui/#/vikt` (restart the server after seeding since the db file was created fresh). The page must render three states correctly (delete the db and restart for state 1):
+1. No profile → "Ingen prognos: ingen profil …" and the plain chart.
+2. Profile + weights → projection, band, goal line, ETA marker, date picker updates instantly, toggle re-fetches.
+3. Recipe list/detail shows `~X min` (from Task 2).
+
+Also run `bun test` — full suite green (no JS unit tests for app.js; the API contract is covered by Task 6).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kcal-assistant/src/ui/static/app.js kcal-assistant/src/ui/static/app.css
+git commit -m "feat(kcal-assistant): Vikt page forecast — projection chart, goals, real-time date picker"
+```
+
+---
+
+### Task 8: Release bump + full verification
+
+**Files:**
+- Modify: `kcal-assistant/package.json` (version `0.5.1` → `0.6.0`)
+- Modify: `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml:26` (image tag `v0.5.1` → `v0.6.0`)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: release-ready branch (merge → CI builds `rutbergphilip/kcal-assistant:v0.6.0` → Flux deploys).
+
+- [ ] **Step 1: Bump versions**
+
+In `kcal-assistant/package.json`: `"version": "0.6.0"`.
+In `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml` line 26: `image: rutbergphilip/kcal-assistant:v0.6.0`.
+
+- [ ] **Step 2: Full verification**
+
+```bash
+cd kcal-assistant && bun test && bunx tsc --noEmit
+```
+
+Expected: all tests pass, no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kcal-assistant/package.json kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+git commit -m "chore(kcal-assistant): release v0.6.0 — tillagningstid + viktprognos"
+```
+
+---
+
+## Post-merge (manual, for Philip — not part of this plan)
+
+1. Merge PR → CI builds and pushes the image → Flux deploys (wait ~10 s after Recreate before verifying the ingress).
+2. Start a **new chat** (connector caches the tool list per conversation) and: `set_profile` once (birth date, man, 180 cm, activity ≈1.5, goal 80 kg + goal date), then backfill recipe times by asking Claude to loop `find_recipes` → `save_recipe`.

--- a/docs/superpowers/specs/2026-07-09-kcal-time-and-forecast-design.md
+++ b/docs/superpowers/specs/2026-07-09-kcal-time-and-forecast-design.md
@@ -1,0 +1,160 @@
+# kcal-assistant v0.6.0 — Tillagningstid + Viktprognos
+
+Date: 2026-07-09
+Status: design approved in brainstorming with Philip; this document is the spec for the implementation plan.
+Scope: one release (one PR), migration 4, two new MCP tools (22 → 24), UI additions to KCAL·DB.
+
+## Feature 1: Recipe cooking time (Tillagningstid)
+
+The "smart calculation" is done by Claude in the chat and stored by the server. The server
+performs no culinary text parsing — consistent with the existing architecture split
+(Claude = intelligence, server = storage + arithmetic).
+
+### Schema (part of migration 4)
+
+Two nullable integer columns on `recipes`:
+
+- `active_minutes` — hands-on time.
+- `total_minutes` — start to done, including passive time (oven, simmer).
+
+### Tool changes
+
+- `save_recipe`: new optional integer params `active_minutes` and `total_minutes`.
+  - Tool description instructs Claude: *always estimate both times from the ingredients and
+    instructions when the user does not state them* (the "smart kalkyl").
+  - Partial-update semantics identical to `servings`: omitted = preserved, `null` = cleared.
+  - Validation: positive integers; when both are set, `total_minutes >= active_minutes`.
+- `get_recipe`: returns both fields.
+- `find_recipes`: summaries include `total_minutes` (for list display).
+
+### UI
+
+- Recipe list: `~45 min` next to each recipe (from `total_minutes`; hidden when null).
+- Recipe detail: `Tid: 45 min totalt · 15 min aktiv` (each part hidden when null).
+
+### Backfill
+
+No server code. Philip asks Claude in a chat to loop existing recipes
+(`find_recipes` → `get_recipe` → `save_recipe` with estimated times).
+
+## Feature 2: Weight forecast (Viktprognos)
+
+### Profile storage (prerequisite)
+
+Single-row `profile` table (part of migration 4):
+
+```sql
+CREATE TABLE profile (
+  id              INTEGER PRIMARY KEY CHECK (id = 1),
+  birth_date      TEXT NOT NULL,          -- age auto-updates; computed per simulated day
+  sex             TEXT NOT NULL CHECK (sex IN ('man','kvinna')),
+  height_cm       REAL NOT NULL CHECK (height_cm > 0),
+  activity_factor REAL NOT NULL CHECK (activity_factor >= 1.2 AND activity_factor <= 2.5),
+  goal_weight_kg  REAL CHECK (goal_weight_kg > 0),
+  goal_date       TEXT,                   -- "when I want to be done"
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+- New MCP tool `set_profile`: partial upsert (omitted = preserved; `null` clears
+  `goal_weight_kg`/`goal_date`; the four physiological fields are required on first insert,
+  never clearable afterwards). Tool description carries activity-factor guidance:
+  1.2 stillasittande, 1.375 lätt aktiv, 1.55 måttligt aktiv, 1.725 mycket aktiv, 1.9 extremt aktiv.
+- `get_context` gains a `profile` block (all fields) when a profile exists.
+- The UI stays read-only: profile and goals are edited via the chat, like everything else.
+
+### Model (`src/lib/forecast.ts`, pure function, unit-tested — same pattern as `trend.ts`)
+
+Calibrated adaptive simulation:
+
+1. **BMR** (Mifflin-St Jeor): `10·kg + 6.25·height_cm − 5·age + 5` (man) / `− 161` (kvinna).
+   Age computed from `birth_date` at each simulated date.
+2. **Formula TDEE**(weight) = BMR(weight) × `activity_factor`.
+3. **Calibration**: reuse the 28-day backwards-TDEE from `computeTrend`. When it yields
+   `est_tdee` with `uncertain: false`, apply
+   `offset = est_tdee − formulaTDEE(start_weight)`, clamped to ±500 kcal, held constant
+   through the simulation. Otherwise `offset = 0`. Report `calibration: "mätdata" | "formel"`.
+4. **Start point**: mean of all weigh-ins within 7 days of the latest weigh-in;
+   simulation starts at the latest weigh-in's date (so if the log is stale, the elapsed days
+   are simulated too). `stale: true` in assumptions when the latest weigh-in is > 7 days old.
+5. **Daily step (Euler)**: `w[i+1] = w[i] − (formulaTDEE(w[i]) + offset − intake) / 7700`.
+   7700 kcal per kg. The curve flattens naturally as weight drops.
+6. **Horizon**: 365 days from today. Sanity floor: stop the curve if weight would go below 40 kg.
+7. **Uncertainty band**: the same simulation run at intake ±150 kcal/day produces
+   `low`/`high` envelope curves.
+
+**Intake sources** (selectable, `intake_source` param):
+
+- `targets` (default — "if I stick to my kcals"): weighted average of `day_targets.kcal` by the
+  observed `day_type` distribution in the `days` table over the last 28 days.
+  Fewer than 7 day rows in that window → fall back to the `vilodag` target and flag it in
+  assumptions.
+- `recent`: average logged kcal over the last 28 days that have logged meals.
+- Explicit `intake_kcal` override (wins over both).
+
+**Outputs** (one result object):
+
+- `curve`: daily points `{date, kg}` plus `low`/`high` band values.
+- `weight_at`: predicted weight at a requested `target_date` (direct lookup in the daily curve;
+  also computed for the profile's `goal_date` when set).
+- `goal_eta`: first date the goal weight is crossed. Already at/past goal → `"uppnått"` today.
+  Not reachable within the horizon (or moving away from goal with current intake) →
+  `null` + reason `"nås inte inom 365 dagar med nuvarande intag"`.
+- `assumptions`: start weight/date, intake used + source, TDEE at start, calibration,
+  stale flag, kcal-per-kg constant.
+- Display rounding: weights to 0.1 kg; ETAs are dates.
+
+### Exposure
+
+- **MCP tool `get_forecast`** `{ target_date?, goal_weight?, intake_kcal?, intake_source? }`
+  (overrides fall back to profile values). Token-lean output: assumptions, `weight_at`,
+  `goal_eta`, and weekly (not daily) curve points — enough for the chat to answer
+  "vad väger jag 1 september?" and "när når jag 80?".
+- **UI API** `GET /ui/api/forecast?source=targets|recent` — computed read, writes nothing
+  (fits the read-only contract). Returns the full daily curve + band so the client can answer
+  any date instantly without re-fetching.
+
+### UI (Vikt page)
+
+The frontend-design skill is used when implementing this section.
+
+- **Goals & tiles**: goal weight, goal date, `goal_eta` ("når 80 kg ≈ 12 okt"), predicted weight
+  at goal date, TDEE used + calibration label (`kalibrerad mot mätdata` / `formel`).
+- **Real-time date picker**: pick any date within the horizon → predicted weight, read
+  client-side from the fetched daily curve (instant; no network churn). Source toggle
+  (`plan` / `senaste 28 d`) triggers one re-fetch.
+- **Chart**: one SVG extending the existing trend chart — actual weigh-ins at full opacity,
+  projected line dashed at low opacity (the "estimate" visual language Philip asked for),
+  uncertainty band as a translucent area, horizontal marker at goal weight, vertical markers
+  at goal date and `goal_eta`.
+
+### Failure modes
+
+- No profile → forecast unavailable, `reason: "ingen profil — sätt via set_profile i chatten"`.
+- No weigh-ins → reason string (same style as trend).
+- `target_date` in the past → 400 / tool error.
+- `target_date` beyond the 365-day horizon → clamped, noted in assumptions.
+- `goal_date` in the past → ignored with a note.
+
+## Tests
+
+- `tests/forecast.test.ts` (pure function): curve flattening, calibration offset + clamp,
+  goal ETA (reached / already reached / unreachable), band, intake-source weighting +
+  fallback, stale start, past/beyond-horizon dates, sanity floor.
+- Recipe tests: time fields save/partial-update/clear/validation, summary field.
+- `ui-api` tests: forecast endpoint (happy path, no profile, source param).
+
+## Release
+
+Single PR to the homelab repo: migration 4 (recipe columns + profile table), tools 23–24,
+`lib/forecast.ts`, UI API + Vikt page work, tests, version bump v0.5.0 → v0.6.0 in
+`package.json` + image tag in `deployment.yaml`. Same CI flow (merge → build → Flux).
+After deploy Philip starts a **new chat** so the connector sees the new tools, then:
+set profile once, backfill recipe times, log on.
+
+## Out of scope (deliberate)
+
+- Server-side text-parsing time heuristics.
+- NIH/Hall body-composition model, adaptive-thermogenesis terms, body-fat % input
+  (profile schema can grow later — "we can add more later").
+- Editing profile/goals from the UI (UI stays read-only).

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/forecast.ts
+++ b/kcal-assistant/src/db/forecast.ts
@@ -1,0 +1,98 @@
+import type { Database } from "bun:sqlite";
+import { computeForecast, type ForecastResult } from "../lib/forecast";
+import { getProfile } from "./profile";
+import { getTrend } from "./weights";
+import { getTargetsFor } from "./preferences";
+import { todayStockholm, addDays } from "../lib/dates";
+
+export type IntakeSource = "targets" | "recent";
+
+export interface ForecastView {
+  forecast: ForecastResult | null;
+  reason?: string;
+}
+
+// Resolves the daily intake assumption:
+//   targets — day targets weighted by the observed day-type mix (28 days)
+//   recent  — actual logged average (28 days), falling back to targets
+// An explicit intake_kcal in buildForecast bypasses this entirely.
+function resolveIntake(
+  db: Database,
+  source: IntakeSource,
+  today: string,
+): { kcal: number; source: "targets" | "recent"; notes: string[] } {
+  const notes: string[] = [];
+  const since = addDays(today, -27);
+
+  if (source === "recent") {
+    const row = db
+      .query<{ avg_kcal: number | null; n: number }, [string, string]>(
+        `SELECT AVG(day_kcal) AS avg_kcal, COUNT(*) AS n FROM (
+           SELECT m.day_date, SUM(mi.kcal) AS day_kcal
+           FROM meals m JOIN meal_items mi ON mi.meal_id = m.id
+           WHERE m.day_date >= ? AND m.day_date <= ?
+           GROUP BY m.day_date)`,
+      )
+      .get(since, today)!;
+    if (row.n > 0 && row.avg_kcal !== null) {
+      return { kcal: Math.round(row.avg_kcal), source: "recent", notes };
+    }
+    notes.push("ingen intagsdata senaste 28 dagarna — planmålen användes i stället");
+  }
+
+  const mix = db
+    .query<{ day_type: string; n: number }, [string, string]>(
+      "SELECT day_type, COUNT(*) AS n FROM days WHERE date >= ? AND date <= ? GROUP BY day_type",
+    )
+    .all(since, today);
+  const total = mix.reduce((s, r) => s + r.n, 0);
+  if (total < 7) {
+    notes.push("för få loggade dagar för dagstypsmix — vilodagsmålet användes");
+    return { kcal: getTargetsFor(db, "vilodag").kcal, source: "targets", notes };
+  }
+  const weighted = mix.reduce((s, r) => s + getTargetsFor(db, r.day_type).kcal * r.n, 0) / total;
+  return { kcal: Math.round(weighted), source: "targets", notes };
+}
+
+export function buildForecast(
+  db: Database,
+  opts: {
+    target_date?: string;
+    goal_weight?: number;
+    intake_kcal?: number;
+    intake_source?: IntakeSource;
+    today?: string;
+  } = {},
+): ForecastView {
+  const profile = getProfile(db);
+  if (!profile) return { forecast: null, reason: "ingen profil — sätt via set_profile i chatten" };
+
+  const weights = db
+    .query<{ date: string; weight_kg: number }, []>(
+      "SELECT date, weight_kg FROM weights ORDER BY date",
+    )
+    .all();
+  if (weights.length === 0) return { forecast: null, reason: "inga viktloggar ännu" };
+
+  const today = opts.today ?? todayStockholm();
+  const resolved =
+    opts.intake_kcal !== undefined
+      ? { kcal: opts.intake_kcal, source: "explicit" as const, notes: [] }
+      : resolveIntake(db, opts.intake_source ?? "targets", today);
+
+  const trend = getTrend(db, 28);
+  const measured = trend.trend && !trend.trend.uncertain ? trend.trend.est_tdee : null;
+
+  const forecast = computeForecast({
+    profile,
+    weights,
+    intake_kcal: resolved.kcal,
+    intake_source: resolved.source,
+    measured_tdee: measured,
+    today,
+    target_date: opts.target_date,
+    goal_weight_override: opts.goal_weight,
+  });
+  forecast.notes.unshift(...resolved.notes);
+  return { forecast };
+}

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -132,6 +132,23 @@ const MIGRATIONS: string[] = [
   );
   CREATE INDEX idx_recipe_ingredients_recipe ON recipe_ingredients(recipe_id);
   `,
+  // 4: recipe cooking times (Claude estimates, server stores) + single-row
+  // physiological profile used by the weight forecast
+  `
+  ALTER TABLE recipes ADD COLUMN active_minutes INTEGER;
+  ALTER TABLE recipes ADD COLUMN total_minutes INTEGER;
+
+  CREATE TABLE profile (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    birth_date      TEXT NOT NULL,
+    sex             TEXT NOT NULL CHECK (sex IN ('man','kvinna')),
+    height_cm       REAL NOT NULL CHECK (height_cm > 0),
+    activity_factor REAL NOT NULL CHECK (activity_factor >= 1.2 AND activity_factor <= 2.5),
+    goal_weight_kg  REAL CHECK (goal_weight_kg > 0),
+    goal_date       TEXT,
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/profile.ts
+++ b/kcal-assistant/src/db/profile.ts
@@ -41,6 +41,24 @@ export function setProfile(db: Database, input: ProfileInput): Profile {
       throw new Error(`Ogiltigt datum för ${field}: ${value} (YYYY-MM-DD)`);
     }
   }
+  if (input.sex !== undefined && input.sex !== "man" && input.sex !== "kvinna") {
+    throw new Error(`Ogiltigt kön: ${input.sex} (man eller kvinna)`);
+  }
+  if (input.height_cm !== undefined && !(input.height_cm > 0)) {
+    throw new Error(`Orimlig längd: ${input.height_cm} cm`);
+  }
+  if (
+    input.activity_factor !== undefined &&
+    !(input.activity_factor >= 1.2 && input.activity_factor <= 2.5)
+  ) {
+    throw new Error(`Orimlig aktivitetsfaktor: ${input.activity_factor} (1.2–2.5)`);
+  }
+  if (
+    typeof input.goal_weight_kg === "number" &&
+    !(input.goal_weight_kg > 0)
+  ) {
+    throw new Error(`Orimlig målvikt: ${input.goal_weight_kg} kg`);
+  }
   const existing = getProfile(db);
   if (!existing) {
     if (

--- a/kcal-assistant/src/db/profile.ts
+++ b/kcal-assistant/src/db/profile.ts
@@ -1,0 +1,82 @@
+import type { Database } from "bun:sqlite";
+import { isValidDate } from "../lib/dates";
+
+export interface Profile {
+  birth_date: string;
+  sex: "man" | "kvinna";
+  height_cm: number;
+  activity_factor: number;
+  goal_weight_kg: number | null;
+  goal_date: string | null;
+  updated_at: string;
+}
+
+export interface ProfileInput {
+  birth_date?: string;
+  sex?: "man" | "kvinna";
+  height_cm?: number;
+  activity_factor?: number;
+  goal_weight_kg?: number | null;
+  goal_date?: string | null;
+}
+
+export function getProfile(db: Database): Profile | null {
+  return (
+    db
+      .query<Profile, []>(
+        "SELECT birth_date, sex, height_cm, activity_factor, goal_weight_kg, goal_date, updated_at FROM profile WHERE id = 1",
+      )
+      .get() ?? null
+  );
+}
+
+// Partial upsert: omitted fields keep their values; explicit null clears the
+// goal fields. The four physiological fields are required on first insert.
+export function setProfile(db: Database, input: ProfileInput): Profile {
+  for (const [field, value] of [
+    ["birth_date", input.birth_date],
+    ["goal_date", input.goal_date],
+  ] as const) {
+    if (typeof value === "string" && !isValidDate(value)) {
+      throw new Error(`Ogiltigt datum för ${field}: ${value} (YYYY-MM-DD)`);
+    }
+  }
+  const existing = getProfile(db);
+  if (!existing) {
+    if (
+      input.birth_date === undefined ||
+      input.sex === undefined ||
+      input.height_cm === undefined ||
+      input.activity_factor === undefined
+    ) {
+      throw new Error("Första anropet kräver birth_date, sex, height_cm och activity_factor");
+    }
+    db.run(
+      "INSERT INTO profile (id, birth_date, sex, height_cm, activity_factor, goal_weight_kg, goal_date) VALUES (1, ?, ?, ?, ?, ?, ?)",
+      [
+        input.birth_date,
+        input.sex,
+        input.height_cm,
+        input.activity_factor,
+        input.goal_weight_kg ?? null,
+        input.goal_date ?? null,
+      ],
+    );
+  } else {
+    db.run(
+      `UPDATE profile SET
+         birth_date = ?, sex = ?, height_cm = ?, activity_factor = ?,
+         goal_weight_kg = ?, goal_date = ?, updated_at = datetime('now')
+       WHERE id = 1`,
+      [
+        input.birth_date ?? existing.birth_date,
+        input.sex ?? existing.sex,
+        input.height_cm ?? existing.height_cm,
+        input.activity_factor ?? existing.activity_factor,
+        input.goal_weight_kg === undefined ? existing.goal_weight_kg : input.goal_weight_kg,
+        input.goal_date === undefined ? existing.goal_date : input.goal_date,
+      ],
+    );
+  }
+  return getProfile(db)!;
+}

--- a/kcal-assistant/src/db/recipes.ts
+++ b/kcal-assistant/src/db/recipes.ts
@@ -9,6 +9,8 @@ export interface RecipeInput {
   notes?: string;
   tags?: string;
   servings?: number | null;
+  active_minutes?: number | null;
+  total_minutes?: number | null;
   product_id?: number | null;
   ingredients?: MealItemInput[];
 }
@@ -34,6 +36,8 @@ export interface RecipeView {
   notes: string | null;
   tags: string | null;
   servings: number | null;
+  active_minutes: number | null;
+  total_minutes: number | null;
   product_id: number | null;
   updated_at: string;
   ingredients: RecipeIngredientView[];
@@ -47,6 +51,7 @@ export interface RecipeSummary {
   name: string;
   tags: string | null;
   servings: number | null;
+  total_minutes: number | null;
   kcal_per_serving: number | null;
   incomplete?: true;
 }
@@ -58,6 +63,8 @@ interface RecipeRow {
   notes: string | null;
   tags: string | null;
   servings: number | null;
+  active_minutes: number | null;
+  total_minutes: number | null;
   product_id: number | null;
   updated_at: string;
 }
@@ -172,6 +179,8 @@ export function getRecipe(db: Database, id: number): RecipeView | null {
     notes: row.notes,
     tags: row.tags,
     servings: row.servings,
+    active_minutes: row.active_minutes,
+    total_minutes: row.total_minutes,
     product_id: row.product_id,
     updated_at: row.updated_at,
     ingredients,
@@ -179,6 +188,20 @@ export function getRecipe(db: Database, id: number): RecipeView | null {
     ...(incomplete && { totals_incomplete: true as const }),
     per_serving,
   };
+}
+
+function validateTimes(active: number | null, total: number | null): void {
+  for (const [label, v] of [
+    ["active_minutes", active],
+    ["total_minutes", total],
+  ] as const) {
+    if (v !== null && (!Number.isInteger(v) || v <= 0)) {
+      throw new Error(`${label} måste vara ett positivt heltal (minuter)`);
+    }
+  }
+  if (active !== null && total !== null && total < active) {
+    throw new Error("total_minutes kan inte vara mindre än active_minutes");
+  }
 }
 
 export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
@@ -190,9 +213,15 @@ export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
     if (id) {
       const existing = db.query<RecipeRow, [number]>("SELECT * FROM recipes WHERE id = ?").get(id);
       if (!existing) throw new Error(`Recipe ${id} not found`);
+      const active =
+        input.active_minutes === undefined ? existing.active_minutes : input.active_minutes;
+      const total =
+        input.total_minutes === undefined ? existing.total_minutes : input.total_minutes;
+      validateTimes(active, total);
       db.run(
         `UPDATE recipes SET
            name = ?, instructions = ?, notes = ?, tags = ?, servings = ?, product_id = ?,
+           active_minutes = ?, total_minutes = ?,
            updated_at = datetime('now')
          WHERE id = ?`,
         [
@@ -202,6 +231,8 @@ export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
           clearable(input.tags, existing.tags),
           input.servings === undefined ? existing.servings : input.servings,
           input.product_id === undefined ? existing.product_id : input.product_id,
+          active,
+          total,
           id,
         ],
       );
@@ -209,8 +240,11 @@ export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
       if (!input.ingredients || input.ingredients.length === 0) {
         throw new Error("Ett recept behöver minst en ingrediens");
       }
+      const active = input.active_minutes ?? null;
+      const total = input.total_minutes ?? null;
+      validateTimes(active, total);
       const result = db.run(
-        "INSERT INTO recipes (name, instructions, notes, tags, servings, product_id) VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO recipes (name, instructions, notes, tags, servings, product_id, active_minutes, total_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         [
           input.name,
           input.instructions ?? null,
@@ -218,6 +252,8 @@ export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
           input.tags ?? null,
           input.servings ?? null,
           input.product_id ?? null,
+          active,
+          total,
         ],
       );
       id = Number(result.lastInsertRowid);
@@ -274,6 +310,7 @@ export function findRecipes(db: Database, query?: string): RecipeSummary[] {
       name: row.name,
       tags: row.tags,
       servings: row.servings,
+      total_minutes: row.total_minutes,
       kcal_per_serving: full.per_serving?.kcal ?? null,
       ...(full.totals_incomplete && { incomplete: true as const }),
     };

--- a/kcal-assistant/src/lib/forecast.ts
+++ b/kcal-assistant/src/lib/forecast.ts
@@ -1,0 +1,210 @@
+import { toEpochDays, addDays } from "./dates";
+
+// Forward weight simulation ("riktig formel"):
+//   BMR (Mifflin-St Jeor) is recomputed every simulated day on the simulated
+//   weight, TDEE = BMR × activity factor + a constant calibration offset
+//   against the measured backwards-TDEE (lib/trend.ts) when that is reliable.
+//   Daily Euler step: w −= (TDEE(w) − intake) / 7700.
+// The curve therefore flattens naturally as weight drops. A ±150 kcal/day
+// re-run gives an honest low/high envelope instead of fake precision.
+
+export interface ForecastProfile {
+  birth_date: string;
+  sex: "man" | "kvinna";
+  height_cm: number;
+  activity_factor: number;
+  goal_weight_kg: number | null;
+  goal_date: string | null;
+}
+
+export interface ForecastWeightEntry {
+  date: string;
+  weight_kg: number;
+}
+
+export interface ForecastInput {
+  profile: ForecastProfile;
+  weights: ForecastWeightEntry[];
+  intake_kcal: number;
+  intake_source: "targets" | "recent" | "explicit";
+  measured_tdee: number | null;
+  today: string;
+  target_date?: string;
+  goal_weight_override?: number;
+  horizon_days?: number;
+}
+
+export interface ForecastPoint {
+  date: string;
+  kg: number;
+  low: number;
+  high: number;
+}
+
+export interface ForecastResult {
+  start: { date: string; weight_kg: number; weighins_smoothed: number; stale: boolean };
+  assumptions: {
+    intake_kcal: number;
+    intake_source: "targets" | "recent" | "explicit";
+    tdee_start: number;
+    calibration: "mätdata" | "formel";
+    calibration_offset: number;
+    kcal_per_kg: number;
+  };
+  curve: ForecastPoint[];
+  weight_at_target: ForecastPoint | null;
+  weight_at_goal_date: ForecastPoint | null;
+  goal: { weight_kg: number; eta: string | null; reached: boolean; reason?: string } | null;
+  notes: string[];
+}
+
+const KCAL_PER_KG = 7700;
+const BAND_KCAL = 150;
+const OFFSET_CLAMP = 500;
+const FLOOR_KG = 40;
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+function ageAt(birthDate: string, date: string): number {
+  return Math.floor((toEpochDays(date) - toEpochDays(birthDate)) / 365.25);
+}
+
+function bmr(profile: ForecastProfile, weightKg: number, date: string): number {
+  const base = 10 * weightKg + 6.25 * profile.height_cm - 5 * ageAt(profile.birth_date, date);
+  return base + (profile.sex === "man" ? 5 : -161);
+}
+
+function simulate(
+  profile: ForecastProfile,
+  startDate: string,
+  startKg: number,
+  intake: number,
+  offset: number,
+  horizonEnd: string,
+): Array<{ date: string; kg: number }> {
+  const points = [{ date: startDate, kg: startKg }];
+  let w = startKg;
+  let date = startDate;
+  const end = toEpochDays(horizonEnd);
+  while (toEpochDays(date) < end) {
+    const tdee = bmr(profile, w, date) * profile.activity_factor + offset;
+    w -= (tdee - intake) / KCAL_PER_KG;
+    date = addDays(date, 1);
+    if (w < FLOOR_KG) break;
+    points.push({ date, kg: w });
+  }
+  return points;
+}
+
+export function computeForecast(input: ForecastInput): ForecastResult {
+  const notes: string[] = [];
+  const sorted = [...input.weights].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const latest = sorted.at(-1);
+  if (!latest) throw new Error("inga viktloggar");
+
+  const horizonDays = input.horizon_days ?? 365;
+  const horizonEnd = addDays(input.today, horizonDays);
+
+  // Start = mean of weigh-ins within 7 days of the latest (noise smoothing);
+  // simulation starts at the latest weigh-in date so a stale log gets its
+  // elapsed days simulated too.
+  const recent = sorted.filter((w) => toEpochDays(latest.date) - toEpochDays(w.date) <= 7);
+  const startKg = recent.reduce((s, w) => s + w.weight_kg, 0) / recent.length;
+  const stale = toEpochDays(input.today) - toEpochDays(latest.date) > 7;
+  if (stale) notes.push("senaste vägningen är över en vecka gammal");
+
+  const formulaTdeeStart = bmr(input.profile, startKg, latest.date) * input.profile.activity_factor;
+  let offset = 0;
+  let calibration: "mätdata" | "formel" = "formel";
+  if (input.measured_tdee !== null) {
+    const raw = input.measured_tdee - formulaTdeeStart;
+    offset = Math.max(-OFFSET_CLAMP, Math.min(OFFSET_CLAMP, raw));
+    calibration = "mätdata";
+    if (Math.abs(raw) > OFFSET_CLAMP) notes.push("kalibreringen begränsades till ±500 kcal");
+  }
+  const tdeeStart = formulaTdeeStart + offset;
+
+  const main = simulate(input.profile, latest.date, startKg, input.intake_kcal, offset, horizonEnd);
+  const lowSim = simulate(input.profile, latest.date, startKg, input.intake_kcal - BAND_KCAL, offset, horizonEnd);
+  const highSim = simulate(input.profile, latest.date, startKg, input.intake_kcal + BAND_KCAL, offset, horizonEnd);
+  if (main.at(-1)!.date !== horizonEnd) notes.push("kurvan stoppades vid 40 kg (orimliga antaganden)");
+
+  const curve: ForecastPoint[] = main.map((p, i) => ({
+    date: p.date,
+    kg: round2(p.kg),
+    low: round2((lowSim[i] ?? lowSim.at(-1)!).kg),
+    high: round2((highSim[i] ?? highSim.at(-1)!).kg),
+  }));
+  const byDate = new Map(curve.map((p) => [p.date, p]));
+
+  let weightAtTarget: ForecastPoint | null = null;
+  if (input.target_date !== undefined) {
+    if (toEpochDays(input.target_date) <= toEpochDays(input.today)) {
+      throw new Error(`target_date ${input.target_date} har redan passerat`);
+    }
+    let t = input.target_date;
+    if (toEpochDays(t) > toEpochDays(horizonEnd)) {
+      t = horizonEnd;
+      notes.push(`target_date ligger bortom horisonten och klipptes till ${horizonEnd}`);
+    }
+    weightAtTarget = byDate.get(t) ?? null;
+  }
+
+  let weightAtGoalDate: ForecastPoint | null = null;
+  if (input.profile.goal_date !== null) {
+    if (toEpochDays(input.profile.goal_date) <= toEpochDays(input.today)) {
+      notes.push("goal_date har passerat och ignorerades");
+    } else {
+      weightAtGoalDate = byDate.get(input.profile.goal_date) ?? null;
+      if (!weightAtGoalDate) notes.push("goal_date ligger bortom horisonten");
+    }
+  }
+
+  // Goal ETA: direction of travel comes from the energy balance, not from the
+  // goal's position — so an overshoot or a surplus reads as "moving away".
+  const losing = input.intake_kcal < tdeeStart;
+  const goalWeight = input.goal_weight_override ?? input.profile.goal_weight_kg;
+  let goal: ForecastResult["goal"] = null;
+  if (goalWeight !== null && goalWeight !== undefined) {
+    const delta = goalWeight - startKg;
+    if (Math.abs(delta) < 0.05) {
+      goal = { weight_kg: goalWeight, eta: null, reached: true };
+    } else {
+      const movingToward = delta < 0 ? losing : !losing;
+      const hit = (kg: number): boolean => (delta < 0 ? kg <= goalWeight : kg >= goalWeight);
+      const eta = movingToward ? (curve.find((p) => hit(p.kg))?.date ?? null) : null;
+      goal = {
+        weight_kg: goalWeight,
+        eta,
+        reached: false,
+        ...(eta === null && {
+          reason: movingToward
+            ? `nås inte inom ${horizonDays} dagar med nuvarande intag`
+            : "med nuvarande intag rör sig vikten bort från målet",
+        }),
+      };
+    }
+  }
+
+  return {
+    start: {
+      date: latest.date,
+      weight_kg: round2(startKg),
+      weighins_smoothed: recent.length,
+      stale,
+    },
+    assumptions: {
+      intake_kcal: input.intake_kcal,
+      intake_source: input.intake_source,
+      tdee_start: Math.round(tdeeStart / 10) * 10,
+      calibration,
+      calibration_offset: Math.round(offset),
+      kcal_per_kg: KCAL_PER_KG,
+    },
+    curve,
+    weight_at_target: weightAtTarget,
+    weight_at_goal_date: weightAtGoalDate,
+    goal,
+    notes,
+  };
+}

--- a/kcal-assistant/src/mcp.ts
+++ b/kcal-assistant/src/mcp.ts
@@ -8,6 +8,7 @@ import { registerNutritionTools } from "./tools/nutrition";
 import { registerStoreTools } from "./tools/store";
 import { registerWeightTools } from "./tools/weights";
 import { registerRecipeTools } from "./tools/recipes";
+import { registerProfileTools } from "./tools/profile";
 
 // A fresh McpServer per request (stateless Streamable HTTP). The Database is
 // the shared singleton — safe because bun:sqlite is synchronous.
@@ -21,5 +22,6 @@ export function buildMcpServer(db: Database): McpServer {
   registerStoreTools(server);
   registerWeightTools(server, db);
   registerRecipeTools(server, db);
+  registerProfileTools(server, db);
   return server;
 }

--- a/kcal-assistant/src/tools/context.ts
+++ b/kcal-assistant/src/tools/context.ts
@@ -3,6 +3,7 @@ import type { Database } from "bun:sqlite";
 import { getDay, getWeek } from "../db/meals";
 import { getTrend } from "../db/weights";
 import { listPreferences, getTargets, type Preference } from "../db/preferences";
+import { getProfile } from "../db/profile";
 import { dateSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
@@ -24,9 +25,11 @@ export function registerContextTools(server: McpServer, db: Database): void {
     },
     wrap(({ date }) => {
       const trend = getTrend(db);
+      const profile = getProfile(db);
       return jsonResult({
         preferences: groupPreferences(listPreferences(db)),
         all_targets: getTargets(db),
+        ...(profile && { profile }),
         day: getDay(db, date),
         ...(trend.latest && {
           weight: {

--- a/kcal-assistant/src/tools/profile.ts
+++ b/kcal-assistant/src/tools/profile.ts
@@ -1,0 +1,48 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { setProfile } from "../db/profile";
+import { buildForecast } from "../db/forecast";
+import { dateSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+export function registerProfileTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "set_profile",
+    {
+      description:
+        "Set or update the physiological profile and goals used by get_forecast (PARTIAL: omitted fields keep their values; explicit null clears goal_weight_kg or goal_date). First call must include birth_date, sex, height_cm and activity_factor. Activity factor guide: 1.2 stillasittande, 1.375 lätt aktiv, 1.55 måttligt aktiv, 1.725 mycket aktiv, 1.9 extremt aktiv.",
+      inputSchema: {
+        birth_date: dateSchema.optional(),
+        sex: z.enum(["man", "kvinna"]).optional(),
+        height_cm: z.number().positive().optional(),
+        activity_factor: z.number().min(1.2).max(2.5).optional(),
+        goal_weight_kg: z.number().positive().nullable().optional().describe("Målvikt i kg; null rensar"),
+        goal_date: dateSchema.nullable().optional().describe("Datum då målet ska vara nått; null rensar"),
+      },
+    },
+    wrap((input) => jsonResult(setProfile(db, input))),
+  );
+
+  server.registerTool(
+    "get_forecast",
+    {
+      description:
+        "Weight forecast from profile + weight log. Simulates day by day: Mifflin-St Jeor BMR on the moving weight × activity factor, calibrated against the measured backwards-TDEE when reliable. Returns predicted weight at target_date and at the profile's goal_date, the date the goal weight is reached (goal.eta), an uncertainty band (±150 kcal/dag), and weekly curve points. intake_source: 'targets' (default; day targets weighted by the recent day-type mix) or 'recent' (actual 28-day average); intake_kcal overrides both. Present the numbers as-is, never recompute.",
+      inputSchema: {
+        target_date: dateSchema.optional().describe("Datum att förutsäga vikten för"),
+        goal_weight: z.number().positive().optional().describe("Överskuggar profilens målvikt"),
+        intake_kcal: z.number().positive().optional(),
+        intake_source: z.enum(["targets", "recent"]).optional(),
+      },
+    },
+    wrap((input) => {
+      const view = buildForecast(db, input);
+      if (!view.forecast) return jsonResult(view);
+      // Token-lean for the chat: weekly points instead of the daily curve.
+      const { curve, ...rest } = view.forecast;
+      const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+      return jsonResult({ forecast: { ...rest, curve: weekly } });
+    }),
+  );
+}

--- a/kcal-assistant/src/tools/recipes.ts
+++ b/kcal-assistant/src/tools/recipes.ts
@@ -10,7 +10,7 @@ export function registerRecipeTools(server: McpServer, db: Database): void {
     "save_recipe",
     {
       description:
-        "Create a recipe, or update by id (PARTIAL: omitted fields keep their values; empty string clears text; explicit null clears servings or unlinks product_id; ingredients replace wholesale). Ingredients use the same format as log_meal and resolve LIVE at every read, so product corrections propagate into the recipe automatically. After computing a batch with compute_batch (save:true), link it here via product_id.",
+        "Create a recipe, or update by id (PARTIAL: omitted fields keep their values; empty string clears text; explicit null clears servings/times or unlinks product_id; ingredients replace wholesale). ALWAYS estimate active_minutes (hands-on) and total_minutes (start to done, incl oven/simmer time) from the ingredients and instructions when the user does not state them. Ingredients use the same format as log_meal and resolve LIVE at every read, so product corrections propagate into the recipe automatically. After computing a batch with compute_batch (save:true), link it here via product_id.",
       inputSchema: {
         id: z.number().int().optional(),
         name: z.string().min(1),
@@ -18,6 +18,10 @@ export function registerRecipeTools(server: McpServer, db: Database): void {
         notes: z.string().optional(),
         tags: z.string().optional().describe("Free text, e.g. 'mealprep,airfryer'"),
         servings: z.number().positive().nullable().optional().describe("Portions the recipe yields; null clears"),
+        active_minutes: z.number().int().positive().nullable().optional()
+          .describe("Hands-on-tid i minuter; null rensar"),
+        total_minutes: z.number().int().positive().nullable().optional()
+          .describe("Total tid start till klart, inkl ugn/koktid; null rensar"),
         product_id: z.number().int().nullable().optional().describe("Linked batch product; null unlinks"),
         ingredients: z.array(mealItemSchema).min(1).optional(),
       },

--- a/kcal-assistant/src/ui/api.ts
+++ b/kcal-assistant/src/ui/api.ts
@@ -4,6 +4,7 @@ import { listProducts } from "../db/products";
 import { findRecipes, getRecipe } from "../db/recipes";
 import { getTrend, listWeights } from "../db/weights";
 import { listPreferences, getTargets } from "../db/preferences";
+import { buildForecast, type IntakeSource } from "../db/forecast";
 import { isValidDate } from "../lib/dates";
 
 export interface UiApiResponse {
@@ -67,6 +68,17 @@ export function handleUiApi(db: Database, pathname: string, search: URLSearchPar
       case "weights": {
         if (param !== undefined) return NOT_FOUND;
         return { status: 200, body: { weights: listWeights(db), trend: getTrend(db, 28) } };
+      }
+      case "forecast": {
+        if (param !== undefined) return NOT_FOUND;
+        const raw = search.get("source");
+        if (raw !== null && raw !== "targets" && raw !== "recent") {
+          return { status: 400, body: { error: "ogiltig källa" } };
+        }
+        // raw is typed string|null — literal comparisons don't narrow it,
+        // so pick the union value explicitly.
+        const source: IntakeSource = raw === "recent" ? "recent" : "targets";
+        return { status: 200, body: buildForecast(db, { intake_source: source }) };
       }
       case "preferences": {
         if (param !== undefined) return NOT_FOUND;

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -378,6 +378,34 @@ td:first-child { text-align: left; color: var(--ink-2); padding-left: 2px; }
 .trend-dot.last { fill: var(--accent); }
 .point-label { fill: var(--ink); font-family: var(--mono); font-size: 11px; font-weight: 700; }
 
+/* forecast (v0.6) */
+.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .35; stroke-dasharray: 5 4; stroke-linejoin: round; }
+.forecast-band { fill: var(--accent); opacity: .08; }
+.goal-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.marker-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.forecast-picker { display: flex; align-items: center; gap: 10px; margin: 10px 0; flex-wrap: wrap; }
+.forecast-picker .label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+.forecast-picker .num { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 13px; color: var(--ink); }
+.forecast-picker input[type="date"] {
+  font: inherit;
+  font-family: var(--mono);
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--hair-2);
+  border-radius: 2px;
+  padding: 6px 8px;
+}
+.forecast-picker input[type="date"]:focus { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+button.chip { font: inherit; cursor: pointer; background: none; }
+button.chip:hover { border-color: var(--accent-dim); }
+button.chip:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 1px; }
+
 /* ---------- stat tiles ---------- */
 .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; margin: 10px 0; }
 .tile {
@@ -451,3 +479,12 @@ td:first-child { text-align: left; color: var(--ink-2); padding-left: 2px; }
   cursor: pointer;
 }
 .pill-flags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+
+/* forecast (v0.6) */
+.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .4; stroke-dasharray: 6 5; stroke-linejoin: round; }
+.forecast-band { fill: var(--accent); opacity: .07; }
+.goal-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.marker-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
+.forecast-picker { display: flex; align-items: center; gap: 10px; margin: 10px 0; flex-wrap: wrap; }
+.forecast-picker input[type="date"] { font: inherit; background: var(--bg); color: var(--ink); border: 1px solid var(--hair); border-radius: 4px; padding: 4px 8px; }
+button.chip { font: inherit; cursor: pointer; }

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -379,8 +379,8 @@ td:first-child { text-align: left; color: var(--ink-2); padding-left: 2px; }
 .point-label { fill: var(--ink); font-family: var(--mono); font-size: 11px; font-weight: 700; }
 
 /* forecast (v0.6) */
-.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .35; stroke-dasharray: 5 4; stroke-linejoin: round; }
-.forecast-band { fill: var(--accent); opacity: .08; }
+.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .4; stroke-dasharray: 6 5; stroke-linejoin: round; }
+.forecast-band { fill: var(--accent); opacity: .07; }
 .goal-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
 .marker-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
 .forecast-picker { display: flex; align-items: center; gap: 10px; margin: 10px 0; flex-wrap: wrap; }

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -479,12 +479,3 @@ button.chip:focus-visible { outline: 2px solid var(--accent-dim); outline-offset
   cursor: pointer;
 }
 .pill-flags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
-
-/* forecast (v0.6) */
-.forecast-line { stroke: var(--accent); stroke-width: 2; fill: none; opacity: .4; stroke-dasharray: 6 5; stroke-linejoin: round; }
-.forecast-band { fill: var(--accent); opacity: .07; }
-.goal-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
-.marker-line { stroke: var(--ink-3); stroke-width: 1; stroke-dasharray: 2 3; }
-.forecast-picker { display: flex; align-items: center; gap: 10px; margin: 10px 0; flex-wrap: wrap; }
-.forecast-picker input[type="date"] { font: inherit; background: var(--bg); color: var(--ink); border: 1px solid var(--hair); border-radius: 4px; padding: 4px 8px; }
-button.chip { font: inherit; cursor: pointer; }

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -460,7 +460,10 @@ async function loadPrognos(chartHost, prognosHost, series, source) {
   for (const [key, label] of [["targets", "planmål"], ["recent", "senaste 28 d"]]) {
     const chip = el("button", `chip${key === source ? " accent" : ""}`, label);
     chip.addEventListener("click", () => {
-      if (key !== source) loadPrognos(chartHost, prognosHost, series, key);
+      if (key === source) return;
+      // in-flight guard: the whole toggle is rebuilt when loadPrognos resolves
+      for (const b of toggle.querySelectorAll("button")) b.disabled = true;
+      loadPrognos(chartHost, prognosHost, series, key);
     });
     toggle.append(chip);
   }

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -290,12 +290,11 @@ async function renderRecept() {
   }
   for (const r of data.recipes) {
     const row = el("button", "rowlink");
-    row.append(
-      el("span", "", r.name),
-      el("span", "grow"),
-      el("span", "dim", r.tags || ""),
-      el("span", "num", r.kcal_per_serving !== null ? `${sv(r.kcal_per_serving, 0)} kcal/port` : "—"),
-    );
+    row.append(el("span", "", r.name));
+    row.append(el("span", "grow"));
+    row.append(el("span", "dim", r.tags || ""));
+    if (r.total_minutes !== null) row.append(el("span", "dim", `~${sv(r.total_minutes, 0)} min`));
+    row.append(el("span", "num", r.kcal_per_serving !== null ? `${sv(r.kcal_per_serving, 0)} kcal/port` : "—"));
     row.addEventListener("click", () => {
       location.hash = `#/recept/${r.id}`;
     });
@@ -329,6 +328,11 @@ async function renderReceptDetalj(id) {
 
   const tiles = el("div", "tiles");
   if (r.servings) tiles.append(tile("Portioner", sv(r.servings), null));
+  if (r.total_minutes !== null) {
+    tiles.append(
+      tile("Tid", `${sv(r.total_minutes, 0)} min`, r.active_minutes !== null ? `${sv(r.active_minutes, 0)} min aktiv` : null),
+    );
+  }
   if (r.per_serving) tiles.append(tile("Per portion", `${sv(r.per_serving.kcal, 0)} kcal`, `P ${sv(r.per_serving.protein)} · F ${sv(r.per_serving.fat)} · K ${sv(r.per_serving.carbs)}`));
   view.append(tiles);
 

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -406,6 +406,18 @@ async function loadPrognos(chartHost, prognosHost, series, source) {
   try {
     fc = await api(`/ui/api/forecast?source=${source}`);
   } catch (e) {
+    if (prognosHost.childElementCount > 0) {
+      // toggle failed mid-session: keep the last good render, surface the
+      // error, and re-enable the chips the click guard disabled
+      let note = prognosHost.querySelector(".error-banner");
+      if (!note) {
+        note = el("div", "error-banner");
+        prognosHost.append(note);
+      }
+      note.textContent = "Kunde inte hämta prognosen — visar senaste lyckade.";
+      for (const b of prognosHost.querySelectorAll("button.chip")) b.disabled = false;
+      return;
+    }
     fc = { forecast: null, reason: "kunde inte hämtas" };
   }
   chartHost.replaceChildren();

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -362,7 +362,8 @@ async function renderVikt() {
   }
 
   const series = [...data.weights].reverse(); // ascending by date
-  if (series.length >= 2) view.append(weightChart(series));
+  const chartHost = el("div");
+  view.append(chartHost);
 
   const tiles = el("div", "tiles");
   tiles.append(tile("Senast", `${sv(data.trend.latest.weight_kg)} kg`, data.trend.latest.date + (data.trend.stale ? " · gammal" : "")));
@@ -380,6 +381,11 @@ async function renderVikt() {
   }
   view.append(tiles);
 
+  view.append(el("h2", "", "Prognos"));
+  const prognosHost = el("div");
+  view.append(prognosHost);
+  await loadPrognos(chartHost, prognosHost, series, "targets");
+
   view.append(el("h2", "", "Alla vägningar"));
   const wrap = el("div", "tablewrap");
   const table = el("table");
@@ -395,20 +401,106 @@ async function renderVikt() {
   view.append(wrap);
 }
 
-function weightChart(series) {
+async function loadPrognos(chartHost, prognosHost, series, source) {
+  let fc;
+  try {
+    fc = await api(`/ui/api/forecast?source=${source}`);
+  } catch (e) {
+    fc = { forecast: null, reason: "kunde inte hämtas" };
+  }
+  chartHost.replaceChildren();
+  if (series.length >= 2 || fc.forecast) chartHost.append(weightChart(series, fc.forecast));
+  prognosHost.replaceChildren();
+
+  if (!fc.forecast) {
+    prognosHost.append(el("div", "empty", `Ingen prognos: ${fc.reason}`));
+    return;
+  }
+  const f = fc.forecast;
+
+  const tiles = el("div", "tiles");
+  if (f.goal) {
+    tiles.append(
+      tile("Målvikt", `${sv(f.goal.weight_kg)} kg`, f.goal.reached ? "uppnådd" : f.goal.eta ? `nås ≈ ${f.goal.eta}` : f.goal.reason),
+    );
+  }
+  if (f.weight_at_goal_date) {
+    tiles.append(tile("Vid måldatum", `≈ ${sv(f.weight_at_goal_date.kg)} kg`, f.weight_at_goal_date.date));
+  }
+  tiles.append(
+    tile("TDEE i kalkylen", sv(f.assumptions.tdee_start, 0), f.assumptions.calibration === "mätdata" ? "kalibrerad mot mätdata" : "formel (Mifflin-St Jeor)"),
+  );
+  tiles.append(
+    tile(
+      "Intag i kalkylen",
+      sv(f.assumptions.intake_kcal, 0),
+      f.assumptions.intake_source === "targets" ? "planmål (dagstypsmix)" : f.assumptions.intake_source === "recent" ? "snitt senaste 28 d" : "angivet",
+    ),
+  );
+  prognosHost.append(tiles);
+
+  // Real-time lookup: the daily curve is already here — no network per date.
+  const byDate = new Map(f.curve.map((p) => [p.date, p]));
+  const picker = el("div", "forecast-picker");
+  const input = el("input");
+  input.type = "date";
+  input.min = f.curve[0].date;
+  input.max = f.curve[f.curve.length - 1].date;
+  input.value = f.weight_at_goal_date ? f.weight_at_goal_date.date : f.curve[Math.min(30, f.curve.length - 1)].date;
+  const out = el("span", "num");
+  const show = () => {
+    const p = byDate.get(input.value);
+    out.textContent = p ? `≈ ${sv(p.kg)} kg (${sv(p.low)}–${sv(p.high)})` : "—";
+  };
+  input.addEventListener("input", show);
+  picker.append(el("span", "label", "Uppskattad vikt"), input, out);
+  prognosHost.append(picker);
+
+  const toggle = el("div", "chip-row");
+  for (const [key, label] of [["targets", "planmål"], ["recent", "senaste 28 d"]]) {
+    const chip = el("button", `chip${key === source ? " accent" : ""}`, label);
+    chip.addEventListener("click", () => {
+      if (key !== source) loadPrognos(chartHost, prognosHost, series, key);
+    });
+    toggle.append(chip);
+  }
+  prognosHost.append(toggle);
+
+  if (f.notes.length) prognosHost.append(el("div", "note", f.notes.join(" · ")));
+  show();
+}
+
+function weightChart(series, forecast) {
   const NS = "http://www.w3.org/2000/svg";
   const W = 640, H = 240, M = { top: 16, right: 52, bottom: 24, left: 10 };
   const frame = el("div", "chart-frame");
   const svg = document.createElementNS(NS, "svg");
   svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
   svg.setAttribute("role", "img");
-  svg.setAttribute("aria-label", "Viktutveckling, kg över tid");
+  svg.setAttribute("aria-label", "Viktutveckling och prognos, kg över tid");
+
+  // Draw the projection only to just past the goal anchors (or 60 days) so
+  // the history is not compressed into a sliver by a 365-day tail.
+  const proj = forecast ? forecast.curve : [];
+  const DAY = 86400000;
+  const anchors = forecast
+    ? [forecast.goal && forecast.goal.eta, forecast.weight_at_goal_date && forecast.weight_at_goal_date.date]
+        .filter(Boolean)
+        .map((d) => Date.parse(d))
+    : [];
+  const horizon = proj.length
+    ? (anchors.length ? Math.max(...anchors) + 7 * DAY : Date.parse(proj[0].date) + 60 * DAY)
+    : 0;
+  const drawn = proj.filter((p) => Date.parse(p.date) <= horizon);
+  const goalKg = forecast && forecast.goal ? forecast.goal.weight_kg : null;
 
   const days = series.map((w) => Date.parse(w.date));
   const kgs = series.map((w) => w.weight_kg);
-  const x0 = Math.min(...days), x1 = Math.max(...days);
-  const pad = Math.max(0.4, (Math.max(...kgs) - Math.min(...kgs)) * 0.15);
-  const y0 = Math.min(...kgs) - pad, y1 = Math.max(...kgs) + pad;
+  const allDays = [...days, ...drawn.map((p) => Date.parse(p.date))];
+  const allKgs = [...kgs, ...drawn.flatMap((p) => [p.low, p.high]), ...(goalKg !== null ? [goalKg] : [])];
+  const x0 = Math.min(...allDays), x1 = Math.max(...allDays);
+  const pad = Math.max(0.4, (Math.max(...allKgs) - Math.min(...allKgs)) * 0.15);
+  const y0 = Math.min(...allKgs) - pad, y1 = Math.max(...allKgs) + pad;
   const X = (t) => M.left + ((t - x0) / Math.max(1, x1 - x0)) * (W - M.left - M.right);
   const Y = (kg) => H - M.bottom - ((kg - y0) / (y1 - y0)) * (H - M.top - M.bottom);
 
@@ -429,7 +521,7 @@ function weightChart(series) {
     label.textContent = sv(kg, 1);
     svg.append(label);
   }
-  // x labels: first + last date
+  // x labels: first + last date of the drawn domain
   for (const [t, anchor] of [[x0, "start"], [x1, "end"]]) {
     const label = document.createElementNS(NS, "text");
     label.setAttribute("class", "axis-label");
@@ -440,11 +532,67 @@ function weightChart(series) {
     svg.append(label);
   }
 
-  const path = document.createElementNS(NS, "path");
-  path.setAttribute("class", "trend-line");
-  path.setAttribute("d", series.map((w, i) => `${i === 0 ? "M" : "L"}${X(days[i]).toFixed(1)},${Y(kgs[i]).toFixed(1)}`).join(""));
-  svg.append(path);
+  // uncertainty band (under everything else)
+  if (drawn.length >= 2) {
+    const band = document.createElementNS(NS, "path");
+    band.setAttribute("class", "forecast-band");
+    const top = drawn.map((p, i) => `${i === 0 ? "M" : "L"}${X(Date.parse(p.date)).toFixed(1)},${Y(p.high).toFixed(1)}`).join("");
+    const bottom = [...drawn].reverse().map((p) => `L${X(Date.parse(p.date)).toFixed(1)},${Y(p.low).toFixed(1)}`).join("");
+    band.setAttribute("d", `${top}${bottom}Z`);
+    svg.append(band);
+  }
 
+  // goal weight line + vertical markers (eta, goal date)
+  if (goalKg !== null) {
+    const gl = document.createElementNS(NS, "line");
+    gl.setAttribute("class", "goal-line");
+    gl.setAttribute("x1", M.left);
+    gl.setAttribute("x2", W - M.right);
+    gl.setAttribute("y1", Y(goalKg));
+    gl.setAttribute("y2", Y(goalKg));
+    svg.append(gl);
+  }
+  const markers = [];
+  if (forecast && forecast.goal && forecast.goal.eta) markers.push([forecast.goal.eta, "mål"]);
+  if (forecast && forecast.weight_at_goal_date) markers.push([forecast.weight_at_goal_date.date, "måldatum"]);
+  for (const [date, text] of markers) {
+    const t = Date.parse(date);
+    if (t < x0 || t > x1) continue;
+    const ml = document.createElementNS(NS, "line");
+    ml.setAttribute("class", "marker-line");
+    ml.setAttribute("x1", X(t));
+    ml.setAttribute("x2", X(t));
+    ml.setAttribute("y1", M.top);
+    ml.setAttribute("y2", H - M.bottom);
+    svg.append(ml);
+    const label = document.createElementNS(NS, "text");
+    label.setAttribute("class", "axis-label");
+    label.setAttribute("x", X(t) + 3);
+    label.setAttribute("y", M.top + 8);
+    label.textContent = text;
+    svg.append(label);
+  }
+
+  // projection: dashed, low opacity — clearly an estimate
+  if (drawn.length >= 1 && series.length >= 1) {
+    const lastT = days[days.length - 1];
+    const lastKg = kgs[kgs.length - 1];
+    const fp = document.createElementNS(NS, "path");
+    fp.setAttribute("class", "forecast-line");
+    const d =
+      `M${X(lastT).toFixed(1)},${Y(lastKg).toFixed(1)}` +
+      drawn.map((p) => `L${X(Date.parse(p.date)).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("");
+    fp.setAttribute("d", d);
+    svg.append(fp);
+  }
+
+  // actual weigh-ins: full opacity line + dots (drawn last, on top)
+  if (series.length >= 2) {
+    const path = document.createElementNS(NS, "path");
+    path.setAttribute("class", "trend-line");
+    path.setAttribute("d", series.map((w, i) => `${i === 0 ? "M" : "L"}${X(days[i]).toFixed(1)},${Y(kgs[i]).toFixed(1)}`).join(""));
+    svg.append(path);
+  }
   series.forEach((w, i) => {
     const dot = document.createElementNS(NS, "circle");
     dot.setAttribute("class", `trend-dot${i === series.length - 1 ? " last" : ""}`);
@@ -457,7 +605,7 @@ function weightChart(series) {
     svg.append(dot);
   });
 
-  // selective direct label: last point only
+  // selective direct label: last actual point only
   const last = series[series.length - 1];
   const label = document.createElementNS(NS, "text");
   label.setAttribute("class", "point-label");

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+import { addDays } from "../src/lib/dates";
+
+// Synthetic fixtures only — public repo.
+//
+// Reference profile chosen so TDEE(w) = 15w + 1500 exactly:
+//   BMR = 10w + 6.25·180 − 5·26 + 5 = 10w + 1000 (man, 180 cm, age 26)
+//   × activity 1.5 → 15w + 1500.
+// With intake 1500 the daily deficit is exactly 15w, so the discrete curve is
+//   w_n = 82·(1 − 15/7700)^n
+// which is hand-checkable: w_1 = 81.84026, w_12 = 80.10 > 80, w_13 = 79.95 ≤ 80.
+const PROFILE: ForecastProfile = {
+  birth_date: "2000-01-15",
+  sex: "man",
+  height_cm: 180,
+  activity_factor: 1.5,
+  goal_weight_kg: 80,
+  goal_date: null,
+};
+const TODAY = "2026-07-09";
+const W = (date: string, kg: number) => ({ date, weight_kg: kg });
+
+function run(overrides: object = {}) {
+  return computeForecast({
+    profile: PROFILE,
+    weights: [W(TODAY, 82)],
+    intake_kcal: 1500,
+    intake_source: "explicit",
+    measured_tdee: null,
+    today: TODAY,
+    ...overrides,
+  });
+}
+
+describe("computeForecast", () => {
+  test("first step and adaptive flattening match the hand calculation", () => {
+    const f = run();
+    expect(f.curve[0]).toMatchObject({ date: TODAY, kg: 82 });
+    expect(f.curve[1]!.kg).toBe(81.84); // 82 − (2730−1500)/7700
+    expect(f.assumptions.tdee_start).toBe(2730);
+    expect(f.assumptions.calibration).toBe("formel");
+    const early = f.curve[1]!.kg - f.curve[31]!.kg;
+    const late = f.curve[301]!.kg - f.curve[331]!.kg;
+    expect(early).toBeGreaterThan(late); // deficit shrinks as weight falls
+  });
+
+  test("goal 80 kg is reached on day 13", () => {
+    const f = run();
+    expect(f.goal!.weight_kg).toBe(80);
+    expect(f.goal!.reached).toBe(false);
+    expect(f.goal!.eta).toBe(addDays(TODAY, 13));
+  });
+
+  test("calibration offsets the TDEE and clamps at ±500", () => {
+    const f = run({ measured_tdee: 2500 });
+    expect(f.assumptions.calibration).toBe("mätdata");
+    expect(f.assumptions.calibration_offset).toBe(-230);
+    expect(f.assumptions.tdee_start).toBe(2500);
+    expect(f.curve[1]!.kg).toBe(81.87); // 82 − 1000/7700
+    const clamped = run({ measured_tdee: 3500 });
+    expect(clamped.assumptions.calibration_offset).toBe(500);
+    expect(clamped.notes.join(" ")).toContain("±500");
+  });
+
+  test("band brackets the main curve", () => {
+    const f = run();
+    expect(f.curve[10]!.low).toBeLessThan(f.curve[10]!.kg);
+    expect(f.curve[10]!.high).toBeGreaterThan(f.curve[10]!.kg);
+  });
+
+  test("start smooths weigh-ins within 7 days of the latest", () => {
+    const f = run({ weights: [W("2026-07-02", 82.4), W("2026-07-06", 82.0), W(TODAY, 81.6)] });
+    expect(f.start.weight_kg).toBe(82);
+    expect(f.start.weighins_smoothed).toBe(3);
+  });
+
+  test("a stale log starts the simulation at the weigh-in date", () => {
+    const f = run({ weights: [W("2026-06-29", 82)], target_date: "2026-07-20" });
+    expect(f.start.stale).toBe(true);
+    expect(f.curve[0]!.date).toBe("2026-06-29");
+    expect(f.weight_at_target!.date).toBe("2026-07-20");
+  });
+
+  test("target date validation and horizon clamping", () => {
+    expect(() => run({ target_date: "2026-07-01" })).toThrow(/passerat/);
+    const f = run({ target_date: addDays(TODAY, 400) });
+    expect(f.weight_at_target!.date).toBe(addDays(TODAY, 365));
+    expect(f.notes.join(" ")).toContain("horisonten");
+  });
+
+  test("moving away from the goal yields no eta and a reason", () => {
+    const f = run({ intake_kcal: 2800 }); // above TDEE 2730 → gaining
+    expect(f.goal!.eta).toBeNull();
+    expect(f.goal!.reason).toContain("bort");
+  });
+
+  test("a passed goal_date is ignored with a note", () => {
+    const f = run({ profile: { ...PROFILE, goal_date: "2026-07-01" } });
+    expect(f.weight_at_goal_date).toBeNull();
+    expect(f.notes.join(" ")).toContain("passerat");
+  });
+
+  test("sanity floor stops the curve at 40 kg", () => {
+    const f = run({
+      weights: [W(TODAY, 41)],
+      intake_kcal: 500,
+      profile: { ...PROFILE, goal_weight_kg: null },
+    });
+    expect(f.goal).toBeNull();
+    expect(f.curve.at(-1)!.kg).toBeGreaterThanOrEqual(40);
+    expect(f.curve.length).toBeLessThan(365);
+    expect(f.notes.join(" ")).toContain("40 kg");
+  });
+});

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
 import { addDays } from "../src/lib/dates";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { setProfile } from "../src/db/profile";
+import { logWeight } from "../src/db/weights";
+import { logMeal } from "../src/db/meals";
+import { buildForecast } from "../src/db/forecast";
 
 // Synthetic fixtures only — public repo.
 //
@@ -111,5 +117,63 @@ describe("computeForecast", () => {
     expect(f.curve.at(-1)!.kg).toBeGreaterThanOrEqual(40);
     expect(f.curve.length).toBeLessThan(365);
     expect(f.notes.join(" ")).toContain("40 kg");
+  });
+});
+
+describe("buildForecast", () => {
+  const TODAY = "2026-07-09";
+
+  function seededDb(): Database {
+    const db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5 });
+    logWeight(db, { weight_kg: 82, date: TODAY });
+    return db;
+  }
+
+  test("missing profile and missing weights give reasons", () => {
+    const db = openDb(":memory:");
+    expect(buildForecast(db, { today: TODAY }).reason).toContain("profil");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5 });
+    expect(buildForecast(db, { today: TODAY }).reason).toContain("viktloggar");
+  });
+
+  test("targets mix weights the day targets by observed day types", () => {
+    const db = seededDb();
+    for (let i = 0; i < 14; i++) {
+      db.run("INSERT OR IGNORE INTO days (date, day_type) VALUES (?, ?)", [
+        addDays(TODAY, -i),
+        i % 2 === 0 ? "vilodag" : "gymdag",
+      ]);
+    }
+    const f = buildForecast(db, { today: TODAY }).forecast!;
+    expect(f.assumptions.intake_source).toBe("targets");
+    expect(f.assumptions.intake_kcal).toBe(2200); // (7·2000 + 7·2400) / 14, seeded targets
+  });
+
+  test("targets mix falls back to vilodag under 7 logged days", () => {
+    const f = buildForecast(seededDb(), { today: TODAY }).forecast!;
+    expect(f.assumptions.intake_kcal).toBe(2000); // seeded vilodag target
+    expect(f.notes.join(" ")).toContain("vilodag");
+  });
+
+  test("recent averages logged kcal and falls back to targets when empty", () => {
+    const db = seededDb();
+    const item = (kcal: number) => [{ description: "x", macros: { kcal, protein: 100, fat: 50, carbs: 100 } }];
+    logMeal(db, { name: "A", date: addDays(TODAY, -1), items: item(1600) });
+    logMeal(db, { name: "B", date: addDays(TODAY, -2), items: item(2000) });
+    const f = buildForecast(db, { today: TODAY, intake_source: "recent" }).forecast!;
+    expect(f.assumptions.intake_source).toBe("recent");
+    expect(f.assumptions.intake_kcal).toBe(1800);
+
+    const empty = seededDb();
+    const g = buildForecast(empty, { today: TODAY, intake_source: "recent" }).forecast!;
+    expect(g.assumptions.intake_source).toBe("targets");
+    expect(g.notes.join(" ")).toContain("intagsdata");
+  });
+
+  test("explicit intake wins over any source", () => {
+    const f = buildForecast(seededDb(), { today: TODAY, intake_kcal: 1234, intake_source: "recent" }).forecast!;
+    expect(f.assumptions.intake_source).toBe("explicit");
+    expect(f.assumptions.intake_kcal).toBe(1234);
   });
 });

--- a/kcal-assistant/tests/profile.test.ts
+++ b/kcal-assistant/tests/profile.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { getProfile, setProfile } from "../src/db/profile";
+
+let db: Database;
+beforeEach(() => {
+  db = openDb(":memory:");
+});
+
+describe("profile", () => {
+  test("getProfile is null before first set", () => {
+    expect(getProfile(db)).toBeNull();
+  });
+
+  test("first set requires the physiological fields", () => {
+    expect(() => setProfile(db, { goal_weight_kg: 80 })).toThrow(/birth_date/);
+  });
+
+  test("insert, partial update, clear goals", () => {
+    const p = setProfile(db, {
+      birth_date: "2000-01-15",
+      sex: "man",
+      height_cm: 180,
+      activity_factor: 1.5,
+      goal_weight_kg: 80,
+      goal_date: "2026-10-01",
+    });
+    expect(p.goal_weight_kg).toBe(80);
+    const upd = setProfile(db, { activity_factor: 1.6 });
+    expect(upd.activity_factor).toBe(1.6);
+    expect(upd.birth_date).toBe("2000-01-15");
+    expect(upd.goal_date).toBe("2026-10-01");
+    const cleared = setProfile(db, { goal_weight_kg: null, goal_date: null });
+    expect(cleared.goal_weight_kg).toBeNull();
+    expect(cleared.goal_date).toBeNull();
+  });
+
+  test("rejects malformed dates", () => {
+    expect(() =>
+      setProfile(db, { birth_date: "15/01/2000", sex: "man", height_cm: 180, activity_factor: 1.5 }),
+    ).toThrow(/datum/i);
+  });
+});

--- a/kcal-assistant/tests/profile.test.ts
+++ b/kcal-assistant/tests/profile.test.ts
@@ -41,4 +41,17 @@ describe("profile", () => {
       setProfile(db, { birth_date: "15/01/2000", sex: "man", height_cm: 180, activity_factor: 1.5 }),
     ).toThrow(/datum/i);
   });
+
+  test("rejects out-of-range physiological fields with Swedish messages", () => {
+    const base = { birth_date: "2000-01-15", height_cm: 180, activity_factor: 1.5 } as const;
+    expect(() => setProfile(db, { ...base, sex: "male" as never })).toThrow(/kön/);
+    expect(() => setProfile(db, { ...base, sex: "man", height_cm: -5 })).toThrow(/längd/i);
+    expect(() => setProfile(db, { ...base, sex: "man", activity_factor: 3.0 })).toThrow(
+      /aktivitetsfaktor/,
+    );
+    expect(() =>
+      setProfile(db, { ...base, sex: "man", goal_weight_kg: -1 }),
+    ).toThrow(/målvikt/);
+    expect(getProfile(db)).toBeNull();
+  });
 });

--- a/kcal-assistant/tests/recipes.test.ts
+++ b/kcal-assistant/tests/recipes.test.ts
@@ -188,3 +188,39 @@ describe("findRecipes / deleteRecipe", () => {
     expect(rows.n).toBe(0);
   });
 });
+
+describe("cooking times", () => {
+  function timeRecipe(extra: object) {
+    return saveRecipe(db, {
+      name: "Tidsrecept",
+      ingredients: [{ product_id: chickenId, grams: 100 }],
+      ...extra,
+    });
+  }
+
+  test("saves, partially updates and clears times", () => {
+    const r = timeRecipe({ active_minutes: 15, total_minutes: 45 });
+    expect(r.active_minutes).toBe(15);
+    expect(r.total_minutes).toBe(45);
+    const upd = saveRecipe(db, { id: r.id, name: r.name, total_minutes: 50 });
+    expect(upd.active_minutes).toBe(15);
+    expect(upd.total_minutes).toBe(50);
+    const cleared = saveRecipe(db, { id: r.id, name: r.name, active_minutes: null });
+    expect(cleared.active_minutes).toBeNull();
+    expect(cleared.total_minutes).toBe(50);
+  });
+
+  test("rejects invalid times, also after a partial merge", () => {
+    expect(() => timeRecipe({ active_minutes: -5 })).toThrow(/heltal/);
+    expect(() => timeRecipe({ total_minutes: 2.5 })).toThrow(/heltal/);
+    expect(() => timeRecipe({ active_minutes: 40, total_minutes: 30 })).toThrow(/total_minutes/);
+    const r = timeRecipe({ active_minutes: 20, total_minutes: 30 });
+    expect(() => saveRecipe(db, { id: r.id, name: r.name, total_minutes: 10 })).toThrow(/total_minutes/);
+  });
+
+  test("summaries include total_minutes", () => {
+    timeRecipe({ active_minutes: 10, total_minutes: 35 });
+    const summary = findRecipes(db, "Tidsrecept")[0]!;
+    expect(summary.total_minutes).toBe(35);
+  });
+});

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -63,7 +63,7 @@ describe("http routing", () => {
 });
 
 describe("mcp over streamable http", () => {
-  test("lists all 22 tools", async () => {
+  test("lists all 24 tools", async () => {
     const client = await connect();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
@@ -91,6 +91,8 @@ describe("mcp over streamable http", () => {
         "get_recipe",
         "find_recipes",
         "delete_recipe",
+        "set_profile",
+        "get_forecast",
       ].sort(),
     );
     await client.close();
@@ -188,6 +190,21 @@ describe("mcp over streamable http", () => {
       arguments: { name: "Trasig", items: [{ product_id: 99999, grams: 100 }] },
     });
     expect(result.isError).toBe(true);
+    await client.close();
+  });
+
+  test("set_profile -> get_forecast round-trips", async () => {
+    const client = await connect();
+    await client.callTool({
+      name: "set_profile",
+      arguments: { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 },
+    });
+    await client.callTool({ name: "log_weight", arguments: { weight_kg: 82 } });
+    const res = await client.callTool({ name: "get_forecast", arguments: {} });
+    const body = JSON.parse((res.content as Array<{ text: string }>)[0]!.text);
+    expect(body.forecast.goal.weight_kg).toBe(80);
+    expect(body.forecast.curve.length).toBeGreaterThan(40); // weekly points over 365 days
+    expect(body.forecast.curve.length).toBeLessThan(60);
     await client.close();
   });
 });

--- a/kcal-assistant/tests/ui-api.test.ts
+++ b/kcal-assistant/tests/ui-api.test.ts
@@ -8,6 +8,7 @@ import { saveProduct } from "../src/db/products";
 import { logMeal } from "../src/db/meals";
 import { logWeight } from "../src/db/weights";
 import { saveRecipe } from "../src/db/recipes";
+import { setProfile } from "../src/db/profile";
 
 const TOKEN = "test-token";
 let httpServer: Server;
@@ -147,5 +148,25 @@ describe("read-only UI API", () => {
     // MCP and healthz unaffected
     expect((await fetch(`http://127.0.0.1:${port}/healthz`)).status).toBe(200);
     await new Promise((r) => closed.close(r));
+  });
+
+  test("forecast without profile returns a reason", async () => {
+    const body = await (await get("/ui/api/forecast")).json();
+    expect(body.forecast).toBeNull();
+    expect(body.reason).toContain("profil");
+  });
+
+  test("forecast with profile returns the full daily curve", async () => {
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    const res = await get("/ui/api/forecast?source=targets");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.forecast.curve.length).toBeGreaterThan(300);
+    expect(body.forecast.assumptions.intake_source).toBe("targets");
+    expect(body.forecast.goal.weight_kg).toBe(80);
+  });
+
+  test("forecast rejects an unknown source", async () => {
+    expect((await get("/ui/api/forecast?source=x")).status).toBe(400);
   });
 });

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.5.1
+          image: rutbergphilip/kcal-assistant:v0.6.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
## Summary

Two new features for the Kcal DB (MCP + UI), spec in `docs/superpowers/specs/2026-07-09-kcal-time-and-forecast-design.md`:

### Tillagningstid
- `recipes.active_minutes` / `total_minutes` (migration 4, nullable, merged-value validation `total >= active`)
- `save_recipe` instructs Claude to always estimate both times from ingredients/instructions
- UI: `~X min` in the recipe list, `Tid` tile in the detail view

### Viktprognos
- Single-row `profile` table + `set_profile` tool (partial upsert, Swedish validation, defense-in-depth with zod + SQLite CHECKs)
- `src/lib/forecast.ts`: pure calibrated adaptive simulation — Mifflin-St Jeor BMR recomputed daily on the simulated weight × activity factor, calibrated against the measured backwards-TDEE (clamped ±500), daily Euler step at 7700 kcal/kg, ±150 kcal/day uncertainty band, 40 kg sanity floor, 365-day horizon, 7-day start smoothing
- Intake sources: plan targets weighted by observed day-type mix (default), 28-day logged average, or explicit override
- `get_forecast` MCP tool (weekly curve; 24 tools total) — chat can answer "vad väger jag 1 september?" and "när når jag målvikten?"
- `GET /ui/api/forecast` (read-only, full daily curve) + Vikt page: dashed low-opacity projection with translucent band over the full-opacity weight series, goal weight/goal date/ETA markers, real-time date picker (client-side curve lookup), intake-source toggle

## Verification
- 148/148 tests (`bun test`), `tsc --noEmit` clean
- Forecast math hand-verified (reference profile TDEE = 15w + 1500; all 10 asserted values re-derived in review)
- Live dev-server smoke check: no-profile reason, seeded 367-point curve with goal ETA + prediction at goal date, static assets
- Migration 4 is purely additive DDL — safe on the live v3 database

## Post-merge
Start a NEW chat (connector caches the tool list per conversation), then `set_profile` once and backfill recipe times via `find_recipes` → `save_recipe`.