### PR TITLE
feat(kcal-assistant): v0.9.0 — prognosmotor v2

### DIFF
--- a/docs/superpowers/plans/2026-07-10-kcal-forecast-engine-v2.md
+++ b/docs/superpowers/plans/2026-07-10-kcal-forecast-engine-v2.md
@@ -1,0 +1,1387 @@
+# kcal-assistant v0.9.0 — Prognosmotor v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Trend-weight smoothing (EWMA), a data-driven uncertainty band with goal-ETA ranges, persisted forecast snapshots with accuracy tracking, and pinned scenario comparison on the Vikt page.
+
+**Architecture:** All math is pure functions in `kcal-assistant/src/lib/` (fixture-tested, no db). `db/forecast.ts` orchestrates: resolves intake, snapshots canonical forecasts (migration 5 table), attaches accuracy/ghost to the view. The React UI (bun-bundled) renders trend line + dots, träffsäkerhet tiles, a ghost overlay, and up to two pinned what-if scenarios.
+
+**Tech Stack:** Bun + TypeScript, bun:sqlite, `bun test`, MCP SDK (zod schemas), React 19 + Radix bundled via `bun build --production`.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md` (approved). Branch: `kcal-forecast-engine-v2`.
+
+## Global Constraints
+
+- All commands run from `kcal-assistant/` unless stated; repo root is `homelab/`.
+- Swedish user-facing copy (UI text, error strings, forecast notes). Code/comments in English.
+- No new MCP tools (count stays 24); no input-schema changes. Exactly ONE description string changes: `get_forecast`'s "±150 kcal/dag" wording (spec scope note).
+- Test fixtures must be obviously synthetic (100 kg range etc.) — public repo, no real weights.
+- Migrations are append-only, tracked via `PRAGMA user_version` (this release adds #5).
+- UI bundle: `bun run build:ui` (has `--production`; NEVER build without it — dev jsx runtime breaks prod React silently).
+- Commit style: `feat(kcal-assistant): …` / `test(kcal-assistant): …`; end commit bodies with the Claude-Session trailer used on this branch.
+- Full suite `bun test` must pass at every commit.
+
+---
+
+### Task 1: EWMA trend weight (`computeTrendWeight`)
+
+**Files:**
+- Modify: `kcal-assistant/src/lib/trend.ts`
+- Test: `kcal-assistant/tests/trend.test.ts`
+
+**Interfaces:**
+- Consumes: existing `WeightEntry { date, weight_kg }`, `toEpochDays` from `lib/dates`.
+- Produces: `export interface TrendWeightPoint { date: string; weight_kg: number; trend_kg: number }` and `export function computeTrendWeight(weights: WeightEntry[]): TrendWeightPoint[]` — Tasks 2, 7, 8, 9 import these exact names.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/trend.test.ts`:
+
+```ts
+import { computeTrendWeight } from "../src/lib/trend";
+
+describe("computeTrendWeight", () => {
+  test("single weigh-in: trend equals the weight", () => {
+    expect(computeTrendWeight([{ date: "2026-06-01", weight_kg: 100 }])).toEqual([
+      { date: "2026-06-01", weight_kg: 100, trend_kg: 100 },
+    ]);
+  });
+
+  test("1-day gap uses alpha 0.1", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-01", weight_kg: 100 },
+      { date: "2026-06-02", weight_kg: 99 },
+    ]);
+    expect(out[1]!.trend_kg).toBe(99.9); // 100 + 0.1·(99−100)
+  });
+
+  test("7-day gap uses alpha 1−0.9^7", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-01", weight_kg: 100 },
+      { date: "2026-06-08", weight_kg: 99 },
+    ]);
+    expect(out[1]!.trend_kg).toBe(99.48); // 100 − (1−0.4782969) = 99.4782969
+  });
+
+  test("trend lags a falling series (stays above raw)", () => {
+    const weights = [0, 1, 2, 3, 4].map((i) => ({
+      date: addDays("2026-06-01", i), weight_kg: 100 - i * 0.5,
+    }));
+    const out = computeTrendWeight(weights);
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]!.trend_kg).toBeGreaterThan(out[i]!.weight_kg);
+    }
+  });
+
+  test("unsorted input is sorted by date", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-02", weight_kg: 99 },
+      { date: "2026-06-01", weight_kg: 100 },
+    ]);
+    expect(out.map((p) => p.date)).toEqual(["2026-06-01", "2026-06-02"]);
+    expect(out[1]!.trend_kg).toBe(99.9);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/trend.test.ts`
+Expected: FAIL — `computeTrendWeight` is not exported.
+
+- [ ] **Step 3: Implement** — append to `src/lib/trend.ts`:
+
+```ts
+// Hacker's Diet-style exponential smoothing for irregular weigh-ins:
+//   trend += α_eff · (weight − trend),  α_eff = 1 − 0.9^gap_days (α = 0.10/day).
+// The running trend is kept unrounded; only the output is rounded.
+const ALPHA_DAILY = 0.1;
+
+export interface TrendWeightPoint {
+  date: string;
+  weight_kg: number;
+  trend_kg: number;
+}
+
+export function computeTrendWeight(weights: WeightEntry[]): TrendWeightPoint[] {
+  const sorted = [...weights].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const out: TrendWeightPoint[] = [];
+  let trend: number | null = null;
+  let prevEpoch = 0;
+  for (const w of sorted) {
+    const epoch = toEpochDays(w.date);
+    if (trend === null) {
+      trend = w.weight_kg;
+    } else {
+      const alphaEff = 1 - Math.pow(1 - ALPHA_DAILY, Math.max(1, epoch - prevEpoch));
+      trend += alphaEff * (w.weight_kg - trend);
+    }
+    prevEpoch = epoch;
+    out.push({ date: w.date, weight_kg: w.weight_kg, trend_kg: round2(trend) });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bun test tests/trend.test.ts`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/trend.ts tests/trend.test.ts
+git commit -m "feat(kcal-assistant): EWMA trendvikt (computeTrendWeight)"
+```
+
+---
+
+### Task 2: Forecast starts from the trend weight
+
+**Files:**
+- Modify: `kcal-assistant/src/lib/forecast.ts` (start computation, `ForecastResult.start`)
+- Test: `kcal-assistant/tests/forecast.test.ts`
+
+**Interfaces:**
+- Consumes: `computeTrendWeight` from Task 1.
+- Produces: `ForecastResult.start` becomes `{ date: string; weight_kg: number; stale: boolean }` — `weighins_smoothed` is REMOVED. Later tasks and the UI type (Task 9) rely on this exact shape.
+
+- [ ] **Step 1: Update the existing start test** — in `tests/forecast.test.ts`, replace the test `"start smooths weigh-ins within 7 days of the latest"` (and its `weighins_smoothed` assertion) with:
+
+```ts
+  test("start is the EWMA trend weight at the latest weigh-in", () => {
+    const f = run({ weights: [W("2026-07-02", 82.4), W("2026-07-06", 82.0), W(TODAY, 81.6)] });
+    // trend: 82.4 → +0.3439·(82−82.4)=82.26244 → +0.271·(81.6−82.26244)=82.08292
+    expect(f.start.weight_kg).toBe(82.08);
+    expect(f.start.date).toBe(TODAY);
+    expect("weighins_smoothed" in f.start).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — start.weight_kg is 82 (7-day mean), `weighins_smoothed` still present.
+
+- [ ] **Step 3: Implement** — in `src/lib/forecast.ts`:
+  - Add import: `import { computeTrendWeight } from "./trend";`
+  - Change `start` in the `ForecastResult` interface to `start: { date: string; weight_kg: number; stale: boolean };`
+  - Replace the start computation block (the `recent`/`startKg` lines) with:
+
+```ts
+  // Start = EWMA trend weight at the latest weigh-in (lib/trend.ts); the
+  // simulation still starts at the latest weigh-in DATE so a stale log gets
+  // its elapsed days simulated too.
+  const startKg = computeTrendWeight(sorted).at(-1)!.trend_kg;
+  const stale = toEpochDays(input.today) - toEpochDays(latest.date) > 7;
+  if (stale) notes.push("senaste vägningen är över en vecka gammal");
+```
+
+  - In the returned object, `start` becomes `{ date: latest.date, weight_kg: round2(startKg), stale }`.
+  - Update the module header comment's "±150 kcal/day" sentence later in Task 3 (leave for now).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS. (`ui-api.test.ts` and others never asserted `weighins_smoothed`; only the test updated in Step 1 did.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/forecast.ts tests/forecast.test.ts
+git commit -m "feat(kcal-assistant): prognosstart från trendvikt i stället för 7-dagarssnitt"
+```
+
+---
+
+### Task 3: Data-driven uncertainty band (`computeBand`)
+
+**Files:**
+- Modify: `kcal-assistant/src/lib/forecast.ts`
+- Test: `kcal-assistant/tests/forecast.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export interface BandInput { calibration: "mätdata" | "formel"; intake_source: "targets" | "recent" | "explicit"; weighins_last_28d: number }`
+  - `export function computeBand(input: BandInput): { kcal: number; reasons: string[] }`
+  - `ForecastResult.assumptions` gains `band_kcal: number`.
+- Consumed by: Task 5 (snapshot stores `band_kcal`), Task 9 (UI type).
+
+- [ ] **Step 1: Write failing tests** — append to `tests/forecast.test.ts`:
+
+```ts
+import { computeBand } from "../src/lib/forecast";
+
+describe("computeBand", () => {
+  test("best case: mätdata + recent + tät vägning = 175", () => {
+    const b = computeBand({ calibration: "mätdata", intake_source: "recent", weighins_last_28d: 20 });
+    expect(b.kcal).toBe(175); // 100 + 50 + 25
+  });
+
+  test("mätdata + targets = 225", () => {
+    expect(computeBand({ calibration: "mätdata", intake_source: "targets", weighins_last_28d: 20 }).kcal).toBe(225);
+  });
+
+  test("formel + targets + glest = 425 clamps to 400 and explains why", () => {
+    const b = computeBand({ calibration: "formel", intake_source: "targets", weighins_last_28d: 3 });
+    expect(b.kcal).toBe(400);
+    expect(b.reasons.join(" ")).toContain("formelkalibrering");
+    expect(b.reasons.join(" ")).toContain("glesa vägningar");
+  });
+
+  test("explicit intake counts as plan adherence (+75)", () => {
+    expect(computeBand({ calibration: "formel", intake_source: "explicit", weighins_last_28d: 20 }).kcal).toBe(375);
+  });
+});
+
+describe("band integration", () => {
+  test("assumptions.band_kcal reflects the budget and a note explains it", () => {
+    const f = run(); // explicit + formel + 1 weigh-in → 100+200+75+50 = 425 → 400
+    expect(f.assumptions.band_kcal).toBe(400);
+    expect(f.notes.join(" ")).toContain("±400");
+  });
+
+  test("band width drives the envelope", () => {
+    const wide = run(); // band 400
+    // 10 weigh-ins 2026-06-21 … 2026-07-07 (step 2) + TODAY = 11 within 28 d, no duplicate dates.
+    const dense = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18].map((i) =>
+      W(addDays("2026-06-21", i), 82));
+    const narrow = run({ weights: [...dense, W(TODAY, 82)], measured_tdee: 2500 }); // band 100+50+75 = 225
+    expect(narrow.assumptions.band_kcal).toBe(225);
+    expect(wide.curve[30]!.high - wide.curve[30]!.low)
+      .toBeGreaterThan(narrow.curve[30]!.high - narrow.curve[30]!.low);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — `computeBand` not exported.
+
+- [ ] **Step 3: Implement** — in `src/lib/forecast.ts`:
+  - Replace `const BAND_KCAL = 150;` with:
+
+```ts
+// Error budget for the uncertainty band: named kcal contributions summed and
+// clamped. The single place a future empirical calibration (from
+// forecast_snapshots history) would slot in.
+const BAND_MIN = 125;
+const BAND_MAX = 400;
+
+export interface BandInput {
+  calibration: "mätdata" | "formel";
+  intake_source: "targets" | "recent" | "explicit";
+  weighins_last_28d: number;
+}
+
+export function computeBand(input: BandInput): { kcal: number; reasons: string[] } {
+  let kcal = 100;
+  const reasons: string[] = ["grundosäkerhet"];
+  if (input.calibration === "mätdata") {
+    kcal += 50;
+    reasons.push("mätdatakalibrerad");
+  } else {
+    kcal += 200;
+    reasons.push("formelkalibrering (ingen tillförlitlig mätdata)");
+  }
+  if (input.intake_source === "recent") {
+    kcal += 25;
+    reasons.push("intag från uppmätt beteende");
+  } else {
+    kcal += 75;
+    reasons.push("intag antar framtida följsamhet");
+  }
+  if (input.weighins_last_28d < 10) {
+    kcal += 50;
+    reasons.push("glesa vägningar (<10 på 28 d)");
+  }
+  return { kcal: Math.min(BAND_MAX, Math.max(BAND_MIN, kcal)), reasons };
+}
+```
+
+  - In `computeForecast`, after the calibration block, add:
+
+```ts
+  const weighinsLast28 = sorted.filter(
+    (w) => toEpochDays(latest.date) - toEpochDays(w.date) <= 27,
+  ).length;
+  const band = computeBand({
+    calibration,
+    intake_source: input.intake_source,
+    weighins_last_28d: weighinsLast28,
+  });
+  notes.push(`osäkerhet ±${band.kcal} kcal/dag: ${band.reasons.join(", ")}`);
+```
+
+  - Change the low/high sims to use `band.kcal` instead of `BAND_KCAL`.
+  - Add `band_kcal: band.kcal,` to `assumptions` in both the interface (`band_kcal: number;`) and the returned object.
+  - Update the module header comment: "A ±150 kcal/day re-run" → "A ±band re-run (data-driven error budget, computeBand)".
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS. If any pre-existing test asserted on `notes` being empty or exact, update it to accommodate the new band note (check `forecast.test.ts` and `ui-api.test.ts` output assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/forecast.ts tests/forecast.test.ts
+git commit -m "feat(kcal-assistant): datadrivet osäkerhetsband (error budget) i prognosen"
+```
+
+---
+
+### Task 4: Goal-ETA range from the envelope curves
+
+**Files:**
+- Modify: `kcal-assistant/src/lib/forecast.ts`
+- Test: `kcal-assistant/tests/forecast.test.ts`
+
+**Interfaces:**
+- Produces: `ForecastResult.goal` gains `eta_range: { earliest: string | null; latest: string | null }` — present whenever `goal` is non-null. Task 9's UI type and Task 11's tiles rely on this exact shape.
+
+- [ ] **Step 1: Write failing tests** — append inside the existing `describe("computeForecast", ...)`:
+
+```ts
+  test("eta_range brackets the point ETA", () => {
+    const f = run(); // goal 80, eta day 13, band 400
+    const r = f.goal!.eta_range;
+    expect(r.earliest).not.toBeNull();
+    expect(r.latest).not.toBeNull();
+    expect(r.earliest! < f.goal!.eta!).toBe(true); // ISO strings compare correctly
+    expect(f.goal!.eta! < r.latest!).toBe(true);
+  });
+
+  test("latest is null when the high curve misses the horizon", () => {
+    const f = run({ horizon_days: 14 }); // main hits day 13, low ~day 10, high ~day 19
+    expect(f.goal!.eta).not.toBeNull();
+    expect(f.goal!.eta_range.earliest).not.toBeNull();
+    expect(f.goal!.eta_range.latest).toBeNull();
+  });
+
+  test("moving away from the goal gives an all-null range", () => {
+    const f = run({ intake_kcal: 4000 }); // surplus, goal below start
+    expect(f.goal!.eta).toBeNull();
+    expect(f.goal!.eta_range).toEqual({ earliest: null, latest: null });
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — `eta_range` undefined.
+
+- [ ] **Step 3: Implement** — in `src/lib/forecast.ts`:
+  - In the `goal` type inside `ForecastResult`, change to:
+
+```ts
+  goal: {
+    weight_kg: number;
+    eta: string | null;
+    eta_range: { earliest: string | null; latest: string | null };
+    reached: boolean;
+    reason?: string;
+  } | null;
+```
+
+  - In the goal block, extend the non-reached branch (the raw `lowSim`/`highSim` arrays are in scope; their kg values are unrounded, which is fine for threshold scanning):
+
+```ts
+      const etaOn = (pts: Array<{ date: string; kg: number }>): string | null =>
+        movingToward ? (pts.find((p) => hit(p.kg))?.date ?? null) : null;
+      const etaLow = etaOn(lowSim);
+      const etaHigh = etaOn(highSim);
+      const eta_range =
+        etaLow !== null && etaHigh !== null
+          ? etaLow <= etaHigh
+            ? { earliest: etaLow, latest: etaHigh }
+            : { earliest: etaHigh, latest: etaLow }
+          : { earliest: etaLow ?? etaHigh, latest: null };
+```
+
+    and include `eta_range` in the returned goal object. The `reached` branch returns `eta_range: { earliest: null, latest: null }`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/forecast.ts tests/forecast.test.ts
+git commit -m "feat(kcal-assistant): mål-ETA som intervall från osäkerhetskurvorna"
+```
+
+---
+
+### Task 5: Migration 5 + snapshot storage
+
+**Files:**
+- Modify: `kcal-assistant/src/db/migrations.ts`
+- Create: `kcal-assistant/src/db/snapshots.ts`
+- Test: `kcal-assistant/tests/snapshots.test.ts` (new)
+
+**Interfaces:**
+- Produces (Tasks 6–8 import these exact names):
+  - `export interface SnapshotRow { date: string; start_date: string; start_kg: number; intake_kcal: number; intake_source: string; tdee_start: number; calibration_offset: number; band_kcal: number; curve: ForecastPoint[] }`
+  - `export function saveSnapshot(db: Database, forecast: ForecastResult, today: string): void`
+  - `export function listSnapshots(db: Database): SnapshotRow[]` (ascending by date)
+
+- [ ] **Step 1: Write failing tests** — create `tests/snapshots.test.ts`:
+
+```ts
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveSnapshot, listSnapshots } from "../src/db/snapshots";
+import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+
+// Synthetic fixtures only — public repo.
+const PROFILE: ForecastProfile = {
+  birth_date: "2000-01-15", sex: "man", height_cm: 180,
+  activity_factor: 1.5, goal_weight_kg: 80, goal_date: null,
+};
+
+function makeForecast(intake: number) {
+  return computeForecast({
+    profile: PROFILE,
+    weights: [{ date: "2026-07-09", weight_kg: 82 }],
+    intake_kcal: intake, intake_source: "explicit",
+    measured_tdee: null, today: "2026-07-09",
+  });
+}
+
+describe("forecast snapshots", () => {
+  let db: Database;
+  beforeEach(() => { db = openDb(":memory:"); });
+
+  test("save + list roundtrips with a weekly curve", () => {
+    saveSnapshot(db, makeForecast(1500), "2026-07-09");
+    const rows = listSnapshots(db);
+    expect(rows).toHaveLength(1);
+    const s = rows[0]!;
+    expect(s.date).toBe("2026-07-09");
+    expect(s.start_kg).toBe(82);
+    expect(s.intake_kcal).toBe(1500);
+    expect(s.band_kcal).toBe(400);
+    expect(s.curve.length).toBeLessThan(60); // weekly, not daily (365)
+    expect(s.curve[0]).toMatchObject({ date: "2026-07-09", kg: 82 });
+  });
+
+  test("same-day save upserts (last write wins)", () => {
+    saveSnapshot(db, makeForecast(1500), "2026-07-09");
+    saveSnapshot(db, makeForecast(1600), "2026-07-09");
+    const rows = listSnapshots(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.intake_kcal).toBe(1600);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/snapshots.test.ts`
+Expected: FAIL — module `../src/db/snapshots` not found.
+
+- [ ] **Step 3: Implement**
+  - Append migration 5 to the `MIGRATIONS` array in `src/db/migrations.ts`:
+
+```ts
+  // 5: canonical forecast snapshots — one per day, weekly curve as JSON.
+  // Never pruned: the data is small and feeds accuracy tracking.
+  `
+  CREATE TABLE forecast_snapshots (
+    date               TEXT PRIMARY KEY,
+    created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    start_date         TEXT NOT NULL,
+    start_kg           REAL NOT NULL,
+    intake_kcal        INTEGER NOT NULL,
+    intake_source      TEXT NOT NULL,
+    tdee_start         INTEGER NOT NULL,
+    calibration_offset INTEGER NOT NULL,
+    band_kcal          INTEGER NOT NULL,
+    curve_json         TEXT NOT NULL
+  );
+  `,
+```
+
+  - Create `src/db/snapshots.ts`:
+
+```ts
+import type { Database } from "bun:sqlite";
+import type { ForecastPoint, ForecastResult } from "../lib/forecast";
+
+export interface SnapshotRow {
+  date: string;
+  start_date: string;
+  start_kg: number;
+  intake_kcal: number;
+  intake_source: string;
+  tdee_start: number;
+  calibration_offset: number;
+  band_kcal: number;
+  curve: ForecastPoint[];
+}
+
+// Weekly sampling mirrors get_forecast's token-lean curve.
+const weekly = (curve: ForecastPoint[]): ForecastPoint[] =>
+  curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+
+export function saveSnapshot(db: Database, forecast: ForecastResult, today: string): void {
+  db.run(
+    `INSERT INTO forecast_snapshots
+       (date, start_date, start_kg, intake_kcal, intake_source,
+        tdee_start, calibration_offset, band_kcal, curve_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET
+       created_at = datetime('now'),
+       start_date = excluded.start_date, start_kg = excluded.start_kg,
+       intake_kcal = excluded.intake_kcal, intake_source = excluded.intake_source,
+       tdee_start = excluded.tdee_start, calibration_offset = excluded.calibration_offset,
+       band_kcal = excluded.band_kcal, curve_json = excluded.curve_json`,
+    [
+      today, forecast.start.date, forecast.start.weight_kg,
+      forecast.assumptions.intake_kcal, forecast.assumptions.intake_source,
+      forecast.assumptions.tdee_start, forecast.assumptions.calibration_offset,
+      forecast.assumptions.band_kcal, JSON.stringify(weekly(forecast.curve)),
+    ],
+  );
+}
+
+export function listSnapshots(db: Database): SnapshotRow[] {
+  return db
+    .query<Omit<SnapshotRow, "curve"> & { curve_json: string }, []>(
+      `SELECT date, start_date, start_kg, intake_kcal, intake_source,
+              tdee_start, calibration_offset, band_kcal, curve_json
+       FROM forecast_snapshots ORDER BY date`,
+    )
+    .all()
+    .map(({ curve_json, ...row }) => ({ ...row, curve: JSON.parse(curve_json) as ForecastPoint[] }));
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS (migration 5 applies in every test db via `openDb`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/migrations.ts src/db/snapshots.ts tests/snapshots.test.ts
+git commit -m "feat(kcal-assistant): migration 5 + forecast_snapshots-lagring"
+```
+
+---
+
+### Task 6: Canonical snapshot wiring (buildForecast + log_weight)
+
+**Files:**
+- Modify: `kcal-assistant/src/db/forecast.ts`, `kcal-assistant/src/tools/weights.ts`
+- Test: `kcal-assistant/tests/snapshots.test.ts`
+
+**Interfaces:**
+- Consumes: `saveSnapshot` (Task 5).
+- Produces: `buildForecast` snapshots canonical calls as a side effect. Canonical = no `target_date`/`goal_weight`/`intake_kcal`/`activity_factor`/`goal_date` override AND `intake_source` targets-or-absent. The `today` opt is allowed (dates the snapshot; tests use it).
+
+- [ ] **Step 1: Write failing tests** — append to `tests/snapshots.test.ts` (add imports `buildForecast` from `../src/db/forecast`, `setProfile` from `../src/db/profile`, `logWeight` from `../src/db/weights`):
+
+```ts
+describe("canonical snapshot wiring", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    logWeight(db, { weight_kg: 82, date: "2026-07-08" });
+  });
+
+  test("canonical buildForecast writes a snapshot", () => {
+    buildForecast(db, { today: "2026-07-09" });
+    expect(listSnapshots(db).map((s) => s.date)).toEqual(["2026-07-09"]);
+  });
+
+  test("preview calls never write", () => {
+    buildForecast(db, { today: "2026-07-09", intake_kcal: 1600 });
+    buildForecast(db, { today: "2026-07-09", intake_source: "recent" });
+    buildForecast(db, { today: "2026-07-09", activity_factor: 1.2 });
+    expect(listSnapshots(db)).toHaveLength(0);
+  });
+
+  test("snapshot failure never breaks the forecast", () => {
+    db.run("DROP TABLE forecast_snapshots");
+    const view = buildForecast(db, { today: "2026-07-09" });
+    expect(view.forecast).not.toBeNull();
+  });
+
+  test("no profile → no snapshot, no crash", () => {
+    const bare = openDb(":memory:");
+    logWeight(bare, { weight_kg: 82, date: "2026-07-08" });
+    expect(buildForecast(bare, { today: "2026-07-09" }).forecast).toBeNull();
+    expect(listSnapshots(bare)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/snapshots.test.ts`
+Expected: FAIL — no snapshot written by `buildForecast`.
+
+- [ ] **Step 3: Implement**
+  - In `src/db/forecast.ts`, import `saveSnapshot` from `./snapshots`; before `return { forecast };` add:
+
+```ts
+  // Canonical (no what-ifs, plan-based intake) forecasts are snapshotted for
+  // accuracy tracking — best-effort: a snapshot failure must never break the
+  // forecast (or a log_weight that triggered it).
+  const canonical =
+    opts.target_date === undefined &&
+    opts.goal_weight === undefined &&
+    opts.intake_kcal === undefined &&
+    opts.activity_factor === undefined &&
+    opts.goal_date === undefined &&
+    (opts.intake_source ?? "targets") === "targets";
+  if (canonical) {
+    try {
+      saveSnapshot(db, forecast, today);
+    } catch (e) {
+      console.error("snapshot:", e instanceof Error ? e.message : e);
+    }
+  }
+```
+
+  - In `src/tools/weights.ts`, the `log_weight` handler triggers a canonical forecast so history accumulates from weigh-ins alone (import `buildForecast` from `../db/forecast` — tools layer, so no db-module import cycle):
+
+```ts
+    wrap((input) => {
+      const view = logWeight(db, input);
+      try {
+        buildForecast(db); // canonical → snapshot; best-effort by construction
+      } catch (e) {
+        console.error("snapshot after log_weight:", e instanceof Error ? e.message : e);
+      }
+      return jsonResult(view);
+    }),
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS. Note: `ui-api.test.ts` and `forecast.test.ts` call `buildForecast` canonically in places — they will now also write snapshot rows; that must not break any row-count assertions (the `TABLES` list in `ui-api.test.ts` doesn't include `forecast_snapshots`). If a test asserts exact `notes`, update for the band note.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/forecast.ts src/tools/weights.ts tests/snapshots.test.ts
+git commit -m "feat(kcal-assistant): kanoniska prognoser snapshotas (även vid log_weight)"
+```
+
+---
+
+### Task 7: Accuracy math (`lib/accuracy.ts`)
+
+**Files:**
+- Create: `kcal-assistant/src/lib/accuracy.ts`
+- Test: `kcal-assistant/tests/accuracy.test.ts` (new)
+
+**Interfaces:**
+- Produces (Task 8 imports these exact names):
+  - `export interface AccuracyBucket { days: number; n: number; mae_kg: number; bias_kg: number }`
+  - `export function computeForecastAccuracy(input: { snapshots: Array<{ date: string; curve: Array<{ date: string; kg: number }> }>; trendWeights: Array<{ date: string; trend_kg: number }>; today: string }): { per_age: AccuracyBucket[] } | null`
+  - `export function pickGhost<T extends { date: string }>(snapshots: T[], today: string): T | null`
+
+- [ ] **Step 1: Write failing tests** — create `tests/accuracy.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { computeForecastAccuracy, pickGhost } from "../src/lib/accuracy";
+import { addDays } from "../src/lib/dates";
+
+// Synthetic fixtures only — public repo.
+// Snapshot curve: linear 100 → falling 0.1 kg/day, weekly points over 8 weeks.
+function snapshotAt(date: string, startKg: number, lossPerDay = 0.1) {
+  const curve = [0, 7, 14, 21, 28, 35, 42, 49, 56].map((d) => ({
+    date: addDays(date, d), kg: startKg - d * lossPerDay,
+  }));
+  return { date, curve };
+}
+// Daily trend weights matching that exact line.
+function trendLine(start: string, days: number, startKg: number, lossPerDay = 0.1) {
+  return Array.from({ length: days }, (_, i) => ({
+    date: addDays(start, i), trend_kg: startKg - i * lossPerDay,
+  }));
+}
+const T0 = "2026-05-01";
+
+describe("computeForecastAccuracy", () => {
+  test("perfect forecasts give zero error", () => {
+    const snapshots = [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1));
+    const acc = computeForecastAccuracy({
+      snapshots, trendWeights: trendLine(T0, 40, 100), today: addDays(T0, 39),
+    })!;
+    const d7 = acc.per_age.find((b) => b.days === 7)!;
+    expect(d7.n).toBe(3);
+    expect(d7.mae_kg).toBe(0);
+    expect(d7.bias_kg).toBe(0);
+  });
+
+  test("optimistic forecasts show negative bias, mae positive", () => {
+    // Forecast says −0.2/day but reality is −0.1/day → predicted BELOW actual.
+    const snapshots = [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1, 0.2));
+    const acc = computeForecastAccuracy({
+      snapshots, trendWeights: trendLine(T0, 40, 100), today: addDays(T0, 39),
+    })!;
+    const d7 = acc.per_age.find((b) => b.days === 7)!;
+    expect(d7.bias_kg).toBeLessThan(0);
+    expect(d7.mae_kg).toBe(Math.abs(d7.bias_kg));
+  });
+
+  test("interpolates between weekly points (age 14+3 lands mid-week)", () => {
+    // A single snapshot, weigh-in exactly 17 days later only.
+    const acc = computeForecastAccuracy({
+      snapshots: [snapshotAt(T0, 100), snapshotAt(addDays(T0, 1), 99.9), snapshotAt(addDays(T0, 2), 99.8)],
+      trendWeights: [14, 15, 16, 17, 18].map((d) => ({ date: addDays(T0, d), trend_kg: 100 - d * 0.1 })),
+      today: addDays(T0, 30),
+    });
+    expect(acc).not.toBeNull();
+    expect(acc!.per_age.find((b) => b.days === 14)!.mae_kg).toBe(0);
+  });
+
+  test("no weigh-in within ±3 days → sample skipped; n<3 → bucket dropped; none → null", () => {
+    expect(computeForecastAccuracy({
+      snapshots: [snapshotAt(T0, 100)],
+      trendWeights: [{ date: addDays(T0, 20), trend_kg: 98 }],
+      today: addDays(T0, 60),
+    })).toBeNull(); // n=1 for 14/28... never ≥3 with one snapshot
+  });
+
+  test("future ages are excluded", () => {
+    const acc = computeForecastAccuracy({
+      snapshots: [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1)),
+      trendWeights: trendLine(T0, 12, 100),
+      today: addDays(T0, 11),
+    })!;
+    expect(acc.per_age.map((b) => b.days)).toEqual([7]); // 14/28/56 not aged yet
+  });
+});
+
+describe("pickGhost", () => {
+  const s = (d: string) => ({ date: d });
+  test("picks the snapshot nearest 28 days old, requiring ≥21", () => {
+    const today = "2026-06-30";
+    expect(pickGhost([s("2026-06-25"), s("2026-06-05"), s("2026-05-20")], today))
+      .toEqual(s("2026-06-05")); // ages: 5 (too young), 25, 41 → 25 nearest 28
+  });
+  test("null when nothing is old enough", () => {
+    expect(pickGhost([s("2026-06-25")], "2026-06-30")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/accuracy.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — create `src/lib/accuracy.ts`:
+
+```ts
+import { toEpochDays, addDays } from "./dates";
+
+// Measures how past forecast snapshots aged: for standard ages, the snapshot
+// curve (weekly points, linearly interpolated) is compared against the EWMA
+// trend weight nearest that date (±3 days). bias > 0 = forecasts ran heavy.
+
+export interface AccuracyBucket {
+  days: number;
+  n: number;
+  mae_kg: number;
+  bias_kg: number;
+}
+
+const AGES = [7, 14, 28, 56];
+const MATCH_TOLERANCE_DAYS = 3;
+const MIN_SAMPLES = 3;
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+export function computeForecastAccuracy(input: {
+  snapshots: Array<{ date: string; curve: Array<{ date: string; kg: number }> }>;
+  trendWeights: Array<{ date: string; trend_kg: number }>;
+  today: string;
+}): { per_age: AccuracyBucket[] } | null {
+  const per_age: AccuracyBucket[] = [];
+  for (const days of AGES) {
+    const errors: number[] = [];
+    for (const s of input.snapshots) {
+      const target = addDays(s.date, days);
+      if (target > input.today) continue;
+      const predicted = interpolate(s.curve, target);
+      if (predicted === null) continue;
+      const actual = nearestTrend(input.trendWeights, target);
+      if (actual === null) continue;
+      errors.push(predicted - actual);
+    }
+    if (errors.length >= MIN_SAMPLES) {
+      const mean = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length;
+      per_age.push({
+        days,
+        n: errors.length,
+        mae_kg: round2(mean(errors.map(Math.abs))),
+        bias_kg: round2(mean(errors)),
+      });
+    }
+  }
+  return per_age.length ? { per_age } : null;
+}
+
+function interpolate(curve: Array<{ date: string; kg: number }>, date: string): number | null {
+  const t = toEpochDays(date);
+  for (let i = 0; i < curve.length - 1; i++) {
+    const a = toEpochDays(curve[i]!.date);
+    const b = toEpochDays(curve[i + 1]!.date);
+    if (t >= a && t <= b) {
+      return a === b ? curve[i]!.kg : curve[i]!.kg + ((t - a) / (b - a)) * (curve[i + 1]!.kg - curve[i]!.kg);
+    }
+  }
+  return null; // outside the stored curve (e.g. sim stopped early)
+}
+
+function nearestTrend(
+  tw: Array<{ date: string; trend_kg: number }>,
+  date: string,
+): number | null {
+  const t = toEpochDays(date);
+  let best: number | null = null;
+  let bestD = Infinity;
+  for (const w of tw) {
+    const d = Math.abs(toEpochDays(w.date) - t);
+    if (d < bestD) {
+      bestD = d;
+      best = w.trend_kg;
+    }
+  }
+  return bestD <= MATCH_TOLERANCE_DAYS ? best : null;
+}
+
+// Ghost overlay candidate: the snapshot nearest 28 days old, at least 21.
+// Ascending input order means ties keep the older snapshot.
+export function pickGhost<T extends { date: string }>(snapshots: T[], today: string): T | null {
+  const t = toEpochDays(today);
+  let best: T | null = null;
+  let bestD = Infinity;
+  for (const s of snapshots) {
+    const age = t - toEpochDays(s.date);
+    if (age < 21) continue;
+    const d = Math.abs(age - 28);
+    if (d < bestD) {
+      bestD = d;
+      best = s;
+    }
+  }
+  return best;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bun test tests/accuracy.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/accuracy.ts tests/accuracy.test.ts
+git commit -m "feat(kcal-assistant): träffsäkerhetsmatematik (accuracy + ghost-val)"
+```
+
+---
+
+### Task 8: Surface accuracy + ghost + trend_kg through db and APIs
+
+**Files:**
+- Modify: `kcal-assistant/src/db/forecast.ts`, `kcal-assistant/src/db/weights.ts`, `kcal-assistant/src/tools/profile.ts`
+- Test: `kcal-assistant/tests/ui-api.test.ts`, `kcal-assistant/tests/weights.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ForecastView` (in `db/forecast.ts`) gains `accuracy?: { per_age: AccuracyBucket[] }` and `ghost?: { snapshot_date: string; curve: ForecastPoint[] }` — attached on every call (canonical or preview) when data qualifies, omitted otherwise.
+  - `db/weights.listWeights` rows gain `trend_kg: number`; `WeightTrendView.latest` gains `trend_kg: number`.
+  - `get_forecast` (MCP) passes `accuracy` through but **strips `ghost`** (token economy — chat never needs a second curve); its description's "±150 kcal/dag" becomes "datadrivet ±band, se assumptions.band_kcal".
+
+- [ ] **Step 1: Write failing tests**
+  - Create `tests/ui-api-forecast.test.ts` — its OWN db + server (copy the `beforeAll` server-boot pattern from `tests/ui-api.test.ts` verbatim: `openDb(":memory:")`, `createHttpServer({ token: "test-token", db, uiAuth: { mode: "dev-bypass" } })`, port 0, `base` from `AddressInfo`). Isolated on purpose: `ui-api.test.ts` has profile-lifecycle tests that must not inherit a pre-seeded profile. Seed in `beforeAll` after boot:
+
+```ts
+setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+logWeight(db, { weight_kg: 100, date: "2026-07-08" });
+```
+
+    Tests:
+
+```ts
+  test("weights payload includes trend_kg on rows and latest", async () => {
+    const res = await fetch(`${base}/ui/api/weights`, { headers: { accept: "application/json" } });
+    const body = await res.json();
+    expect(body.weights[0].trend_kg).toBeTypeOf("number");
+    expect(body.trend.latest.trend_kg).toBeTypeOf("number");
+  });
+
+  test("forecast payload omits accuracy/ghost when no aged snapshots exist", async () => {
+    const res = await fetch(`${base}/ui/api/forecast`, { headers: { accept: "application/json" } });
+    const body = await res.json();
+    expect(body.forecast).not.toBeNull();
+    expect(body.forecast.assumptions.band_kcal).toBeTypeOf("number");
+    expect(body.forecast.goal.eta_range).toBeDefined();
+    expect("accuracy" in body).toBe(false); // only today's own snapshot exists (age 0)
+    expect("ghost" in body).toBe(false);
+  });
+```
+
+  - Append to `tests/snapshots.test.ts` a NEW top-level describe with a FRESH db and strictly chronological weigh-ins (the wiring describe's `beforeEach` logs a 2026-07-08 weight, which would sit AFTER the backdated snapshot dates and corrupt their curves):
+
+```ts
+describe("aged snapshots", () => {
+  test("surface accuracy and ghost in the view", () => {
+    const db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    // Three backdated canonical snapshots, weights logged in date order.
+    for (const off of [-30, -29, -28]) {
+      const day = addDays("2026-07-09", off);
+      logWeight(db, { weight_kg: 82, date: day });
+      buildForecast(db, { today: day });
+    }
+    // Weigh-ins near each accuracy target (snap+7/14/28 within ±3 days).
+    for (const off of [-23, -16, -9, -2]) {
+      logWeight(db, { weight_kg: 82, date: addDays("2026-07-09", off) });
+    }
+    const view = buildForecast(db, { today: "2026-07-09" });
+    expect(view.forecast).not.toBeNull();
+    expect(view.accuracy).toBeDefined();
+    expect(view.accuracy!.per_age.find((b) => b.days === 7)!.n).toBe(3);
+    expect(view.ghost).toBeDefined();
+    expect(view.ghost!.snapshot_date).toBe(addDays("2026-07-09", -28)); // age 28 exactly
+  });
+});
+```
+
+    (add `import { addDays } from "../src/lib/dates";` to the test file)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/ui-api.test.ts tests/snapshots.test.ts`
+Expected: FAIL — `trend_kg` missing; `accuracy`/`ghost` missing.
+
+- [ ] **Step 3: Implement**
+  - `src/db/weights.ts`: import `computeTrendWeight`; change `WeightTrendView` and both functions:
+
+```ts
+export interface WeightTrendView extends Omit<TrendResult, "latest"> {
+  latest: (WeightEntry & { trend_kg: number }) | null;
+  weights: WeightEntry[]; // weighings inside the window, ascending
+}
+```
+
+    In `listWeights`, compute `const trendByDate = new Map(computeTrendWeight(rows).map((p) => [p.date, p.trend_kg]));` from the fetched rows and return `rows.map((r) => ({ ...r, trend_kg: trendByDate.get(r.date)! }))` (return type `Array<WeightEntry & { trend_kg: number; note: string | null }>`).
+    In `getTrend`, build the same map from `allWeights` and return `latest` as `result.latest ? { ...result.latest, trend_kg: trendByDate.get(result.latest.date)! } : null`.
+  - `src/db/forecast.ts`: import `computeTrendWeight` from `../lib/trend`, `computeForecastAccuracy, pickGhost, type AccuracyBucket` from `../lib/accuracy`, `listSnapshots` from `./snapshots`. Extend the view type:
+
+```ts
+export interface ForecastView {
+  forecast: ForecastResult | null;
+  reason?: string;
+  accuracy?: { per_age: AccuracyBucket[] };
+  ghost?: { snapshot_date: string; curve: ForecastResult["curve"] };
+}
+```
+
+    Replace `return { forecast };` (after the canonical-snapshot block from Task 6, so today's snapshot exists before we read — its age 0 excludes it from ghost/accuracy anyway):
+
+```ts
+  // Accuracy + ghost ride on every response (previews too — same read cost),
+  // omitted entirely when no snapshot has aged enough.
+  const snapshots = listSnapshots(db);
+  const accuracy = computeForecastAccuracy({
+    snapshots, trendWeights: computeTrendWeight(weights), today,
+  });
+  const ghostSnap = pickGhost(snapshots, today);
+  return {
+    forecast,
+    ...(accuracy !== null && { accuracy }),
+    ...(ghostSnap !== null && { ghost: { snapshot_date: ghostSnap.date, curve: ghostSnap.curve } }),
+  };
+```
+
+  - `src/tools/profile.ts` — `get_forecast` handler keeps `accuracy`, strips `ghost`, and the description swaps "an uncertainty band (±150 kcal/dag)" for "an uncertainty band (datadrivet ±band, se assumptions.band_kcal) with goal.eta_range":
+
+```ts
+    wrap((input) => {
+      const view = buildForecast(db, input);
+      if (!view.forecast) return jsonResult(view);
+      // Token-lean for the chat: weekly points, and no ghost curve.
+      const { curve, ...rest } = view.forecast;
+      const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+      return jsonResult({
+        forecast: { ...rest, curve: weekly },
+        ...(view.accuracy && { accuracy: view.accuracy }),
+      });
+    }),
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/forecast.ts src/db/weights.ts src/tools/profile.ts tests/ui-api.test.ts tests/snapshots.test.ts
+git commit -m "feat(kcal-assistant): accuracy/ghost i prognossvaret + trend_kg i viktdata"
+```
+
+---
+
+### Task 9: UI foundation — types, trend line + dots, hover with both values
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/api.ts`, `kcal-assistant/src/ui/app/lib/chart.ts`, `kcal-assistant/src/ui/app/components/WeightChart.tsx`, `kcal-assistant/src/ui/static/app.css`
+- Test: `kcal-assistant/tests/chart.test.ts`
+
+**Interfaces:**
+- Consumes: server payloads from Task 8.
+- Produces (Tasks 10–11 rely on these):
+  - `api.ts`: `Weight` gains `trend_kg: number`; `Forecast.assumptions` gains `band_kcal: number`; `Forecast.goal` gains `eta_range: { earliest: string | null; latest: string | null }`; `Forecast.start` loses nothing (already minimal); new `AccuracyBucket`; `ForecastView` gains `accuracy?/ghost?`.
+  - `chart.ts`: `ActualPt` becomes `{ t: number; kg: number; trend: number }`; `HoverHit` actual variant gains `trend: number`.
+  - `WeightChart` props: `{ series: Weight[]; forecast: Forecast | null; ghost?: { snapshot_date: string; curve: ForecastPoint[] } | null; scenarios?: Array<{ slot: 0 | 1; curve: ForecastPoint[] }> }`.
+
+- [ ] **Step 1: Update chart helper test** — in `tests/chart.test.ts`, update every `ActualPt`-shaped literal (`{ t, kg }`) passed to `nearestHit` to include `trend` (e.g. `{ t: 1, kg: 100, trend: 100.2 }`) and assert the actual-hit result carries `trend`:
+
+```ts
+  test("actual hit carries the trend value", () => {
+    const hit = nearestHit(1, [{ t: 1, kg: 100, trend: 100.2 }], []);
+    expect(hit).toEqual({ kind: "actual", t: 1, kg: 100, trend: 100.2 });
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/chart.test.ts`
+Expected: FAIL — type error / missing `trend` in result.
+
+- [ ] **Step 3: Implement**
+  - `src/ui/app/lib/chart.ts`:
+
+```ts
+export interface ActualPt { t: number; kg: number; trend: number }
+export type HoverHit =
+  | { kind: "actual"; t: number; kg: number; trend: number }
+  | { kind: "prognos"; t: number; kg: number; low: number; high: number };
+```
+
+    and in `nearestHit`'s actual loop: `best = { kind: "actual", t: p.t, kg: p.kg, trend: p.trend };`
+  - `src/ui/app/api.ts` type updates (exact shapes):
+
+```ts
+export interface Weight { date: string; weight_kg: number; trend_kg: number; note: string | null }
+export interface AccuracyBucket { days: number; n: number; mae_kg: number; bias_kg: number }
+export interface Forecast { start: { date: string; weight_kg: number; stale: boolean };
+  assumptions: { intake_kcal: number; intake_source: string; tdee_start: number; calibration: string; band_kcal: number };
+  curve: ForecastPoint[]; weight_at_target: ForecastPoint | null; weight_at_goal_date: ForecastPoint | null;
+  goal: { weight_kg: number; eta: string | null; eta_range: { earliest: string | null; latest: string | null }; reached: boolean; reason?: string } | null; notes: string[] }
+export interface ForecastView { forecast: Forecast | null; reason?: string;
+  accuracy?: { per_age: AccuracyBucket[] }; ghost?: { snapshot_date: string; curve: ForecastPoint[] } }
+```
+
+    `TrendView.latest` becomes `(WeightEntry & { trend_kg: number }) | null`.
+  - `src/ui/app/components/WeightChart.tsx`:
+    - Props: `{ series, forecast, ghost = null, scenarios = [] }` per the Interfaces block.
+    - `actual` mapping becomes `series.map((w) => ({ t: Date.parse(w.date), kg: w.weight_kg, trend: w.trend_kg }))`.
+    - Compute `ghostPts` and clipped scenario point arrays INSIDE the `useMemo` (where `actual` and `horizon` are in scope), return them from it, and add `ghost` + `scenarios` to the useMemo dependency array. Include their extents in the domain: `allT` also spreads their `t` values, `allKg` their kg values.
+    - Ghost points: `const ghostPts = ghost ? ghost.curve.map((p) => ({ t: Date.parse(p.date), kg: p.kg })).filter((p) => p.t <= lastActualT) : [];` where `lastActualT = actual.at(-1)?.t ?? 0` — the ghost never draws into the future.
+    - Scenario points: clip each scenario curve to the main chart horizon (`p.t <= horizon` with the existing `horizon` value).
+    - The main line path (`actualD`) now goes through `Y(p.trend)` instead of `Y(p.kg)` (the drawn line IS the trend); dots stay at raw `kg`. The `point-label` after the last dot shows raw weight as before.
+    - New paths rendered between the band and the main lines:
+
+```tsx
+        {ghostPts.length >= 2 ? (
+          <path className="ghost-line" d={ghostPts.map((p, i) =>
+            `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")} />
+        ) : null}
+        {scenarios.map((s) => {
+          const pts = s.curve.map((p) => ({ t: Date.parse(p.date), kg: p.kg })).filter((p) => p.t <= horizon);
+          return pts.length >= 2 ? (
+            <path key={s.slot} className={`scenario-line s${s.slot}`} d={pts.map((p, i) =>
+              `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")} />
+          ) : null;
+        })}
+```
+
+      (this requires `horizon` to be returned from the `useMemo` — add it to the returned object.)
+    - Hover tooltip for `kind === "actual"` gains a third line (reuse the 34-height box): date, `${sv(hover.kg)} kg`, and `trend ${sv(hover.trend)}` in the `hover-tip-band` style. When scenarios are visible, append one tooltip line per scenario with the nearest scenario kg at `hover.t` (helper below in the component):
+
+```ts
+  const kgAt = (curve: ForecastPoint[], t: number): number | null => {
+    let best: number | null = null, bestD = 4 * DAY;
+    for (const p of curve) {
+      const d = Math.abs(Date.parse(p.date) - t);
+      if (d < bestD) { bestD = d; best = p.kg; }
+    }
+    return best;
+  };
+```
+
+      Render scenario lines in the tooltip as `S1 ≈ x kg` / `S2 ≈ y kg` (grow the tip rect height by 10 per visible scenario line).
+  - `src/ui/static/app.css` — add (respecting the existing kvitto variables; Okabe-Ito colors read on both themes):
+
+```css
+.ghost-line { fill: none; stroke: var(--ink, currentColor); stroke-width: 1; stroke-dasharray: 3 4; opacity: 0.35; }
+.scenario-line { fill: none; stroke-width: 1.5; }
+.scenario-line.s0 { stroke: #0072b2; }
+.scenario-line.s1 { stroke: #e69f00; }
+```
+
+- [ ] **Step 4: Verify** — `bun test tests/chart.test.ts` → PASS, then typecheck the bundle path:
+
+Run: `bun run build:ui`
+Expected: builds without errors. (`Vikt.tsx` still compiles because the new `WeightChart` props are optional.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/app/api.ts src/ui/app/lib/chart.ts src/ui/app/components/WeightChart.tsx src/ui/static/app.css tests/chart.test.ts
+git commit -m "feat(kcal-assistant): trendlinje + prickar, ghost/scenario-lager i viktdiagrammet"
+```
+
+---
+
+### Task 10: UI — Träffsäkerhet section, ghost toggle, ETA range tile
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/views/Vikt.tsx`
+
+**Interfaces:**
+- Consumes: `fc.data.accuracy` / `fc.data.ghost` (Task 8 payload), `WeightChart` `ghost` prop (Task 9), `goal.eta_range` (Task 4).
+
+- [ ] **Step 1: Implement** — in `ViktInner`:
+  - Update the local `TrendData` interface: `latest: { date: string; weight_kg: number; trend_kg: number } | null`.
+  - Add `const [showGhost, setShowGhost] = useState(false);` and `const ghostData = fc.data?.ghost ?? null;` (the const gives TS a stable narrowing for the JSX below).
+  - Pass ghost to the chart: `<WeightChart series={series} forecast={forecast} ghost={showGhost ? ghostData : null} />`
+  - "Senast" tile sub gains the trend: `sub={`${t.latest.date}${t.stale ? " · gammal" : ""} · trend ${sv(t.latest.trend_kg)}`}`
+  - Ghost toggle chip directly under the chart (only when a ghost exists):
+
+```tsx
+      {ghostData ? (
+        <div className="chip-row">
+          <button className={`chip${showGhost ? " accent" : ""}`} onClick={() => setShowGhost((v) => !v)}>
+            prognos för {Math.round((Date.now() - Date.parse(ghostData.snapshot_date)) / 86_400_000)} d sedan
+          </button>
+        </div>
+      ) : null}
+```
+
+  - Träffsäkerhet section after `PrognosResult` (entirely absent without data):
+
+```tsx
+      {fc.data?.accuracy ? (
+        <>
+          <h2>Träffsäkerhet</h2>
+          <div className="tiles">
+            {fc.data.accuracy.per_age.map((b) => (
+              <Tile key={b.days} label={`${b.days} d`} value={`±${sv(b.mae_kg)} kg`}
+                    sub={`bias ${b.bias_kg > 0 ? "+" : ""}${sv(b.bias_kg)} kg · ${b.n} prognoser`} />
+            ))}
+          </div>
+          <div className="note">Hur tidigare prognoser träffat trendvikten i efterhand. Positiv bias = prognosen låg för högt.</div>
+        </>
+      ) : null}
+```
+
+  - In `PrognosResult`, the Målvikt tile's sub uses the range when available:
+
+```tsx
+        {f.goal ? <Tile label="Målvikt" value={`${sv(f.goal.weight_kg)} kg`}
+          sub={f.goal.reached ? "uppnådd"
+            : f.goal.eta
+              ? `nås ≈ ${f.goal.eta}${f.goal.eta_range.earliest ? ` (${f.goal.eta_range.earliest} – ${f.goal.eta_range.latest ?? "senare"})` : ""}`
+              : f.goal.reason ?? null} /> : null}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `bun run build:ui`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/app/views/Vikt.tsx
+git commit -m "feat(kcal-assistant): träffsäkerhet, ghost-kurva och ETA-intervall på Vikt-sidan"
+```
+
+---
+
+### Task 11: UI — scenario pinning with localStorage
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/views/Vikt.tsx`, `kcal-assistant/src/ui/app/components/PrognosPanel.tsx`, `kcal-assistant/src/ui/static/app.css`
+
+**Interfaces:**
+- Consumes: `forecastQuery(params)` and `PrognosParams` (existing exports of `PrognosPanel.tsx`); `WeightChart` `scenarios` prop (Task 9).
+- Produces: `PrognosPanel` props gain `onPin: () => void` and `canPin: boolean`.
+
+- [ ] **Step 1: Implement pin storage in `ViktInner`:**
+
+```tsx
+const STORAGE_KEY = "kcal.scenarios";
+
+function loadPinned(): PrognosParams[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((p): p is PrognosParams =>
+      p && (p.source === "targets" || p.source === "recent") && typeof p.overrides === "object" && p.overrides !== null,
+    ).slice(0, 2);
+  } catch {
+    return [];
+  }
+}
+```
+
+  In `ViktInner`:
+
+```tsx
+  const [pinned, setPinned] = useState<PrognosParams[]>(loadPinned);
+  useEffect(() => { localStorage.setItem(STORAGE_KEY, JSON.stringify(pinned)); }, [pinned]);
+  const pin = () => setPinned((prev) => [...prev, params].slice(-2)); // third pin replaces the oldest
+  const unpin = (i: number) => setPinned((prev) => prev.filter((_, idx) => idx !== i));
+  const s0 = useApi<ForecastView>(pinned[0] ? `/ui/api/forecast?${forecastQuery(pinned[0])}` : null, true);
+  const s1 = useApi<ForecastView>(pinned[1] ? `/ui/api/forecast?${forecastQuery(pinned[1])}` : null, true);
+  const scenarios = [
+    ...(pinned[0] && s0.data?.forecast ? [{ slot: 0 as const, curve: s0.data.forecast.curve }] : []),
+    ...(pinned[1] && s1.data?.forecast ? [{ slot: 1 as const, curve: s1.data.forecast.curve }] : []),
+  ];
+```
+
+  Pass `scenarios={scenarios}` to `WeightChart`. `canPin` is true when the current params differ from canonical: `params.source !== "targets" || Object.values(params.overrides).some((v) => v !== undefined && v !== "")`. No cap check — the third pin replaces the oldest.
+  Scenario chips row (under the preview chip row, before the error banner):
+
+```tsx
+      {pinned.length ? (
+        <div className="chip-row">
+          {pinned.map((p, i) => {
+            const res = i === 0 ? s0 : s1;
+            const eta = res.data?.forecast?.goal?.eta;
+            return (
+              <span key={i} className={`chip scenario-chip s${i}`}>
+                {scenarioLabel(p)}{eta ? ` · mål ≈ ${eta}` : ""}
+                <button className="chip-x" aria-label="ta bort scenario" onClick={() => unpin(i)}>×</button>
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
+```
+
+  with:
+
+```tsx
+function scenarioLabel(p: PrognosParams): string {
+  const parts: string[] = [];
+  const o = p.overrides;
+  if (o.intake) parts.push(`intag ${o.intake}`);
+  if (o.activity) parts.push(`aktivitet ${o.activity.replace(".", ",")}`);
+  if (o.goal) parts.push(`mål ${o.goal}`);
+  if (o.goal_date) parts.push(`till ${o.goal_date}`);
+  if (p.source === "recent") parts.push("senaste 28 d");
+  return parts.length ? parts.join(" · ") : "planmål";
+}
+```
+
+- [ ] **Step 2: Add the pin button to `PrognosPanel`** — props gain `onPin: () => void; canPin: boolean`; render next to the source chips:
+
+```tsx
+        <button className="chip" disabled={!canPin} onClick={onPin} title="fäst nuvarande förhandsvisning som jämförelse">
+          fäst scenario
+        </button>
+```
+
+  Vikt passes `onPin={pin} canPin={...}` per Step 1.
+
+- [ ] **Step 3: CSS** — append to `app.css`:
+
+```css
+.scenario-chip .chip-x { background: none; border: none; cursor: pointer; margin-left: 4px; font-size: 12px; color: inherit; }
+.scenario-chip.s0 { border-color: #0072b2; }
+.scenario-chip.s1 { border-color: #e69f00; }
+```
+
+- [ ] **Step 4: Verify build + full suite**
+
+Run: `bun run build:ui && bun test`
+Expected: both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/app/views/Vikt.tsx src/ui/app/components/PrognosPanel.tsx src/ui/static/app.css
+git commit -m "feat(kcal-assistant): fästa what-if-scenarier med localStorage på Vikt-sidan"
+```
+
+---
+
+### Task 12: Browser verification, version bump, PR
+
+**Files:**
+- Modify: `kcal-assistant/package.json` (version), `kubernetes/apps/home-automation/kcal-assistant/app/deployment.yaml` (image tag)
+
+- [ ] **Step 1: Manual browser walk** (dev server, seeded db):
+
+```bash
+cd kcal-assistant && bun run build:ui && \
+  UI_DEV_NO_AUTH=1 MCP_TOKEN=dev DB_PATH=/tmp/kcal-dev.db PORT=3999 bun run start
+```
+
+Open `http://localhost:3999/ui` in a real browser (or via the Playwright plugin) and verify:
+1. Vikt chart draws a smooth trend line with raw weigh-in dots around it; hover shows both values.
+2. Forecast notes include the "osäkerhet ±… kcal/dag: …" line; Målvikt tile shows the ETA range when a goal is set.
+3. Träffsäkerhet section is ABSENT (fresh db, no aged snapshots) — no empty shell.
+4. No ghost chip appears (no old snapshots).
+5. Pin a what-if (change intag → "fäst scenario") → colored thin line + chip with ETA; pin a second; a third replaces the oldest; reload the page → pins survive; × removes.
+6. Console shows no new CSP violations beyond the 6 known Radix inline-style ones.
+
+- [ ] **Step 2: Version bump + manifest**
+
+- `kcal-assistant/package.json`: `"version": "0.9.0"`.
+- `kubernetes/apps/home-automation/kcal-assistant/app/deployment.yaml`: image `docker.io/rutbergphilip/kcal-assistant:v0.9.0`.
+
+- [ ] **Step 3: Full suite + production build one last time**
+
+Run: `bun test && bun run build:ui`
+Expected: all green.
+
+- [ ] **Step 4: Commit + PR**
+
+```bash
+git add package.json ../kubernetes/apps/home-automation/kcal-assistant/app/deployment.yaml
+git commit -m "feat(kcal-assistant): v0.9.0 — prognosmotor v2"
+git push -u origin kcal-forecast-engine-v2
+gh pr create --title "feat(kcal-assistant): v0.9.0 — prognosmotor v2" --body "$(cat <<'EOF'
+Prognosmotor v2 per spec docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md:
+
+- **Trendvikt**: EWMA-utjämning (α 0,10/dag, gap-justerad) — diagrammets linje, prognosens startvikt och get_trend/vikt-API:t använder trenden; rådata blir prickar.
+- **Ärlig osäkerhet**: ±150 kcal ersatt av datadriven felbudget (kalibrering, intagskälla, vägningstäthet; 125–400 kcal) + mål-ETA som intervall (eta_range).
+- **Träffsäkerhet**: migration 5, forecast_snapshots (kanoniska prognoser, upsert per dag, triggas bl.a. av log_weight), accuracy per ålder (7/14/28/56 d, MAE + bias) + ghost-kurva i UI.
+- **Scenariojämförelse**: upp till 2 fästa what-if-kurvor på Vikt-sidan, localStorage-persistens. UI-only.
+
+MCP: 24 verktyg, inga input-schemaändringar (get_forecast-beskrivningens bandformulering korrigerad). Ingen ny chatt behövs.
+
+Plan: docs/superpowers/plans/2026-07-10-kcal-forecast-engine-v2.md
+
+https://claude.ai/code/session_018bdcBb7HJ6UUj8LXCt18qD
+EOF
+)"
+```
+
+After merge: CI builds/pushes the image, Flux (`cluster-apps`) deploys within ~2 min; verify pod image v0.9.0, healthz 200, `tools/list` = 24, and the Vikt page live behind Authentik. No new chat needed (input schemas unchanged). Träffsäkerhet populates after ~a week of weigh-ins.

--- a/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
+++ b/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
@@ -2,8 +2,12 @@
 
 Date: 2026-07-10
 Status: design approved in brainstorming with Philip; this document is the spec for the implementation plan.
-Scope: one release (one PR), migration 5, no new MCP tools and **no MCP input-schema
-or tool-description changes** (response payloads only grow → no new chat needed).
+Scope: one release (one PR), migration 5, no new MCP tools and **no MCP
+input-schema changes** (response payloads only grow → no new chat needed).
+One description string is corrected: `get_forecast` currently claims a fixed
+"±150 kcal/dag" band, which §2 makes false — the description switches to
+"datadrivet ±band, se assumptions.band_kcal". Stale descriptions in old chats
+are harmless; responses self-describe.
 Builds on v0.6.0 forecast (spec `2026-07-09-kcal-time-and-forecast-design.md`) and
 v0.7.0 what-if previews (spec `2026-07-10-kcal-ui-profile-editing-design.md`).
 

--- a/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
+++ b/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
@@ -150,6 +150,9 @@ returns null when no bucket qualifies.
   - `accuracy: { per_age: [...] }`
   - `ghost: { snapshot_date, curve }` — the snapshot nearest 28 days ago
     (only when one ≥ 21 days old exists), for the UI overlay.
+    *Erratum (as built): `ghost` is served only on `/ui/api/forecast`; the MCP
+    `get_forecast` strips it deliberately (token economy — chat never needs a
+    second curve). `accuracy` flows through both.*
 - **Vikt page:** "Träffsäkerhet" section under the chart (per-age tiles:
   "28 d: ±0.4 kg, bias −0.2 kg" with a one-line explanation), hidden entirely
   until data exists. Ghost curve: faint dashed overlay drawn **only from its

--- a/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
+++ b/docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md
@@ -1,0 +1,194 @@
+# kcal-assistant v0.9.0 — Prognosmotor v2 (trendvikt, ärlig osäkerhet, träffsäkerhet, scenarier)
+
+Date: 2026-07-10
+Status: design approved in brainstorming with Philip; this document is the spec for the implementation plan.
+Scope: one release (one PR), migration 5, no new MCP tools and **no MCP input-schema
+or tool-description changes** (response payloads only grow → no new chat needed).
+Builds on v0.6.0 forecast (spec `2026-07-09-kcal-time-and-forecast-design.md`) and
+v0.7.0 what-if previews (spec `2026-07-10-kcal-ui-profile-editing-design.md`).
+
+## Goal
+
+Four upgrades to the weight forecast, all chosen by Philip:
+
+1. **Trendvikt** — smooth noisy daily weigh-ins (EWMA) and drive display + forecast
+   start from the trend, not raw points.
+2. **Ärlig osäkerhet** — replace the hardcoded ±150 kcal band with a data-driven
+   error budget; goal-ETA becomes a range instead of a point.
+3. **Träffsäkerhet** — persist daily forecast snapshots and measure past forecasts
+   against actual (trend) weight; show the error.
+4. **Scenariojämförelse** — pin up to two what-if previews next to the saved
+   baseline on the Vikt chart (UI-only).
+
+Ordering rationale: snapshots only accumulate from the day they ship, and the
+smoother trend/TDEE feeds every later feature (målrekommendation, veckobalans,
+veckorapport — separate future releases).
+
+## 1. Trendvikt (EWMA)
+
+New pure function in `src/lib/trend.ts`:
+
+```
+computeTrendWeight(weights: WeightEntry[]): Array<{ date, weight_kg, trend_kg }>
+```
+
+- Hacker's Diet-style exponential smoothing adapted for irregular weigh-ins:
+  `trend_i = trend_{i-1} + α_eff × (weight_i − trend_{i-1})` with
+  `α_eff = 1 − 0.9^gap_days` (α = 0.10/day). Seed: `trend_0 = weight_0`.
+  Computed at weigh-in dates only; `trend_kg` rounded to 2 decimals.
+- **Used in three places:**
+  1. **Vikt chart** — raw weigh-ins become dots, the trend is the drawn line;
+     hover shows both values. The UI weights payload gains `trend_kg` per point
+     (computed server-side; the chart never re-implements the math).
+  2. **Forecast start weight** — `computeForecast` starts from the trend value at
+     the latest weigh-in instead of the 7-day mean. `start.weighins_smoothed` is
+     removed from `ForecastResult`; UI copy says "trendvikt". `start.stale`
+     logic unchanged.
+  3. **`get_trend`** — response's `latest` gains `trend_kg`.
+- **Deliberately NOT used for the TDEE calculation.** `computeTrend`'s
+  two-half-window means already smooth both endpoints; EWMA lags by design and
+  would bias the measured rate (and TDEE) toward zero. The TDEE math is untouched.
+
+## 2. Ärlig osäkerhet (error budget + ETA range)
+
+`BAND_KCAL = 150` is replaced by a computed budget. New pure function in
+`src/lib/forecast.ts`:
+
+```
+computeBand(input: {
+  calibration: "mätdata" | "formel",
+  intake_source: "targets" | "recent" | "explicit",
+  weighins_last_28d: number,
+}): { kcal: number, reasons: string[] }
+```
+
+| Contribution | Condition | kcal |
+|---|---|---|
+| Bas (modell- + loggbrus) | alltid | 100 |
+| Kalibrering | mätdata | +50 |
+| | formel (ingen/osäker mätning) | +200 |
+| Intagsantagande | recent (uppmätt beteende) | +25 |
+| | targets / explicit (antar framtida följsamhet) | +75 |
+| Glesa vägningar | < 10 vägningar senaste 28 d | +50 |
+
+Clamped to **[125, 400]**. The low/high curves re-simulate at `intake ∓ band`
+exactly as today, so kg-uncertainty keeps growing with horizon naturally.
+
+- `assumptions.band_kcal` added to `ForecastResult`; a Swedish note explains the
+  budget ("osäkerhet ±350 kcal/dag: formelkalibrering, glesa vägningar").
+- **ETA range:** goal ETA is additionally computed on the low and high curves →
+  `goal.eta_range = { earliest: string | null, latest: string | null }`.
+  When losing toward the goal the low curve (larger deficit) gives `earliest`,
+  the high curve gives `latest`; `latest: null` = "möjligen bortom horisonten".
+  `eta_range` is present whenever `goal` is (null members allowed); the point
+  `eta` stays for compatibility. UI ETA tile shows "~24 sep (12 sep – 18 okt)";
+  chat gets the same fields via `get_forecast`.
+- Considered and rejected: Monte Carlo (unexplainable overkill). Deferred:
+  empirically fitted band from measured forecast error — becomes possible once
+  §3's snapshots accumulate; the budget function is the single place to re-base.
+
+## 3. Träffsäkerhet (snapshots + accuracy)
+
+### Storage (migration 5)
+
+```sql
+CREATE TABLE forecast_snapshots (
+  date               TEXT PRIMARY KEY,  -- snapshot day (Stockholm)
+  created_at         TEXT NOT NULL,
+  start_date         TEXT NOT NULL,
+  start_kg           REAL NOT NULL,
+  intake_kcal        INTEGER NOT NULL,
+  intake_source      TEXT NOT NULL,
+  tdee_start         INTEGER NOT NULL,
+  calibration_offset INTEGER NOT NULL,
+  band_kcal          INTEGER NOT NULL,
+  curve_json         TEXT NOT NULL      -- weekly points [{date, kg, low, high}]
+);
+```
+
+One row per day, upsert (last write of the day wins). Weekly curve ≈ 53 points,
+a few KB/row. New module `src/db/snapshots.ts` (save + read + prune-nothing —
+data is small and precious).
+
+### Write policy
+
+Only **canonical** forecasts snapshot: stored profile, `intake_source =
+"targets"`, no overrides (`intake_kcal`/`goal_weight`/`activity_factor`/
+`goal_date`/`target_date` all absent). Previews never write. Triggers:
+
+- `log_weight` — after insert, compute canonical forecast → snapshot,
+  **best-effort**: a snapshot failure must never fail the weight log (try/catch;
+  weight write commits regardless).
+- `get_forecast` (MCP) and `GET /ui/api/forecast` when called canonically.
+- No profile / no weigh-ins → `buildForecast` returns null → skip silently.
+
+### Accuracy math
+
+New pure module `src/lib/accuracy.ts`:
+
+```
+computeForecastAccuracy(
+  snapshots, trendWeights, today
+): { per_age: Array<{ days, n, mae_kg, bias_kg }> } | null
+```
+
+For each snapshot and each age `a ∈ {7, 14, 28, 56}` days: predicted weight =
+linear interpolation of the snapshot curve at `snapshot.date + a`; actual =
+`trend_kg` of the weigh-in nearest that date within ±3 days (else skip).
+`bias_kg` = mean(predicted − actual): positive = forecasts run heavy
+(pessimistic for weight loss). An age bucket reports only with `n ≥ 3`;
+returns null when no bucket qualifies.
+
+### Surfaces
+
+- **`get_forecast` / `/ui/api/forecast` response** gains, when data qualifies
+  (omitted otherwise — never empty objects):
+  - `accuracy: { per_age: [...] }`
+  - `ghost: { snapshot_date, curve }` — the snapshot nearest 28 days ago
+    (only when one ≥ 21 days old exists), for the UI overlay.
+- **Vikt page:** "Träffsäkerhet" section under the chart (per-age tiles:
+  "28 d: ±0.4 kg, bias −0.2 kg" with a one-line explanation), hidden entirely
+  until data exists. Ghost curve: faint dashed overlay drawn **only from its
+  start to today** (never into the future — the live projection owns that side),
+  toggleable via chip ("prognos för 28 d sedan").
+
+## 4. Scenariojämförelse (UI-only)
+
+No server changes — `/ui/api/forecast` already takes preview params; comparison
+is parallel fetches.
+
+- The live preview in Prognos-inställningar gains **"Fäst scenario"**: pins the
+  current param set as a chip. Max 2 pinned; a third pin replaces the oldest.
+- Chart: the saved baseline is the only curve with a band; pinned scenarios are
+  thin solid lines in distinct colorblind-safe colors from the existing chart
+  palette. Hover tooltip lists every visible curve's kg.
+- Chips show a params summary + that scenario's goal-ETA; removable (×).
+- Pins persist in `localStorage` (param sets, refetched on load) with the
+  existing in-flight guard / keep-last-good-on-failure pattern.
+- Deliberately **no** scenario batching in `get_forecast` (MCP): Claude can
+  already call it with explicit intake; comparison is a visual activity.
+
+## Testing
+
+- **Unit (pure fns):** EWMA — single point, regular series, gap α_eff, lag
+  behavior; band — every contribution, combinations, clamps; ETA range —
+  losing/gaining/never-reaches, null latest; accuracy — synthetic snapshots vs
+  synthetic actuals, bias sign, ±3-day matching, n < 3 gate, null result.
+- **db:** migration 5 applies; same-day upsert; canonical-only writes (preview
+  params → no row); `log_weight` succeeds even when snapshotting throws.
+- **API:** `/ui/api/forecast` new fields present/omitted correctly; auth matrix
+  untouched (read-only additions).
+- **Playwright:** trend line + dots render; pin/unpin + reload persistence;
+  träffsäkerhet hidden when empty; ghost toggle.
+- Build gotcha (standing): `bun run build:ui` must use `--production`; verify UI
+  in a real browser, not just tests.
+
+## Rollout
+
+Same-PR: `package.json` 0.9.0 + `deployment.yaml` image tag → merge → CI builds
+→ Flux (`cluster-apps` Kustomization, lags ~1 min; pods match label
+`app=kcal-assistant`; ~10 s ingress 503 after Recreate). Verify: pod v0.9.0,
+healthz 200, `tools/list` = 24, Vikt page in browser (trend line, band note,
+pinned scenario). **No new chat needed** — tool inputs and descriptions are
+frozen this release. Träffsäkerhet stays empty for ~a week by design; first
+snapshot lands with Philip's first post-deploy weigh-in.

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/forecast.ts
+++ b/kcal-assistant/src/db/forecast.ts
@@ -1,16 +1,20 @@
 import type { Database } from "bun:sqlite";
 import { computeForecast, type ForecastResult } from "../lib/forecast";
+import { computeTrendWeight } from "../lib/trend";
+import { computeForecastAccuracy, pickGhost, type AccuracyBucket } from "../lib/accuracy";
 import { getProfile } from "./profile";
 import { getTrend } from "./weights";
 import { getTargetsFor } from "./preferences";
 import { todayStockholm, addDays } from "../lib/dates";
-import { saveSnapshot } from "./snapshots";
+import { saveSnapshot, listSnapshots } from "./snapshots";
 
 export type IntakeSource = "targets" | "recent";
 
 export interface ForecastView {
   forecast: ForecastResult | null;
   reason?: string;
+  accuracy?: { per_age: AccuracyBucket[] };
+  ghost?: { snapshot_date: string; curve: ForecastResult["curve"] };
 }
 
 // Resolves the daily intake assumption:
@@ -137,5 +141,27 @@ export function buildForecast(
     }
   }
 
-  return { forecast };
+  // Accuracy + ghost ride on every response (previews too — same read cost),
+  // omitted entirely when no snapshot has aged enough — or, same best-effort
+  // contract as the save above, when the read itself fails.
+  return { forecast, ...readAccuracyAndGhost(db, weights, today) };
+}
+
+function readAccuracyAndGhost(
+  db: Database,
+  weights: Array<{ date: string; weight_kg: number }>,
+  today: string,
+): Pick<ForecastView, "accuracy" | "ghost"> {
+  try {
+    const snapshots = listSnapshots(db);
+    const accuracy = computeForecastAccuracy({ snapshots, trendWeights: computeTrendWeight(weights), today });
+    const ghostSnap = pickGhost(snapshots, today);
+    return {
+      ...(accuracy !== null && { accuracy }),
+      ...(ghostSnap !== null && { ghost: { snapshot_date: ghostSnap.date, curve: ghostSnap.curve } }),
+    };
+  } catch (e) {
+    console.error("snapshot:", e instanceof Error ? e.message : e);
+    return {};
+  }
 }

--- a/kcal-assistant/src/db/forecast.ts
+++ b/kcal-assistant/src/db/forecast.ts
@@ -4,6 +4,7 @@ import { getProfile } from "./profile";
 import { getTrend } from "./weights";
 import { getTargetsFor } from "./preferences";
 import { todayStockholm, addDays } from "../lib/dates";
+import { saveSnapshot } from "./snapshots";
 
 export type IntakeSource = "targets" | "recent";
 
@@ -117,5 +118,24 @@ export function buildForecast(
       "kalibrerad mot mätdata — den sparade prognosen påverkas mindre av ändrad aktivitetsfaktor",
     );
   }
+
+  // Canonical (no what-ifs, plan-based intake) forecasts are snapshotted for
+  // accuracy tracking — best-effort: a snapshot failure must never break the
+  // forecast (or a log_weight that triggered it).
+  const canonical =
+    opts.target_date === undefined &&
+    opts.goal_weight === undefined &&
+    opts.intake_kcal === undefined &&
+    opts.activity_factor === undefined &&
+    opts.goal_date === undefined &&
+    (opts.intake_source ?? "targets") === "targets";
+  if (canonical) {
+    try {
+      saveSnapshot(db, forecast, today);
+    } catch (e) {
+      console.error("snapshot:", e instanceof Error ? e.message : e);
+    }
+  }
+
   return { forecast };
 }

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -149,6 +149,22 @@ const MIGRATIONS: string[] = [
     updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
   );
   `,
+  // 5: canonical forecast snapshots — one per day, weekly curve as JSON.
+  // Never pruned: the data is small and feeds accuracy tracking.
+  `
+  CREATE TABLE forecast_snapshots (
+    date               TEXT PRIMARY KEY,
+    created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+    start_date         TEXT NOT NULL,
+    start_kg           REAL NOT NULL,
+    intake_kcal        INTEGER NOT NULL,
+    intake_source      TEXT NOT NULL,
+    tdee_start         INTEGER NOT NULL,
+    calibration_offset INTEGER NOT NULL,
+    band_kcal          INTEGER NOT NULL,
+    curve_json         TEXT NOT NULL
+  );
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/snapshots.ts
+++ b/kcal-assistant/src/db/snapshots.ts
@@ -1,0 +1,50 @@
+import type { Database } from "bun:sqlite";
+import type { ForecastPoint, ForecastResult } from "../lib/forecast";
+
+export interface SnapshotRow {
+  date: string;
+  start_date: string;
+  start_kg: number;
+  intake_kcal: number;
+  intake_source: string;
+  tdee_start: number;
+  calibration_offset: number;
+  band_kcal: number;
+  curve: ForecastPoint[];
+}
+
+// Weekly sampling mirrors get_forecast's token-lean curve.
+const weekly = (curve: ForecastPoint[]): ForecastPoint[] =>
+  curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+
+export function saveSnapshot(db: Database, forecast: ForecastResult, today: string): void {
+  db.run(
+    `INSERT INTO forecast_snapshots
+       (date, start_date, start_kg, intake_kcal, intake_source,
+        tdee_start, calibration_offset, band_kcal, curve_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET
+       created_at = datetime('now'),
+       start_date = excluded.start_date, start_kg = excluded.start_kg,
+       intake_kcal = excluded.intake_kcal, intake_source = excluded.intake_source,
+       tdee_start = excluded.tdee_start, calibration_offset = excluded.calibration_offset,
+       band_kcal = excluded.band_kcal, curve_json = excluded.curve_json`,
+    [
+      today, forecast.start.date, forecast.start.weight_kg,
+      forecast.assumptions.intake_kcal, forecast.assumptions.intake_source,
+      forecast.assumptions.tdee_start, forecast.assumptions.calibration_offset,
+      forecast.assumptions.band_kcal, JSON.stringify(weekly(forecast.curve)),
+    ],
+  );
+}
+
+export function listSnapshots(db: Database): SnapshotRow[] {
+  return db
+    .query<Omit<SnapshotRow, "curve"> & { curve_json: string }, []>(
+      `SELECT date, start_date, start_kg, intake_kcal, intake_source,
+              tdee_start, calibration_offset, band_kcal, curve_json
+       FROM forecast_snapshots ORDER BY date`,
+    )
+    .all()
+    .map(({ curve_json, ...row }) => ({ ...row, curve: JSON.parse(curve_json) as ForecastPoint[] }));
+}

--- a/kcal-assistant/src/db/weights.ts
+++ b/kcal-assistant/src/db/weights.ts
@@ -1,8 +1,9 @@
 import type { Database } from "bun:sqlite";
-import { computeTrend, type TrendResult, type WeightEntry } from "../lib/trend";
+import { computeTrend, computeTrendWeight, type TrendResult, type WeightEntry } from "../lib/trend";
 import { todayStockholm, isValidDate, toEpochDays } from "../lib/dates";
 
-export interface WeightTrendView extends TrendResult {
+export interface WeightTrendView extends Omit<TrendResult, "latest"> {
+  latest: (WeightEntry & { trend_kg: number }) | null;
   weights: WeightEntry[]; // weighings inside the window, ascending
 }
 
@@ -25,12 +26,14 @@ export function logWeight(
   return getTrend(db);
 }
 
-export function listWeights(db: Database): Array<WeightEntry & { note: string | null }> {
-  return db
+export function listWeights(db: Database): Array<WeightEntry & { note: string | null; trend_kg: number }> {
+  const rows = db
     .query<WeightEntry & { note: string | null }, []>(
       "SELECT date, weight_kg, note FROM weights ORDER BY date DESC",
     )
     .all();
+  const trendByDate = new Map(computeTrendWeight(rows).map((p) => [p.date, p.trend_kg]));
+  return rows.map((r) => ({ ...r, trend_kg: trendByDate.get(r.date)! }));
 }
 
 export function getTrend(db: Database, windowDays = 28): WeightTrendView {
@@ -52,5 +55,10 @@ export function getTrend(db: Database, windowDays = 28): WeightTrendView {
         (w) => toEpochDays(w.date) >= toEpochDays(result.latest!.date) - (windowDays - 1),
       )
     : [];
-  return { ...result, weights };
+  const trendByDate = new Map(computeTrendWeight(allWeights).map((p) => [p.date, p.trend_kg]));
+  return {
+    ...result,
+    latest: result.latest ? { ...result.latest, trend_kg: trendByDate.get(result.latest.date)! } : null,
+    weights,
+  };
 }

--- a/kcal-assistant/src/lib/accuracy.ts
+++ b/kcal-assistant/src/lib/accuracy.ts
@@ -1,0 +1,95 @@
+import { toEpochDays, addDays } from "./dates";
+
+// Measures how past forecast snapshots aged: for standard ages, the snapshot
+// curve (weekly points, linearly interpolated) is compared against the EWMA
+// trend weight nearest that date (±3 days). bias > 0 = forecasts ran heavy.
+
+export interface AccuracyBucket {
+  days: number;
+  n: number;
+  mae_kg: number;
+  bias_kg: number;
+}
+
+const AGES = [7, 14, 28, 56];
+const MATCH_TOLERANCE_DAYS = 3;
+const MIN_SAMPLES = 3;
+
+const round2 = (x: number): number => Math.round(x * 100) / 100;
+
+export function computeForecastAccuracy(input: {
+  snapshots: Array<{ date: string; curve: Array<{ date: string; kg: number }> }>;
+  trendWeights: Array<{ date: string; trend_kg: number }>;
+  today: string;
+}): { per_age: AccuracyBucket[] } | null {
+  const per_age: AccuracyBucket[] = [];
+  for (const days of AGES) {
+    const errors: number[] = [];
+    for (const s of input.snapshots) {
+      const target = addDays(s.date, days);
+      if (target > input.today) continue;
+      const predicted = interpolate(s.curve, target);
+      if (predicted === null) continue;
+      const actual = nearestTrend(input.trendWeights, target);
+      if (actual === null) continue;
+      errors.push(predicted - actual);
+    }
+    if (errors.length >= MIN_SAMPLES) {
+      const mean = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length;
+      per_age.push({
+        days,
+        n: errors.length,
+        mae_kg: round2(mean(errors.map(Math.abs))),
+        bias_kg: round2(mean(errors)),
+      });
+    }
+  }
+  return per_age.length ? { per_age } : null;
+}
+
+function interpolate(curve: Array<{ date: string; kg: number }>, date: string): number | null {
+  const t = toEpochDays(date);
+  for (let i = 0; i < curve.length - 1; i++) {
+    const a = toEpochDays(curve[i]!.date);
+    const b = toEpochDays(curve[i + 1]!.date);
+    if (t >= a && t <= b) {
+      return a === b ? curve[i]!.kg : curve[i]!.kg + ((t - a) / (b - a)) * (curve[i + 1]!.kg - curve[i]!.kg);
+    }
+  }
+  return null; // outside the stored curve (e.g. sim stopped early)
+}
+
+function nearestTrend(
+  tw: Array<{ date: string; trend_kg: number }>,
+  date: string,
+): number | null {
+  const t = toEpochDays(date);
+  let best: number | null = null;
+  let bestD = Infinity;
+  for (const w of tw) {
+    const d = Math.abs(toEpochDays(w.date) - t);
+    if (d < bestD) {
+      bestD = d;
+      best = w.trend_kg;
+    }
+  }
+  return bestD <= MATCH_TOLERANCE_DAYS ? best : null;
+}
+
+// Ghost overlay candidate: the snapshot nearest 28 days old, at least 21.
+// Ascending input order means ties keep the older snapshot.
+export function pickGhost<T extends { date: string }>(snapshots: T[], today: string): T | null {
+  const t = toEpochDays(today);
+  let best: T | null = null;
+  let bestD = Infinity;
+  for (const s of snapshots) {
+    const age = t - toEpochDays(s.date);
+    if (age < 21) continue;
+    const d = Math.abs(age - 28);
+    if (d < bestD) {
+      bestD = d;
+      best = s;
+    }
+  }
+  return best;
+}

--- a/kcal-assistant/src/lib/forecast.ts
+++ b/kcal-assistant/src/lib/forecast.ts
@@ -58,7 +58,13 @@ export interface ForecastResult {
   curve: ForecastPoint[];
   weight_at_target: ForecastPoint | null;
   weight_at_goal_date: ForecastPoint | null;
-  goal: { weight_kg: number; eta: string | null; reached: boolean; reason?: string } | null;
+  goal: {
+    weight_kg: number;
+    eta: string | null;
+    eta_range: { earliest: string | null; latest: string | null };
+    reached: boolean;
+    reason?: string;
+  } | null;
   notes: string[];
 }
 
@@ -220,14 +226,25 @@ export function computeForecast(input: ForecastInput): ForecastResult {
   if (goalWeight !== null && goalWeight !== undefined) {
     const delta = goalWeight - startKg;
     if (Math.abs(delta) < 0.05) {
-      goal = { weight_kg: goalWeight, eta: null, reached: true };
+      goal = { weight_kg: goalWeight, eta: null, eta_range: { earliest: null, latest: null }, reached: true };
     } else {
       const movingToward = delta < 0 ? losing : !losing;
       const hit = (kg: number): boolean => (delta < 0 ? kg <= goalWeight : kg >= goalWeight);
       const eta = movingToward ? (curve.find((p) => hit(p.kg))?.date ?? null) : null;
+      const etaOn = (pts: Array<{ date: string; kg: number }>): string | null =>
+        movingToward ? (pts.find((p) => hit(p.kg))?.date ?? null) : null;
+      const etaLow = etaOn(lowSim);
+      const etaHigh = etaOn(highSim);
+      const eta_range =
+        etaLow !== null && etaHigh !== null
+          ? etaLow <= etaHigh
+            ? { earliest: etaLow, latest: etaHigh }
+            : { earliest: etaHigh, latest: etaLow }
+          : { earliest: etaLow ?? etaHigh, latest: null };
       goal = {
         weight_kg: goalWeight,
         eta,
+        eta_range,
         reached: false,
         ...(eta === null && {
           reason: movingToward

--- a/kcal-assistant/src/lib/forecast.ts
+++ b/kcal-assistant/src/lib/forecast.ts
@@ -6,8 +6,9 @@ import { computeTrendWeight } from "./trend";
 //   weight, TDEE = BMR × activity factor + a constant calibration offset
 //   against the measured backwards-TDEE (lib/trend.ts) when that is reliable.
 //   Daily Euler step: w −= (TDEE(w) − intake) / 7700.
-// The curve therefore flattens naturally as weight drops. A ±150 kcal/day
-// re-run gives an honest low/high envelope instead of fake precision.
+// The curve therefore flattens naturally as weight drops. A ±band re-run
+// (data-driven error budget, computeBand) gives an honest low/high envelope
+// instead of fake precision.
 
 export interface ForecastProfile {
   birth_date: string;
@@ -52,6 +53,7 @@ export interface ForecastResult {
     calibration: "mätdata" | "formel";
     calibration_offset: number;
     kcal_per_kg: number;
+    band_kcal: number;
   };
   curve: ForecastPoint[];
   weight_at_target: ForecastPoint | null;
@@ -61,9 +63,44 @@ export interface ForecastResult {
 }
 
 const KCAL_PER_KG = 7700;
-const BAND_KCAL = 150;
 const OFFSET_CLAMP = 500;
 const FLOOR_KG = 40;
+
+// Error budget for the uncertainty band: named kcal contributions summed and
+// clamped. The single place a future empirical calibration (from
+// forecast_snapshots history) would slot in.
+const BAND_MIN = 125;
+const BAND_MAX = 400;
+
+export interface BandInput {
+  calibration: "mätdata" | "formel";
+  intake_source: "targets" | "recent" | "explicit";
+  weighins_last_28d: number;
+}
+
+export function computeBand(input: BandInput): { kcal: number; reasons: string[] } {
+  let kcal = 100;
+  const reasons: string[] = ["grundosäkerhet"];
+  if (input.calibration === "mätdata") {
+    kcal += 50;
+    reasons.push("mätdatakalibrerad");
+  } else {
+    kcal += 200;
+    reasons.push("formelkalibrering (ingen tillförlitlig mätdata)");
+  }
+  if (input.intake_source === "recent") {
+    kcal += 25;
+    reasons.push("intag från uppmätt beteende");
+  } else {
+    kcal += 75;
+    reasons.push("intag antar framtida följsamhet");
+  }
+  if (input.weighins_last_28d < 10) {
+    kcal += 50;
+    reasons.push("glesa vägningar (<10 på 28 d)");
+  }
+  return { kcal: Math.min(BAND_MAX, Math.max(BAND_MIN, kcal)), reasons };
+}
 
 const round2 = (x: number): number => Math.round(x * 100) / 100;
 
@@ -129,9 +166,19 @@ export function computeForecast(input: ForecastInput): ForecastResult {
   }
   const tdeeStart = formulaTdeeStart + offset;
 
+  const weighinsLast28 = sorted.filter(
+    (w) => toEpochDays(latest.date) - toEpochDays(w.date) <= 27,
+  ).length;
+  const band = computeBand({
+    calibration,
+    intake_source: input.intake_source,
+    weighins_last_28d: weighinsLast28,
+  });
+  notes.push(`osäkerhet ±${band.kcal} kcal/dag: ${band.reasons.join(", ")}`);
+
   const main = simulate(input.profile, latest.date, startKg, input.intake_kcal, offset, horizonEnd);
-  const lowSim = simulate(input.profile, latest.date, startKg, input.intake_kcal - BAND_KCAL, offset, horizonEnd);
-  const highSim = simulate(input.profile, latest.date, startKg, input.intake_kcal + BAND_KCAL, offset, horizonEnd);
+  const lowSim = simulate(input.profile, latest.date, startKg, input.intake_kcal - band.kcal, offset, horizonEnd);
+  const highSim = simulate(input.profile, latest.date, startKg, input.intake_kcal + band.kcal, offset, horizonEnd);
   if (main.at(-1)!.date !== horizonEnd) notes.push("kurvan stoppades vid 40 kg (orimliga antaganden)");
 
   const curve: ForecastPoint[] = main.map((p, i) => ({
@@ -204,6 +251,7 @@ export function computeForecast(input: ForecastInput): ForecastResult {
       calibration,
       calibration_offset: Math.round(offset),
       kcal_per_kg: KCAL_PER_KG,
+      band_kcal: band.kcal,
     },
     curve,
     weight_at_target: weightAtTarget,

--- a/kcal-assistant/src/lib/forecast.ts
+++ b/kcal-assistant/src/lib/forecast.ts
@@ -1,4 +1,5 @@
 import { toEpochDays, addDays } from "./dates";
+import { computeTrendWeight } from "./trend";
 
 // Forward weight simulation ("riktig formel"):
 //   BMR (Mifflin-St Jeor) is recomputed every simulated day on the simulated
@@ -43,7 +44,7 @@ export interface ForecastPoint {
 }
 
 export interface ForecastResult {
-  start: { date: string; weight_kg: number; weighins_smoothed: number; stale: boolean };
+  start: { date: string; weight_kg: number; stale: boolean };
   assumptions: {
     intake_kcal: number;
     intake_source: "targets" | "recent" | "explicit";
@@ -106,11 +107,10 @@ export function computeForecast(input: ForecastInput): ForecastResult {
   const horizonDays = input.horizon_days ?? 365;
   const horizonEnd = addDays(input.today, horizonDays);
 
-  // Start = mean of weigh-ins within 7 days of the latest (noise smoothing);
-  // simulation starts at the latest weigh-in date so a stale log gets its
-  // elapsed days simulated too.
-  const recent = sorted.filter((w) => toEpochDays(latest.date) - toEpochDays(w.date) <= 7);
-  const startKg = recent.reduce((s, w) => s + w.weight_kg, 0) / recent.length;
+  // Start = EWMA trend weight at the latest weigh-in (lib/trend.ts); the
+  // simulation still starts at the latest weigh-in DATE so a stale log gets
+  // its elapsed days simulated too.
+  const startKg = computeTrendWeight(sorted).at(-1)!.trend_kg;
   const stale = toEpochDays(input.today) - toEpochDays(latest.date) > 7;
   if (stale) notes.push("senaste vägningen är över en vecka gammal");
 
@@ -195,7 +195,6 @@ export function computeForecast(input: ForecastInput): ForecastResult {
     start: {
       date: latest.date,
       weight_kg: round2(startKg),
-      weighins_smoothed: recent.length,
       stale,
     },
     assumptions: {

--- a/kcal-assistant/src/lib/trend.ts
+++ b/kcal-assistant/src/lib/trend.ts
@@ -103,3 +103,33 @@ export function computeTrend(input: {
     },
   };
 }
+
+// Hacker's Diet-style exponential smoothing for irregular weigh-ins:
+//   trend += α_eff · (weight − trend),  α_eff = 1 − 0.9^gap_days (α = 0.10/day).
+// The running trend is kept unrounded; only the output is rounded.
+const ALPHA_DAILY = 0.1;
+
+export interface TrendWeightPoint {
+  date: string;
+  weight_kg: number;
+  trend_kg: number;
+}
+
+export function computeTrendWeight(weights: WeightEntry[]): TrendWeightPoint[] {
+  const sorted = [...weights].sort((a, b) => (a.date < b.date ? -1 : 1));
+  const out: TrendWeightPoint[] = [];
+  let trend: number | null = null;
+  let prevEpoch = 0;
+  for (const w of sorted) {
+    const epoch = toEpochDays(w.date);
+    if (trend === null) {
+      trend = w.weight_kg;
+    } else {
+      const alphaEff = 1 - Math.pow(1 - ALPHA_DAILY, Math.max(1, epoch - prevEpoch));
+      trend += alphaEff * (w.weight_kg - trend);
+    }
+    prevEpoch = epoch;
+    out.push({ date: w.date, weight_kg: w.weight_kg, trend_kg: round2(trend) });
+  }
+  return out;
+}

--- a/kcal-assistant/src/tools/profile.ts
+++ b/kcal-assistant/src/tools/profile.ts
@@ -28,7 +28,7 @@ export function registerProfileTools(server: McpServer, db: Database): void {
     "get_forecast",
     {
       description:
-        "Weight forecast from profile + weight log. Simulates day by day: Mifflin-St Jeor BMR on the moving weight × activity factor, calibrated against the measured backwards-TDEE when reliable. Returns predicted weight at target_date and at the profile's goal_date, the date the goal weight is reached (goal.eta), an uncertainty band (±150 kcal/dag), and weekly curve points. intake_source: 'targets' (default; day targets weighted by the recent day-type mix) or 'recent' (actual 28-day average); intake_kcal overrides both. Present the numbers as-is, never recompute.",
+        "Weight forecast from profile + weight log. Simulates day by day: Mifflin-St Jeor BMR on the moving weight × activity factor, calibrated against the measured backwards-TDEE when reliable. Returns predicted weight at target_date and at the profile's goal_date, the date the goal weight is reached (goal.eta), an uncertainty band (datadrivet ±band, se assumptions.band_kcal) with goal.eta_range, and weekly curve points. intake_source: 'targets' (default; day targets weighted by the recent day-type mix) or 'recent' (actual 28-day average); intake_kcal overrides both. Present the numbers as-is, never recompute.",
       inputSchema: {
         target_date: dateSchema.optional().describe("Datum att förutsäga vikten för"),
         goal_weight: z.number().positive().optional().describe("Överskuggar profilens målvikt"),
@@ -39,10 +39,13 @@ export function registerProfileTools(server: McpServer, db: Database): void {
     wrap((input) => {
       const view = buildForecast(db, input);
       if (!view.forecast) return jsonResult(view);
-      // Token-lean for the chat: weekly points instead of the daily curve.
+      // Token-lean for the chat: weekly points, and no ghost curve.
       const { curve, ...rest } = view.forecast;
       const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
-      return jsonResult({ forecast: { ...rest, curve: weekly } });
+      return jsonResult({
+        forecast: { ...rest, curve: weekly },
+        ...(view.accuracy && { accuracy: view.accuracy }),
+      });
     }),
   );
 }

--- a/kcal-assistant/src/tools/weights.ts
+++ b/kcal-assistant/src/tools/weights.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
 import { logWeight, getTrend } from "../db/weights";
+import { buildForecast } from "../db/forecast";
 import { dateSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
@@ -17,7 +18,15 @@ export function registerWeightTools(server: McpServer, db: Database): void {
         note: z.string().optional().describe("E.g. 'efter flexhelg', 'kreatinladdning'"),
       },
     },
-    wrap((input) => jsonResult(logWeight(db, input))),
+    wrap((input) => {
+      const view = logWeight(db, input);
+      try {
+        buildForecast(db); // canonical → snapshot; best-effort by construction
+      } catch (e) {
+        console.error("snapshot after log_weight:", e instanceof Error ? e.message : e);
+      }
+      return jsonResult(view);
+    }),
   );
 
   server.registerTool(

--- a/kcal-assistant/src/ui/app/api.ts
+++ b/kcal-assistant/src/ui/app/api.ts
@@ -64,7 +64,7 @@ export interface DayTargets { kcal: number; protein_min: number; fat_min: number
 export interface DayView { date: string; day_type: string; targets: DayTargets; meals: Meal[]; totals: Macros; remaining: Macros }
 export interface DaySummary { date: string; day_type: string; meal_count: number; totals: Macros }
 export interface WeightEntry { date: string; weight_kg: number }
-export interface TrendView { latest: WeightEntry | null; stale: boolean; reason?: string;
+export interface TrendView { latest: (WeightEntry & { trend_kg: number }) | null; stale: boolean; reason?: string;
   trend: { delta_kg: number; span_days: number; rate_kg_week: number; est_tdee: number | null; uncertain: boolean; intake_days: number } | null;
   weights: WeightEntry[] }
 export interface WeekView { days_logged: number; start_date: string; end_date: string; avg_logged: Macros | null; avg_target_kcal: number }
@@ -73,13 +73,15 @@ export interface Product { id: number; name: string; brand: string | null; per_1
 export interface RecipeSummary { id: number; name: string; tags: string | null; servings: number | null; kcal_per_serving: number | null; total_minutes: number | null; incomplete?: true }
 export interface RecipeIngredient { description: string; grams: number | null; quantity: number | null; kcal?: number; unresolved?: true; reason?: string }
 export interface RecipeView { id: number; name: string; instructions: string | null; notes: string | null; tags: string | null; servings: number | null; active_minutes: number | null; total_minutes: number | null; ingredients: RecipeIngredient[]; totals: Macros; totals_incomplete?: true; per_serving: Macros | null }
-export interface Weight { date: string; weight_kg: number; note: string | null }
+export interface Weight { date: string; weight_kg: number; trend_kg: number; note: string | null }
 export interface ForecastPoint { date: string; kg: number; low: number; high: number }
+export interface AccuracyBucket { days: number; n: number; mae_kg: number; bias_kg: number }
 export interface Forecast { start: { date: string; weight_kg: number; stale: boolean };
-  assumptions: { intake_kcal: number; intake_source: string; tdee_start: number; calibration: string };
+  assumptions: { intake_kcal: number; intake_source: string; tdee_start: number; calibration: string; band_kcal: number };
   curve: ForecastPoint[]; weight_at_target: ForecastPoint | null; weight_at_goal_date: ForecastPoint | null;
-  goal: { weight_kg: number; eta: string | null; reached: boolean; reason?: string } | null; notes: string[] }
-export interface ForecastView { forecast: Forecast | null; reason?: string }
+  goal: { weight_kg: number; eta: string | null; eta_range: { earliest: string | null; latest: string | null }; reached: boolean; reason?: string } | null; notes: string[] }
+export interface ForecastView { forecast: Forecast | null; reason?: string;
+  accuracy?: { per_age: AccuracyBucket[] }; ghost?: { snapshot_date: string; curve: ForecastPoint[] } }
 export interface Profile { birth_date: string; sex: "man" | "kvinna"; height_cm: number; activity_factor: number; goal_weight_kg: number | null; goal_date: string | null }
 export interface Preference { id: number; category: string; content: string }
 export interface OverviewView { day: DayView; trend: TrendView; week: WeekView; counts: { products: number; recipes: number } }

--- a/kcal-assistant/src/ui/app/components/PrognosPanel.tsx
+++ b/kcal-assistant/src/ui/app/components/PrognosPanel.tsx
@@ -24,11 +24,13 @@ const ACTIVITY_LEVELS: SelectOption[] = [
   { value: "1.9", label: "extremt aktiv (1,9)", description: "mycket hård träning och fysiskt arbete" },
 ];
 
-export function PrognosPanel({ profile, params, setParams, onSaved }: {
+export function PrognosPanel({ profile, params, setParams, onSaved, onPin, canPin }: {
   profile: Profile | null;
   params: PrognosParams;
   setParams: (fn: (prev: PrognosParams) => PrognosParams) => void;
   onSaved: () => void;
+  onPin: () => void;
+  canPin: boolean;
 }) {
   const hasProfile = profile !== null;
   const storedAf = profile ? String(profile.activity_factor) : "";
@@ -103,6 +105,9 @@ export function PrognosPanel({ profile, params, setParams, onSaved }: {
             {label}
           </button>
         ))}
+        <button className="chip" disabled={!canPin} onClick={onPin} title="fäst nuvarande förhandsvisning som jämförelse">
+          fäst scenario
+        </button>
       </div>
       <Collapsible.Root defaultOpen={!hasProfile}>
         <div className="card">

--- a/kcal-assistant/src/ui/app/components/WeightChart.tsx
+++ b/kcal-assistant/src/ui/app/components/WeightChart.tsx
@@ -4,8 +4,9 @@ import { sv, type Forecast, type ForecastPoint, type Weight } from "../api";
 
 const W = 640, H = 240, M = { top: 16, right: 52, bottom: 24, left: 10 };
 const DAY = 86_400_000;
+const NO_SCENARIOS: Array<{ slot: 0 | 1; curve: ForecastPoint[] }> = [];
 
-export function WeightChart({ series, forecast, ghost = null, scenarios = [] }: {
+export function WeightChart({ series, forecast, ghost = null, scenarios = NO_SCENARIOS }: {
   series: Weight[]; forecast: Forecast | null;
   ghost?: { snapshot_date: string; curve: ForecastPoint[] } | null;
   scenarios?: Array<{ slot: 0 | 1; curve: ForecastPoint[] }>;

--- a/kcal-assistant/src/ui/app/components/WeightChart.tsx
+++ b/kcal-assistant/src/ui/app/components/WeightChart.tsx
@@ -1,11 +1,15 @@
 import { useMemo, useRef, useState } from "react";
 import { invertScale, makeScale, nearestHit, tickDates, type HoverHit } from "../lib/chart";
-import { sv, type Forecast, type Weight } from "../api";
+import { sv, type Forecast, type ForecastPoint, type Weight } from "../api";
 
 const W = 640, H = 240, M = { top: 16, right: 52, bottom: 24, left: 10 };
 const DAY = 86_400_000;
 
-export function WeightChart({ series, forecast }: { series: Weight[]; forecast: Forecast | null }) {
+export function WeightChart({ series, forecast, ghost = null, scenarios = [] }: {
+  series: Weight[]; forecast: Forecast | null;
+  ghost?: { snapshot_date: string; curve: ForecastPoint[] } | null;
+  scenarios?: Array<{ slot: 0 | 1; curve: ForecastPoint[] }>;
+}) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [hover, setHover] = useState<HoverHit | null>(null);
 
@@ -21,9 +25,23 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
       .filter((p) => Date.parse(p.date) <= horizon)
       .map((p) => ({ t: Date.parse(p.date), kg: p.kg, low: p.low, high: p.high }));
     const goalKg = forecast?.goal?.weight_kg ?? null;
-    const actual = series.map((w) => ({ t: Date.parse(w.date), kg: w.weight_kg }));
-    const allT = [...actual.map((p) => p.t), ...drawn.map((p) => p.t)];
-    const allKg = [...actual.map((p) => p.kg), ...drawn.flatMap((p) => [p.low, p.high]), ...(goalKg !== null ? [goalKg] : [])];
+    const actual = series.map((w) => ({ t: Date.parse(w.date), kg: w.weight_kg, trend: w.trend_kg }));
+    const lastActualT = actual.at(-1)?.t ?? 0;
+    const ghostPts = ghost
+      ? ghost.curve.map((p) => ({ t: Date.parse(p.date), kg: p.kg })).filter((p) => p.t <= lastActualT)
+      : [];
+    const scenarioPts = scenarios.map((s) => ({
+      slot: s.slot,
+      pts: s.curve.map((p) => ({ t: Date.parse(p.date), kg: p.kg })).filter((p) => p.t <= horizon),
+    }));
+    const allT = [
+      ...actual.map((p) => p.t), ...drawn.map((p) => p.t),
+      ...ghostPts.map((p) => p.t), ...scenarioPts.flatMap((s) => s.pts.map((p) => p.t)),
+    ];
+    const allKg = [
+      ...actual.map((p) => p.kg), ...drawn.flatMap((p) => [p.low, p.high]), ...(goalKg !== null ? [goalKg] : []),
+      ...ghostPts.map((p) => p.kg), ...scenarioPts.flatMap((s) => s.pts.map((p) => p.kg)),
+    ];
     const x0 = Math.min(...allT), x1 = Math.max(...allT);
     const pad = Math.max(0.4, (Math.max(...allKg) - Math.min(...allKg)) * 0.15);
     const y0 = Math.min(...allKg) - pad, y1 = Math.max(...allKg) + pad;
@@ -33,10 +51,19 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
     const markers: Array<[number, string]> = [];
     if (forecast?.goal?.eta) markers.push([Date.parse(forecast.goal.eta), "mål"]);
     if (forecast?.weight_at_goal_date) markers.push([Date.parse(forecast.weight_at_goal_date.date), "måldatum"]);
-    return { drawn, goalKg, actual, x0, x1, y0, y1, X, Y, invX, markers };
-  }, [series, forecast]);
+    return { drawn, goalKg, actual, x0, x1, y0, y1, X, Y, invX, markers, horizon, ghostPts };
+  }, [series, forecast, ghost, scenarios]);
 
-  const { drawn, goalKg, actual, x0, x1, y0, y1, X, Y, invX, markers } = g;
+  const { drawn, goalKg, actual, x0, x1, y0, y1, X, Y, invX, markers, horizon, ghostPts } = g;
+
+  const kgAt = (curve: ForecastPoint[], t: number): number | null => {
+    let best: number | null = null, bestD = 4 * DAY;
+    for (const p of curve) {
+      const d = Math.abs(Date.parse(p.date) - t);
+      if (d < bestD) { bestD = d; best = p.kg; }
+    }
+    return best;
+  };
 
   const onPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -57,7 +84,7 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
       drawn.map((p) => `L${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")
     : null;
   const actualD = actual.length >= 2
-    ? actual.map((p, i) => `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")
+    ? actual.map((p, i) => `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.trend).toFixed(1)}`).join("")
     : null;
 
   // Tooltip box: clamp inside the frame; flip above/below the point.
@@ -90,6 +117,17 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
             <text className="axis-label" x={X(t) + 3} y={M.top + 8}>{text}</text>
           </g>
         ))}
+        {ghostPts.length >= 2 ? (
+          <path className="ghost-line" d={ghostPts.map((p, i) =>
+            `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")} />
+        ) : null}
+        {scenarios.map((s) => {
+          const pts = s.curve.map((p) => ({ t: Date.parse(p.date), kg: p.kg })).filter((p) => p.t <= horizon);
+          return pts.length >= 2 ? (
+            <path key={s.slot} className={`scenario-line s${s.slot}`} d={pts.map((p, i) =>
+              `${i === 0 ? "M" : "L"}${X(p.t).toFixed(1)},${Y(p.kg).toFixed(1)}`).join("")} />
+          ) : null;
+        })}
         {projD ? <path className="forecast-line" d={projD} /> : null}
         {actualD ? <path className="trend-line" d={actualD} /> : null}
         {actual.map((p, i) => (
@@ -105,7 +143,7 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
             <line className="hover-crosshair" x1={X(hover.t)} x2={X(hover.t)} y1={M.top} y2={H - M.bottom} />
             <circle className="hover-dot" cx={X(hover.t)} cy={Y(hover.kg)} r={4.5} />
             <g transform={`translate(${tip.x},${tip.y})`}>
-              <rect className="hover-tip-bg" x={-58} y={-30} width={116} height={hover.kind === "prognos" ? 34 : 26} rx={2} />
+              <rect className="hover-tip-bg" x={-58} y={-30} width={116} height={34 + scenarios.length * 10} rx={2} />
               <text className="hover-tip-date" x={0} y={-19} textAnchor="middle">{new Date(hover.t).toISOString().slice(0, 10)}</text>
               <text className="hover-tip-kg" x={0} y={-7} textAnchor="middle">
                 {hover.kind === "actual" ? `${sv(hover.kg)} kg` : `≈ ${sv(hover.kg)} kg`}
@@ -113,6 +151,14 @@ export function WeightChart({ series, forecast }: { series: Weight[]; forecast: 
               {hover.kind === "prognos" ? (
                 <text className="hover-tip-band" x={0} y={2} textAnchor="middle">({sv(hover.low)}–{sv(hover.high)})</text>
               ) : null}
+              {hover.kind === "actual" ? (
+                <text className="hover-tip-band" x={0} y={2} textAnchor="middle">trend {sv(hover.trend)}</text>
+              ) : null}
+              {scenarios.map((s, i) => (
+                <text key={s.slot} className="hover-tip-band" x={0} y={13 + i * 10} textAnchor="middle">
+                  S{s.slot + 1} ≈ {sv(kgAt(s.curve, hover.t))} kg
+                </text>
+              ))}
             </g>
           </g>
         ) : null}

--- a/kcal-assistant/src/ui/app/lib/chart.ts
+++ b/kcal-assistant/src/ui/app/lib/chart.ts
@@ -17,10 +17,10 @@ export function tickDates(t0: number, t1: number, n: number): number[] {
   return out;
 }
 
-export interface ActualPt { t: number; kg: number }
+export interface ActualPt { t: number; kg: number; trend: number }
 export interface ProjPt { t: number; kg: number; low: number; high: number }
 export type HoverHit =
-  | { kind: "actual"; t: number; kg: number }
+  | { kind: "actual"; t: number; kg: number; trend: number }
   | { kind: "prognos"; t: number; kg: number; low: number; high: number };
 
 // Nearest by |t - tx| across both series; actual wins ties (<=) so a hover on
@@ -30,7 +30,7 @@ export function nearestHit(tx: number, actual: ActualPt[], proj: ProjPt[]): Hove
   let bestD = Infinity;
   for (const p of actual) {
     const d = Math.abs(p.t - tx);
-    if (d <= bestD) { bestD = d; best = { kind: "actual", t: p.t, kg: p.kg }; }
+    if (d <= bestD) { bestD = d; best = { kind: "actual", t: p.t, kg: p.kg, trend: p.trend }; }
   }
   for (const p of proj) {
     const d = Math.abs(p.t - tx);

--- a/kcal-assistant/src/ui/app/views/Vikt.tsx
+++ b/kcal-assistant/src/ui/app/views/Vikt.tsx
@@ -19,6 +19,7 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
     return () => clearTimeout(t);
   }, [params]);
   const fc = useApi<ForecastView>(`/ui/api/forecast?${query}`, true);
+  const [showGhost, setShowGhost] = useState(false);
 
   if (weights.error) return <ErrorNote message={weights.error} />;
   if (profileRes.error) return <ErrorNote message={profileRes.error} />;
@@ -28,15 +29,23 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
 
   const series = [...data.weights].reverse(); // ascending by date
   const forecast = fc.data?.forecast ?? null;
+  const ghostData = fc.data?.ghost ?? null;
   const t = data.trend;
   const previewing = Object.keys(params.overrides).length > 0;
 
   return (
     <>
       <h2>Vikt</h2>
-      {(series.length >= 2 || forecast) ? <WeightChart series={series} forecast={forecast} /> : null}
+      {(series.length >= 2 || forecast) ? <WeightChart series={series} forecast={forecast} ghost={showGhost ? ghostData : null} /> : null}
+      {ghostData ? (
+        <div className="chip-row">
+          <button className={`chip${showGhost ? " accent" : ""}`} onClick={() => setShowGhost((v) => !v)}>
+            prognos för {Math.round((Date.now() - Date.parse(ghostData.snapshot_date)) / 86_400_000)} d sedan
+          </button>
+        </div>
+      ) : null}
       <div className="tiles">
-        {t.latest ? <Tile label="Senast" value={`${sv(t.latest.weight_kg)} kg`} sub={t.latest.date + (t.stale ? " · gammal" : "")} /> : null}
+        {t.latest ? <Tile label="Senast" value={`${sv(t.latest.weight_kg)} kg`} sub={`${t.latest.date}${t.stale ? " · gammal" : ""} · trend ${sv(t.latest.trend_kg)}`} /> : null}
         {t.trend ? (
           <>
             <Tile label="Takt" value={`${sv(t.trend.rate_kg_week)} kg/v`} sub={`${sv(t.trend.delta_kg)} kg / ${sv(t.trend.span_days, 0)} d`} />
@@ -51,6 +60,18 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
       {fc.error ? <div className="error-banner">Kunde inte hämta prognosen ({fc.error}){fc.data ? " — visar senaste lyckade." : ""}</div> : null}
       {fc.data && !fc.data.forecast ? <EmptyState>Ingen prognos: {fc.data.reason}</EmptyState> : null}
       {forecast ? <PrognosResult f={forecast} /> : null}
+      {fc.data?.accuracy ? (
+        <>
+          <h2>Träffsäkerhet</h2>
+          <div className="tiles">
+            {fc.data.accuracy.per_age.map((b) => (
+              <Tile key={b.days} label={`${b.days} d`} value={`±${sv(b.mae_kg)} kg`}
+                    sub={`bias ${b.bias_kg > 0 ? "+" : ""}${sv(b.bias_kg)} kg · ${b.n} prognoser`} />
+            ))}
+          </div>
+          <div className="note">Hur tidigare prognoser träffat trendvikten i efterhand. Positiv bias = prognosen låg för högt.</div>
+        </>
+      ) : null}
       <h2>Alla vägningar</h2>
       <div className="tablewrap">
         <table>
@@ -67,7 +88,7 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
 }
 
 interface TrendData {
-  latest: { date: string; weight_kg: number } | null;
+  latest: { date: string; weight_kg: number; trend_kg: number } | null;
   stale: boolean;
   reason?: string;
   trend: { delta_kg: number; span_days: number; rate_kg_week: number; est_tdee: number | null; uncertain: boolean; intake_days: number } | null;
@@ -82,7 +103,11 @@ function PrognosResult({ f }: { f: Forecast }) {
   return (
     <>
       <div className="tiles">
-        {f.goal ? <Tile label="Målvikt" value={`${sv(f.goal.weight_kg)} kg`} sub={f.goal.reached ? "uppnådd" : f.goal.eta ? `nås ≈ ${f.goal.eta}` : f.goal.reason ?? null} /> : null}
+        {f.goal ? <Tile label="Målvikt" value={`${sv(f.goal.weight_kg)} kg`}
+          sub={f.goal.reached ? "uppnådd"
+            : f.goal.eta
+              ? `nås ≈ ${f.goal.eta}${f.goal.eta_range.earliest ? ` (${f.goal.eta_range.earliest} – ${f.goal.eta_range.latest ?? "senare"})` : ""}`
+              : f.goal.reason ?? null} /> : null}
         {f.weight_at_goal_date ? <Tile label="Vid måldatum" value={`≈ ${sv(f.weight_at_goal_date.kg)} kg`} sub={f.weight_at_goal_date.date} /> : null}
         <Tile label="TDEE i kalkylen" value={sv(f.assumptions.tdee_start, 0)} sub={f.assumptions.calibration === "mätdata" ? "kalibrerad mot mätdata" : "formel (Mifflin-St Jeor)"} />
         <Tile label="Intag i kalkylen" value={sv(f.assumptions.intake_kcal, 0)}

--- a/kcal-assistant/src/ui/app/views/Vikt.tsx
+++ b/kcal-assistant/src/ui/app/views/Vikt.tsx
@@ -9,6 +9,31 @@ export function Vikt() {
   return <ViktInner key={epoch} onSaved={() => setEpoch((e) => e + 1)} />;
 }
 
+const STORAGE_KEY = "kcal.scenarios";
+
+function loadPinned(): PrognosParams[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((p): p is PrognosParams =>
+      p && (p.source === "targets" || p.source === "recent") && typeof p.overrides === "object" && p.overrides !== null,
+    ).slice(0, 2);
+  } catch {
+    return [];
+  }
+}
+
+function scenarioLabel(p: PrognosParams): string {
+  const parts: string[] = [];
+  const o = p.overrides;
+  if (o.intake) parts.push(`intag ${o.intake}`);
+  if (o.activity) parts.push(`aktivitet ${o.activity.replace(".", ",")}`);
+  if (o.goal) parts.push(`mål ${o.goal}`);
+  if (o.goal_date) parts.push(`till ${o.goal_date}`);
+  if (p.source === "recent") parts.push("senaste 28 d");
+  return parts.length ? parts.join(" · ") : "planmål";
+}
+
 function ViktInner({ onSaved }: { onSaved: () => void }) {
   const weights = useApi<{ weights: Weight[]; trend: TrendData }>("/ui/api/weights");
   const profileRes = useApi<{ profile: Profile | null }>("/ui/api/profile");
@@ -20,6 +45,17 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
   }, [params]);
   const fc = useApi<ForecastView>(`/ui/api/forecast?${query}`, true);
   const [showGhost, setShowGhost] = useState(false);
+  const [pinned, setPinned] = useState<PrognosParams[]>(loadPinned);
+  useEffect(() => { localStorage.setItem(STORAGE_KEY, JSON.stringify(pinned)); }, [pinned]);
+  const pin = () => setPinned((prev) => [...prev, params].slice(-2)); // third pin replaces the oldest
+  const unpin = (i: number) => setPinned((prev) => prev.filter((_, idx) => idx !== i));
+  const s0 = useApi<ForecastView>(pinned[0] ? `/ui/api/forecast?${forecastQuery(pinned[0])}` : null, true);
+  const s1 = useApi<ForecastView>(pinned[1] ? `/ui/api/forecast?${forecastQuery(pinned[1])}` : null, true);
+  const scenarios = [
+    ...(pinned[0] && s0.data?.forecast ? [{ slot: 0 as const, curve: s0.data.forecast.curve }] : []),
+    ...(pinned[1] && s1.data?.forecast ? [{ slot: 1 as const, curve: s1.data.forecast.curve }] : []),
+  ];
+  const canPin = params.source !== "targets" || Object.values(params.overrides).some((v) => v !== undefined && v !== "");
 
   if (weights.error) return <ErrorNote message={weights.error} />;
   if (profileRes.error) return <ErrorNote message={profileRes.error} />;
@@ -36,7 +72,7 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
   return (
     <>
       <h2>Vikt</h2>
-      {(series.length >= 2 || forecast) ? <WeightChart series={series} forecast={forecast} ghost={showGhost ? ghostData : null} /> : null}
+      {(series.length >= 2 || forecast) ? <WeightChart series={series} forecast={forecast} ghost={showGhost ? ghostData : null} scenarios={scenarios} /> : null}
       {ghostData ? (
         <div className="chip-row">
           <button className={`chip${showGhost ? " accent" : ""}`} onClick={() => setShowGhost((v) => !v)}>
@@ -55,8 +91,22 @@ function ViktInner({ onSaved }: { onSaved: () => void }) {
         ) : t.reason ? <Tile label="Trend" value="—" sub={t.reason} /> : null}
       </div>
       <h2>Prognos</h2>
-      <PrognosPanel profile={profileRes.data?.profile ?? null} params={params} setParams={setParams} onSaved={onSaved} />
+      <PrognosPanel profile={profileRes.data?.profile ?? null} params={params} setParams={setParams} onSaved={onSaved} onPin={pin} canPin={canPin} />
       {previewing ? <div className="chip-row"><span className="chip accent">förhandsvisning — ej sparad</span></div> : null}
+      {pinned.length ? (
+        <div className="chip-row">
+          {pinned.map((p, i) => {
+            const res = i === 0 ? s0 : s1;
+            const eta = res.data?.forecast?.goal?.eta;
+            return (
+              <span key={i} className={`chip scenario-chip s${i}`}>
+                {scenarioLabel(p)}{eta ? ` · mål ≈ ${eta}` : ""}
+                <button className="chip-x" aria-label="ta bort scenario" onClick={() => unpin(i)}>×</button>
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
       {fc.error ? <div className="error-banner">Kunde inte hämta prognosen ({fc.error}){fc.data ? " — visar senaste lyckade." : ""}</div> : null}
       {fc.data && !fc.data.forecast ? <EmptyState>Ingen prognos: {fc.data.reason}</EmptyState> : null}
       {forecast ? <PrognosResult f={forecast} /> : null}

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -515,6 +515,9 @@ button.chip:focus-visible { outline: 2px solid var(--accent-dim); outline-offset
 .scenario-line { fill: none; stroke-width: 1.5; }
 .scenario-line.s0 { stroke: #0072b2; }
 .scenario-line.s1 { stroke: #e69f00; }
+.scenario-chip .chip-x { background: none; border: none; cursor: pointer; margin-left: 4px; font-size: 12px; color: inherit; }
+.scenario-chip.s0 { border-color: #0072b2; }
+.scenario-chip.s1 { border-color: #e69f00; }
 
 /* collapsible profile (v0.8) */
 .collapsible-summary { display: block; width: 100%; text-align: left; font: inherit; font-family: var(--mono); font-size: 13px; color: var(--ink); background: none; border: none; padding: 10px 12px; cursor: pointer; }

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -510,6 +510,12 @@ button.chip:focus-visible { outline: 2px solid var(--accent-dim); outline-offset
 .hover-tip-band { fill: var(--ink-3); font-family: var(--mono); font-size: 9px; pointer-events: none; }
 .chart-frame svg { touch-action: pan-y; }
 
+/* ghost + scenario layers (v0.9) */
+.ghost-line { fill: none; stroke: var(--ink, currentColor); stroke-width: 1; stroke-dasharray: 3 4; opacity: 0.35; }
+.scenario-line { fill: none; stroke-width: 1.5; }
+.scenario-line.s0 { stroke: #0072b2; }
+.scenario-line.s1 { stroke: #e69f00; }
+
 /* collapsible profile (v0.8) */
 .collapsible-summary { display: block; width: 100%; text-align: left; font: inherit; font-family: var(--mono); font-size: 13px; color: var(--ink); background: none; border: none; padding: 10px 12px; cursor: pointer; }
 .collapsible-summary:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 0; }

--- a/kcal-assistant/tests/accuracy.test.ts
+++ b/kcal-assistant/tests/accuracy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { computeForecastAccuracy, pickGhost } from "../src/lib/accuracy";
+import { addDays } from "../src/lib/dates";
+
+// Synthetic fixtures only — public repo.
+// Snapshot curve: linear 100 → falling 0.1 kg/day, weekly points over 8 weeks.
+function snapshotAt(date: string, startKg: number, lossPerDay = 0.1) {
+  const curve = [0, 7, 14, 21, 28, 35, 42, 49, 56].map((d) => ({
+    date: addDays(date, d), kg: startKg - d * lossPerDay,
+  }));
+  return { date, curve };
+}
+// Daily trend weights matching that exact line.
+function trendLine(start: string, days: number, startKg: number, lossPerDay = 0.1) {
+  return Array.from({ length: days }, (_, i) => ({
+    date: addDays(start, i), trend_kg: startKg - i * lossPerDay,
+  }));
+}
+const T0 = "2026-05-01";
+
+describe("computeForecastAccuracy", () => {
+  test("perfect forecasts give zero error", () => {
+    const snapshots = [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1));
+    const acc = computeForecastAccuracy({
+      snapshots, trendWeights: trendLine(T0, 40, 100), today: addDays(T0, 39),
+    })!;
+    const d7 = acc.per_age.find((b) => b.days === 7)!;
+    expect(d7.n).toBe(3);
+    expect(d7.mae_kg).toBe(0);
+    expect(d7.bias_kg).toBe(0);
+  });
+
+  test("optimistic forecasts show negative bias, mae positive", () => {
+    // Forecast says −0.2/day but reality is −0.1/day → predicted BELOW actual.
+    const snapshots = [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1, 0.2));
+    const acc = computeForecastAccuracy({
+      snapshots, trendWeights: trendLine(T0, 40, 100), today: addDays(T0, 39),
+    })!;
+    const d7 = acc.per_age.find((b) => b.days === 7)!;
+    expect(d7.bias_kg).toBeLessThan(0);
+    expect(d7.mae_kg).toBe(Math.abs(d7.bias_kg));
+  });
+
+  test("interpolates between weekly points (age 14+3 lands mid-week)", () => {
+    // A single snapshot, weigh-in exactly 17 days later only.
+    const acc = computeForecastAccuracy({
+      snapshots: [snapshotAt(T0, 100), snapshotAt(addDays(T0, 1), 99.9), snapshotAt(addDays(T0, 2), 99.8)],
+      trendWeights: [14, 15, 16, 17, 18].map((d) => ({ date: addDays(T0, d), trend_kg: 100 - d * 0.1 })),
+      today: addDays(T0, 30),
+    });
+    expect(acc).not.toBeNull();
+    expect(acc!.per_age.find((b) => b.days === 14)!.mae_kg).toBe(0);
+  });
+
+  test("no weigh-in within ±3 days → sample skipped; n<3 → bucket dropped; none → null", () => {
+    expect(computeForecastAccuracy({
+      snapshots: [snapshotAt(T0, 100)],
+      trendWeights: [{ date: addDays(T0, 20), trend_kg: 98 }],
+      today: addDays(T0, 60),
+    })).toBeNull(); // n=1 for 14/28... never ≥3 with one snapshot
+  });
+
+  test("future ages are excluded", () => {
+    const acc = computeForecastAccuracy({
+      snapshots: [0, 1, 2].map((i) => snapshotAt(addDays(T0, i), 100 - i * 0.1)),
+      trendWeights: trendLine(T0, 12, 100),
+      today: addDays(T0, 11),
+    })!;
+    expect(acc.per_age.map((b) => b.days)).toEqual([7]); // 14/28/56 not aged yet
+  });
+});
+
+describe("pickGhost", () => {
+  const s = (d: string) => ({ date: d });
+  test("picks the snapshot nearest 28 days old, requiring ≥21", () => {
+    const today = "2026-06-30";
+    expect(pickGhost([s("2026-06-25"), s("2026-06-05"), s("2026-05-20")], today))
+      .toEqual(s("2026-06-05")); // ages: 5 (too young), 25, 41 → 25 nearest 28
+  });
+  test("null when nothing is old enough", () => {
+    expect(pickGhost([s("2026-06-25")], "2026-06-30")).toBeNull();
+  });
+});

--- a/kcal-assistant/tests/chart.test.ts
+++ b/kcal-assistant/tests/chart.test.ts
@@ -36,11 +36,11 @@ describe("tickDates", () => {
 });
 
 describe("nearestHit", () => {
-  const actual = [{ t: 0, kg: 100 }, { t: 10, kg: 99 }];
+  const actual = [{ t: 0, kg: 100, trend: 100.3 }, { t: 10, kg: 99, trend: 99.1 }];
   const proj = [{ t: 20, kg: 98, low: 97, high: 99 }, { t: 30, kg: 97.5, low: 96, high: 99 }];
 
   test("picks nearest actual point", () => {
-    expect(nearestHit(2, actual, proj)).toEqual({ kind: "actual", t: 0, kg: 100 });
+    expect(nearestHit(2, actual, proj)).toEqual({ kind: "actual", t: 0, kg: 100, trend: 100.3 });
   });
 
   test("picks nearest projection point with band", () => {
@@ -48,7 +48,12 @@ describe("nearestHit", () => {
   });
 
   test("actual wins exact ties and empty input gives null", () => {
-    expect(nearestHit(15, actual, proj)).toEqual({ kind: "actual", t: 10, kg: 99 });
+    expect(nearestHit(15, actual, proj)).toEqual({ kind: "actual", t: 10, kg: 99, trend: 99.1 });
     expect(nearestHit(5, [], [])).toBeNull();
+  });
+
+  test("actual hit carries the trend value", () => {
+    const hit = nearestHit(1, [{ t: 1, kg: 100, trend: 100.2 }], []);
+    expect(hit).toEqual({ kind: "actual", t: 1, kg: 100, trend: 100.2 });
   });
 });

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -75,10 +75,12 @@ describe("computeForecast", () => {
     expect(f.curve[10]!.high).toBeGreaterThan(f.curve[10]!.kg);
   });
 
-  test("start smooths weigh-ins within 7 days of the latest", () => {
+  test("start is the EWMA trend weight at the latest weigh-in", () => {
     const f = run({ weights: [W("2026-07-02", 82.4), W("2026-07-06", 82.0), W(TODAY, 81.6)] });
-    expect(f.start.weight_kg).toBe(82);
-    expect(f.start.weighins_smoothed).toBe(3);
+    // trend: 82.4 → +0.3439·(82−82.4)=82.26244 → +0.271·(81.6−82.26244)=82.08292
+    expect(f.start.weight_kg).toBe(82.08);
+    expect(f.start.date).toBe(TODAY);
+    expect("weighins_smoothed" in f.start).toBe(false);
   });
 
   test("a stale log starts the simulation at the weigh-in date", () => {

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -133,6 +133,28 @@ describe("computeForecast", () => {
     expect(f.curve.length).toBeLessThan(365);
     expect(f.notes.join(" ")).toContain("40 kg");
   });
+
+  test("eta_range brackets the point ETA", () => {
+    const f = run(); // goal 80, eta day 13, band 400
+    const r = f.goal!.eta_range;
+    expect(r.earliest).not.toBeNull();
+    expect(r.latest).not.toBeNull();
+    expect(r.earliest! < f.goal!.eta!).toBe(true); // ISO strings compare correctly
+    expect(f.goal!.eta! < r.latest!).toBe(true);
+  });
+
+  test("latest is null when the high curve misses the horizon", () => {
+    const f = run({ horizon_days: 14 }); // main hits day 13, low ~day 10, high ~day 19
+    expect(f.goal!.eta).not.toBeNull();
+    expect(f.goal!.eta_range.earliest).not.toBeNull();
+    expect(f.goal!.eta_range.latest).toBeNull();
+  });
+
+  test("moving away from the goal gives an all-null range", () => {
+    const f = run({ intake_kcal: 4000 }); // surplus, goal below start
+    expect(f.goal!.eta).toBeNull();
+    expect(f.goal!.eta_range).toEqual({ earliest: null, latest: null });
+  });
 });
 
 describe("buildForecast", () => {

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+import { computeForecast, computeBand, type ForecastProfile } from "../src/lib/forecast";
 import { addDays } from "../src/lib/dates";
 import type { Database } from "bun:sqlite";
 import { openDb } from "../src/db/index";
@@ -239,5 +239,46 @@ describe("buildForecast", () => {
     expect(preview.notes.join(" ")).toContain("påverkas mindre av ändrad aktivitetsfaktor");
     const samAsStored = buildForecast(db, { today: TODAY, activity_factor: 1.5 }).forecast!;
     expect(samAsStored.notes.join(" ")).not.toContain("aktivitetsfaktor");
+  });
+});
+
+describe("computeBand", () => {
+  test("best case: mätdata + recent + tät vägning = 175", () => {
+    const b = computeBand({ calibration: "mätdata", intake_source: "recent", weighins_last_28d: 20 });
+    expect(b.kcal).toBe(175); // 100 + 50 + 25
+  });
+
+  test("mätdata + targets = 225", () => {
+    expect(computeBand({ calibration: "mätdata", intake_source: "targets", weighins_last_28d: 20 }).kcal).toBe(225);
+  });
+
+  test("formel + targets + glest = 425 clamps to 400 and explains why", () => {
+    const b = computeBand({ calibration: "formel", intake_source: "targets", weighins_last_28d: 3 });
+    expect(b.kcal).toBe(400);
+    expect(b.reasons.join(" ")).toContain("formelkalibrering");
+    expect(b.reasons.join(" ")).toContain("glesa vägningar");
+  });
+
+  test("explicit intake counts as plan adherence (+75)", () => {
+    expect(computeBand({ calibration: "formel", intake_source: "explicit", weighins_last_28d: 20 }).kcal).toBe(375);
+  });
+});
+
+describe("band integration", () => {
+  test("assumptions.band_kcal reflects the budget and a note explains it", () => {
+    const f = run(); // explicit + formel + 1 weigh-in → 100+200+75+50 = 425 → 400
+    expect(f.assumptions.band_kcal).toBe(400);
+    expect(f.notes.join(" ")).toContain("±400");
+  });
+
+  test("band width drives the envelope", () => {
+    const wide = run(); // band 400
+    // 10 weigh-ins 2026-06-21 … 2026-07-07 (step 2) + TODAY = 11 within 28 d, no duplicate dates.
+    const dense = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18].map((i) =>
+      W(addDays("2026-06-21", i), 82));
+    const narrow = run({ weights: [...dense, W(TODAY, 82)], measured_tdee: 2500 }); // band 100+50+75 = 225
+    expect(narrow.assumptions.band_kcal).toBe(225);
+    expect(wide.curve[30]!.high - wide.curve[30]!.low)
+      .toBeGreaterThan(narrow.curve[30]!.high - narrow.curve[30]!.low);
   });
 });

--- a/kcal-assistant/tests/snapshots.test.ts
+++ b/kcal-assistant/tests/snapshots.test.ts
@@ -6,6 +6,7 @@ import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
 import { buildForecast } from "../src/db/forecast";
 import { setProfile } from "../src/db/profile";
 import { logWeight } from "../src/db/weights";
+import { addDays } from "../src/lib/dates";
 
 // Synthetic fixtures only — public repo.
 const PROFILE: ForecastProfile = {
@@ -79,5 +80,28 @@ describe("canonical snapshot wiring", () => {
     logWeight(bare, { weight_kg: 82, date: "2026-07-08" });
     expect(buildForecast(bare, { today: "2026-07-09" }).forecast).toBeNull();
     expect(listSnapshots(bare)).toHaveLength(0);
+  });
+});
+
+describe("aged snapshots", () => {
+  test("surface accuracy and ghost in the view", () => {
+    const db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    // Three backdated canonical snapshots, weights logged in date order.
+    for (const off of [-30, -29, -28]) {
+      const day = addDays("2026-07-09", off);
+      logWeight(db, { weight_kg: 82, date: day });
+      buildForecast(db, { today: day });
+    }
+    // Weigh-ins near each accuracy target (snap+7/14/28 within ±3 days).
+    for (const off of [-23, -16, -9, -2]) {
+      logWeight(db, { weight_kg: 82, date: addDays("2026-07-09", off) });
+    }
+    const view = buildForecast(db, { today: "2026-07-09" });
+    expect(view.forecast).not.toBeNull();
+    expect(view.accuracy).toBeDefined();
+    expect(view.accuracy!.per_age.find((b) => b.days === 7)!.n).toBe(3);
+    expect(view.ghost).toBeDefined();
+    expect(view.ghost!.snapshot_date).toBe(addDays("2026-07-09", -28)); // age 28 exactly
   });
 });

--- a/kcal-assistant/tests/snapshots.test.ts
+++ b/kcal-assistant/tests/snapshots.test.ts
@@ -3,6 +3,9 @@ import type { Database } from "bun:sqlite";
 import { openDb } from "../src/db/index";
 import { saveSnapshot, listSnapshots } from "../src/db/snapshots";
 import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+import { buildForecast } from "../src/db/forecast";
+import { setProfile } from "../src/db/profile";
+import { logWeight } from "../src/db/weights";
 
 // Synthetic fixtures only — public repo.
 const PROFILE: ForecastProfile = {
@@ -42,5 +45,39 @@ describe("forecast snapshots", () => {
     const rows = listSnapshots(db);
     expect(rows).toHaveLength(1);
     expect(rows[0]!.intake_kcal).toBe(1600);
+  });
+});
+
+describe("canonical snapshot wiring", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = openDb(":memory:");
+    setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+    logWeight(db, { weight_kg: 82, date: "2026-07-08" });
+  });
+
+  test("canonical buildForecast writes a snapshot", () => {
+    buildForecast(db, { today: "2026-07-09" });
+    expect(listSnapshots(db).map((s) => s.date)).toEqual(["2026-07-09"]);
+  });
+
+  test("preview calls never write", () => {
+    buildForecast(db, { today: "2026-07-09", intake_kcal: 1600 });
+    buildForecast(db, { today: "2026-07-09", intake_source: "recent" });
+    buildForecast(db, { today: "2026-07-09", activity_factor: 1.2 });
+    expect(listSnapshots(db)).toHaveLength(0);
+  });
+
+  test("snapshot failure never breaks the forecast", () => {
+    db.run("DROP TABLE forecast_snapshots");
+    const view = buildForecast(db, { today: "2026-07-09" });
+    expect(view.forecast).not.toBeNull();
+  });
+
+  test("no profile → no snapshot, no crash", () => {
+    const bare = openDb(":memory:");
+    logWeight(bare, { weight_kg: 82, date: "2026-07-08" });
+    expect(buildForecast(bare, { today: "2026-07-09" }).forecast).toBeNull();
+    expect(listSnapshots(bare)).toHaveLength(0);
   });
 });

--- a/kcal-assistant/tests/snapshots.test.ts
+++ b/kcal-assistant/tests/snapshots.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveSnapshot, listSnapshots } from "../src/db/snapshots";
+import { computeForecast, type ForecastProfile } from "../src/lib/forecast";
+
+// Synthetic fixtures only — public repo.
+const PROFILE: ForecastProfile = {
+  birth_date: "2000-01-15", sex: "man", height_cm: 180,
+  activity_factor: 1.5, goal_weight_kg: 80, goal_date: null,
+};
+
+function makeForecast(intake: number) {
+  return computeForecast({
+    profile: PROFILE,
+    weights: [{ date: "2026-07-09", weight_kg: 82 }],
+    intake_kcal: intake, intake_source: "explicit",
+    measured_tdee: null, today: "2026-07-09",
+  });
+}
+
+describe("forecast snapshots", () => {
+  let db: Database;
+  beforeEach(() => { db = openDb(":memory:"); });
+
+  test("save + list roundtrips with a weekly curve", () => {
+    saveSnapshot(db, makeForecast(1500), "2026-07-09");
+    const rows = listSnapshots(db);
+    expect(rows).toHaveLength(1);
+    const s = rows[0]!;
+    expect(s.date).toBe("2026-07-09");
+    expect(s.start_kg).toBe(82);
+    expect(s.intake_kcal).toBe(1500);
+    expect(s.band_kcal).toBe(400);
+    expect(s.curve.length).toBeLessThan(60); // weekly, not daily (365)
+    expect(s.curve[0]).toMatchObject({ date: "2026-07-09", kg: 82 });
+  });
+
+  test("same-day save upserts (last write wins)", () => {
+    saveSnapshot(db, makeForecast(1500), "2026-07-09");
+    saveSnapshot(db, makeForecast(1600), "2026-07-09");
+    const rows = listSnapshots(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.intake_kcal).toBe(1600);
+  });
+});

--- a/kcal-assistant/tests/trend.test.ts
+++ b/kcal-assistant/tests/trend.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { computeTrend } from "../src/lib/trend";
+import { computeTrend, computeTrendWeight } from "../src/lib/trend";
 import { toEpochDays, addDays } from "../src/lib/dates";
 
 // All fixtures use obviously synthetic weights (100 kg range) — public repo.
@@ -141,5 +141,48 @@ describe("computeTrend", () => {
       today: addDays(day(27), 10),
     });
     expect(result.stale).toBe(true);
+  });
+});
+
+describe("computeTrendWeight", () => {
+  test("single weigh-in: trend equals the weight", () => {
+    expect(computeTrendWeight([{ date: "2026-06-01", weight_kg: 100 }])).toEqual([
+      { date: "2026-06-01", weight_kg: 100, trend_kg: 100 },
+    ]);
+  });
+
+  test("1-day gap uses alpha 0.1", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-01", weight_kg: 100 },
+      { date: "2026-06-02", weight_kg: 99 },
+    ]);
+    expect(out[1]!.trend_kg).toBe(99.9); // 100 + 0.1·(99−100)
+  });
+
+  test("7-day gap uses alpha 1−0.9^7", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-01", weight_kg: 100 },
+      { date: "2026-06-08", weight_kg: 99 },
+    ]);
+    expect(out[1]!.trend_kg).toBe(99.48); // 100 − (1−0.4782969) = 99.4782969
+  });
+
+  test("trend lags a falling series (stays above raw)", () => {
+    const weights = [0, 1, 2, 3, 4].map((i) => ({
+      date: addDays("2026-06-01", i), weight_kg: 100 - i * 0.5,
+    }));
+    const out = computeTrendWeight(weights);
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]!.trend_kg).toBeGreaterThan(out[i]!.weight_kg);
+    }
+  });
+
+  test("unsorted input is sorted by date", () => {
+    const out = computeTrendWeight([
+      { date: "2026-06-02", weight_kg: 99 },
+      { date: "2026-06-01", weight_kg: 100 },
+    ]);
+    expect(out.map((p) => p.date)).toEqual(["2026-06-01", "2026-06-02"]);
+    expect(out[1]!.trend_kg).toBe(99.9);
   });
 });

--- a/kcal-assistant/tests/ui-api-forecast.test.ts
+++ b/kcal-assistant/tests/ui-api-forecast.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { createHttpServer } from "../src/server";
+import { logWeight } from "../src/db/weights";
+import { setProfile } from "../src/db/profile";
+
+const TOKEN = "test-token";
+let httpServer: Server;
+let db: Database;
+let base: string;
+
+// Own db + server, isolated from ui-api.test.ts on purpose: that suite has
+// profile-lifecycle tests that must not inherit a pre-seeded profile.
+beforeAll(async () => {
+  db = openDb(":memory:");
+  setProfile(db, { birth_date: "2000-01-15", sex: "man", height_cm: 180, activity_factor: 1.5, goal_weight_kg: 80 });
+  logWeight(db, { weight_kg: 100, date: "2026-07-08" });
+  httpServer = createHttpServer({ token: TOKEN, db, uiAuth: { mode: "dev-bypass" } });
+  await new Promise<void>((r) => httpServer.listen(0, r));
+  base = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((r) => httpServer.close(r));
+});
+
+describe("forecast + weights UI API (accuracy/ghost/trend_kg)", () => {
+  test("weights payload includes trend_kg on rows and latest", async () => {
+    const res = await fetch(`${base}/ui/api/weights`, { headers: { accept: "application/json" } });
+    const body = await res.json();
+    expect(body.weights[0].trend_kg).toBeTypeOf("number");
+    expect(body.trend.latest.trend_kg).toBeTypeOf("number");
+  });
+
+  test("forecast payload omits accuracy/ghost when no aged snapshots exist", async () => {
+    const res = await fetch(`${base}/ui/api/forecast`, { headers: { accept: "application/json" } });
+    const body = await res.json();
+    expect(body.forecast).not.toBeNull();
+    expect(body.forecast.assumptions.band_kcal).toBeTypeOf("number");
+    expect(body.forecast.goal.eta_range).toBeDefined();
+    expect("accuracy" in body).toBe(false); // only today's own snapshot exists (age 0)
+    expect("ghost" in body).toBe(false);
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.8.1
+          image: rutbergphilip/kcal-assistant:v0.9.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
Prognosmotor v2 per spec docs/superpowers/specs/2026-07-10-kcal-forecast-engine-v2-design.md:

- **Trendvikt**: EWMA-utjämning (α 0,10/dag, gap-justerad) — diagrammets linje, prognosens startvikt och get_trend/vikt-API:t använder trenden; rådata blir prickar.
- **Ärlig osäkerhet**: ±150 kcal ersatt av datadriven felbudget (kalibrering, intagskälla, vägningstäthet; 125–400 kcal) + mål-ETA som intervall (eta_range).
- **Träffsäkerhet**: migration 5, forecast_snapshots (kanoniska prognoser, upsert per dag, triggas bl.a. av log_weight), accuracy per ålder (7/14/28/56 d, MAE + bias) + ghost-kurva i UI.
- **Scenariojämförelse**: upp till 2 fästa what-if-kurvor på Vikt-sidan, localStorage-persistens. UI-only.

MCP: 24 verktyg, inga input-schemaändringar (get_forecast-beskrivningens bandformulering korrigerad). Ingen ny chatt behövs.

Kvalitet: 12 uppgifter, granskning per uppgift (alla Approved), slutlig helgrensgranskning: MERGE-READY. 201/201 tester, tsc clean, produktionsbygge verifierat i browser-walk (6/6).

Plan: docs/superpowers/plans/2026-07-10-kcal-forecast-engine-v2.md

https://claude.ai/code/session_018bdcBb7HJ6UUj8LXCt18qD