### PR TITLE
feat(kcal-assistant): v0.7.1 — aktivitetsnivå som namngivna val

### DIFF
--- a/docs/superpowers/specs/2026-07-10-kcal-activity-levels-design.md
+++ b/docs/superpowers/specs/2026-07-10-kcal-activity-levels-design.md
@@ -1,0 +1,42 @@
+# kcal-assistant v0.7.1 — Aktivitetsnivå som namngivna val
+
+Date: 2026-07-10. Status: approved (design presented and accepted verbatim).
+Scope: UI-only patch; one file (`src/ui/static/app.js`) + version bump.
+
+Philip's feedback: the raw aktivitetsfaktor number input (1.2 etc.) is unclear;
+he wants named levels ("stillasittande" osv).
+
+## Change
+
+In `buildPrognosPanel`, the aktivitetsfaktor `number` input becomes a `select`
+labeled **Aktivitetsnivå** with the five canonical levels (same scale
+`set_profile`'s tool description documents):
+
+- stillasittande (1,2) → 1.2 — "kontorsjobb, lite eller ingen träning"
+- lätt aktiv (1,375) → 1.375 — "lätt träning 1–3 dagar i veckan"
+- måttligt aktiv (1,55) → 1.55 — "träning 3–5 dagar i veckan"
+- mycket aktiv (1,725) → 1.725 — "hård träning 6–7 dagar i veckan"
+- extremt aktiv (1,9) → 1.9 — "mycket hård träning och fysiskt arbete"
+
+Labels show name + factor (comma-decimal, sv-SE); option values stay
+dot-decimal numerics sent to the API unchanged. A small description line
+(k-sub style) under the select shows the selected level's example (per
+Philip's follow-up: "typ gym 3–5 dagar i veckan") and updates on change;
+for "anpassad" it reads "eget värde satt via chatten". Selecting a level previews
+live (same `state.overrides.activity` + debounce path) and Spara persists the
+numeric factor. No server, API, or MCP changes — chat can still set any
+1.2–2.5 factor.
+
+## Non-preset stored values
+
+If the stored factor isn't one of the five presets (Philip's current 1.5),
+the select shows a **disabled, selected** "anpassad (1,5)" option so the UI
+displays the saved truth; choosing any named level replaces it and the
+anpassad entry can't be re-selected. With no profile, a disabled
+"välj nivå …" placeholder with empty value keeps the existing
+first-save semantics (activity omitted from the PUT until chosen;
+`setProfile`'s Swedish first-insert error already covers it).
+
+## Out of scope
+
+Any change to `set_profile`, the forecast endpoints, or the stored data model.

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/ui/static/app.js
+++ b/kcal-assistant/src/ui/static/app.js
@@ -444,7 +444,45 @@ function buildPrognosPanel(panelHost, chartHost, resultHost, series, state, prof
   };
 
   // What-if row: previews live; everything except intag persists via Spara
-  const activityInput = num(profile ? profile.activity_factor : "", 1.2, 2.5, 0.05, (v) => { state.overrides.activity = v; preview(); });
+  const ACTIVITY_LEVELS = [
+    ["1.2", "stillasittande (1,2)", "kontorsjobb, lite eller ingen träning"],
+    ["1.375", "lätt aktiv (1,375)", "lätt träning 1–3 dagar i veckan"],
+    ["1.55", "måttligt aktiv (1,55)", "träning 3–5 dagar i veckan"],
+    ["1.725", "mycket aktiv (1,725)", "hård träning 6–7 dagar i veckan"],
+    ["1.9", "extremt aktiv (1,9)", "mycket hård träning och fysiskt arbete"],
+  ];
+  const activityInput = el("select");
+  const activityDesc = el("div", "k-sub");
+  const storedAf = profile ? String(profile.activity_factor) : "";
+  if (!hasProfile) {
+    const opt = el("option", "", "välj nivå …");
+    opt.value = "";
+    opt.disabled = true;
+    activityInput.append(opt);
+  } else if (!ACTIVITY_LEVELS.some(([v]) => v === storedAf)) {
+    // Saved factor isn't a preset (set via chatten): show the truth,
+    // non-reselectable once the user picks a named level.
+    const opt = el("option", "", `anpassad (${sv(profile.activity_factor)})`);
+    opt.value = storedAf;
+    opt.disabled = true;
+    activityInput.append(opt);
+  }
+  for (const [value, label] of ACTIVITY_LEVELS) {
+    const opt = el("option", "", label);
+    opt.value = value;
+    activityInput.append(opt);
+  }
+  activityInput.value = storedAf;
+  const showActivityDesc = () => {
+    const level = ACTIVITY_LEVELS.find(([v]) => v === activityInput.value);
+    activityDesc.textContent = level ? level[2] : hasProfile ? "eget värde satt via chatten" : "";
+  };
+  activityInput.addEventListener("change", () => {
+    state.overrides.activity = activityInput.value;
+    showActivityDesc();
+    preview();
+  });
+  showActivityDesc();
   const intakeInput = num("", 500, 10000, 50, (v) => { state.overrides.intake = v; preview(); });
   intakeInput.placeholder = "auto";
   const goalInput = num(profile ? profile.goal_weight_kg : "", 1, 500, 0.5, (v) => { state.overrides.goal = v; preview(); });
@@ -453,9 +491,11 @@ function buildPrognosPanel(panelHost, chartHost, resultHost, series, state, prof
   if (profile && profile.goal_date) goalDateInput.value = profile.goal_date;
   goalDateInput.addEventListener("input", () => { state.overrides.goal_date = goalDateInput.value; preview(); });
 
+  const activityField = field("Aktivitetsnivå", activityInput);
+  activityField.append(activityDesc);
   const row = el("div", "settings-row");
   row.append(
-    field("Aktivitetsfaktor", activityInput),
+    activityField,
     field("Intag (what-if)", intakeInput),
     field("Målvikt kg", goalInput),
     field("Måldatum", goalDateInput),

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.7.0
+          image: rutbergphilip/kcal-assistant:v0.7.1
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
Philip's feedback on v0.7.0: the raw aktivitetsfaktor number (1.2 …) is unclear.

The number input is now a select of the five canonical levels with concrete examples shown under it (updates live):

- stillasittande (1,2) — kontorsjobb, lite eller ingen träning
- lätt aktiv (1,375) — lätt träning 1–3 dagar i veckan
- måttligt aktiv (1,55) — träning 3–5 dagar i veckan
- mycket aktiv (1,725) — hård träning 6–7 dagar i veckan
- extremt aktiv (1,9) — mycket hård träning och fysiskt arbete

Non-preset stored factors (e.g. 1.5 set via chatten) show as a disabled "anpassad (1,5)" entry so the UI never lies; picking a named level replaces it. UI-only — set_profile/MCP/forecast untouched. Suite 163/163, tsc clean, dev-server asset check passed. Spec: docs/superpowers/specs/2026-07-10-kcal-activity-levels-design.md