### PR TITLE
feat(kcal-assistant): v0.9.1 — temaväxlare + fast-follows

### DIFF
--- a/docs/superpowers/plans/2026-07-11-kcal-theme-switcher.md
+++ b/docs/superpowers/plans/2026-07-11-kcal-theme-switcher.md
@@ -1,0 +1,397 @@
+# kcal-assistant v0.9.1 — Temaväxlare Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A 3-state theme switcher (system → ljust → mörkt) for KCAL·DB with zero-flash startup, plus three ship-triaged v0.9.0 fast-follows.
+
+**Architecture:** The CSS palette collapses to single `light-dark()` variables switched by the `color-scheme` property; a tiny external blocking `theme.js` in `<head>` stamps the saved choice before first paint (strict CSP — no inline scripts); a masthead button cycles the state and persists it in `localStorage["kcal.theme"]`. UI-only release: no migration, no MCP changes.
+
+**Tech Stack:** Bun + TypeScript, React 19, plain CSS custom properties, `bun test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-kcal-theme-switcher-design.md` (approved). Branch: `kcal-v0.9.1-theme-switcher`.
+
+## Global Constraints
+
+- All commands run from `kcal-assistant/`; repo root is `homelab/`.
+- Swedish user-facing copy; English code/comments.
+- Strict CSP: NO inline scripts or styles — theme.js must be an external same-origin file.
+- MCP surface frozen: 24 tools, zero schema/description changes this release.
+- UI stays read-only except the pre-existing `PUT /ui/api/profile` — no new endpoints; static serving stays a hardcoded whitelist (no filesystem-derived paths).
+- `bun run build:ui` uses `--production` (never build without it); full `bun test` + `bunx tsc --noEmit` green at every commit.
+- localStorage keys: theme = `"kcal.theme"` (values `"light"`/`"dark"`; ABSENT = system), scenarios = `"kcal.scenarios"` (existing).
+- Commit style `feat(kcal-assistant): …`; end commit bodies with the Claude-Session trailer used on this branch.
+
+---
+
+### Task 1: Shared `weeklyCurve` helper
+
+**Files:**
+- Modify: `kcal-assistant/src/lib/forecast.ts`, `kcal-assistant/src/db/snapshots.ts:16-18`, `kcal-assistant/src/tools/profile.ts:43-45`
+- Test: `kcal-assistant/tests/forecast.test.ts`
+
+**Interfaces:**
+- Produces: `export function weeklyCurve<T>(curve: T[]): T[]` in `src/lib/forecast.ts` — weekly sampling (every 7th point + always the last). Both call sites import it; the duplicated one-liners are deleted.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/forecast.test.ts`:
+
+```ts
+import { weeklyCurve } from "../src/lib/forecast";
+
+describe("weeklyCurve", () => {
+  test("keeps every 7th point and always the last", () => {
+    const days = Array.from({ length: 16 }, (_, i) => i); // 0..15
+    expect(weeklyCurve(days)).toEqual([0, 7, 14, 15]);
+  });
+  test("single point and empty pass through", () => {
+    expect(weeklyCurve([42])).toEqual([42]);
+    expect(weeklyCurve([])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/forecast.test.ts`
+Expected: FAIL — `weeklyCurve` not exported.
+
+- [ ] **Step 3: Implement**
+  - Add to `src/lib/forecast.ts` (near the other small helpers):
+
+```ts
+// Weekly curve sampling shared by snapshot storage and the MCP get_forecast
+// response (token economy): every 7th point plus always the endpoint.
+export function weeklyCurve<T>(curve: T[]): T[] {
+  return curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+}
+```
+
+  - `src/db/snapshots.ts`: delete the local `weekly` const (lines 16-18) and its comment; import `weeklyCurve` from `../lib/forecast` (extend the existing import line) and use `weeklyCurve(forecast.curve)` in `saveSnapshot`.
+  - `src/tools/profile.ts`: in the `get_forecast` handler, replace `const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);` with `const weekly = weeklyCurve(curve);` and import `weeklyCurve` from `../lib/forecast`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: all pass (existing snapshot/roundtrip tests prove the call sites still sample identically).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/forecast.ts src/db/snapshots.ts src/tools/profile.ts tests/forecast.test.ts
+git commit -m "refactor(kcal-assistant): delad weeklyCurve-helper för veckosampling"
+```
+
+---
+
+### Task 2: `theme.js` + static route + index.html
+
+**Files:**
+- Create: `kcal-assistant/src/ui/static/theme.js`
+- Modify: `kcal-assistant/src/server.ts:21-25` (STATIC_ROUTES), `kcal-assistant/src/ui/static/index.html`
+- Test: `kcal-assistant/tests/ui-api.test.ts:94-102` (the existing "static routes serve with security headers" test)
+
+**Interfaces:**
+- Produces: `GET /ui/static/theme.js` served with `text/javascript; charset=utf-8`; `<html>` carries `data-theme="light"|"dark"` before first paint when a choice is saved, no attribute for system. Tasks 3-4 rely on the attribute name `data-theme` and storage key `kcal.theme` exactly.
+
+- [ ] **Step 1: Extend the failing test** — in `tests/ui-api.test.ts`, inside the "static routes serve with security headers" test, add alongside the app.js/app.css assertions:
+
+```ts
+    expect((await get("/ui/static/theme.js")).headers.get("content-type")).toContain("javascript");
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bun test tests/ui-api.test.ts`
+Expected: FAIL — theme.js 404s (content-type `application/json`).
+
+- [ ] **Step 3: Implement**
+  - Create `src/ui/static/theme.js` (classic script, ES5-safe, no modules):
+
+```js
+// Stamp the saved theme before first paint (CSP forbids inline scripts, and
+// app.js is a deferred module — too late). System preference = no attribute.
+try {
+  var t = localStorage.getItem("kcal.theme");
+  if (t === "light" || t === "dark") document.documentElement.dataset.theme = t;
+} catch (e) {}
+```
+
+  - `src/server.ts` STATIC_ROUTES gains one entry (keeping the whitelist-only comment true):
+
+```ts
+  "/ui/static/theme.js": { file: new URL("./ui/static/theme.js", import.meta.url), type: "text/javascript; charset=utf-8" },
+```
+
+  - `src/ui/static/index.html` `<head>`, after the stylesheet link:
+
+```html
+  <script src="/ui/static/theme.js"></script>
+```
+
+    (classic blocking script — no `defer`, no `type="module"` — that's what guarantees the stamp lands before first paint).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `bun test && bunx tsc --noEmit`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/static/theme.js src/server.ts src/ui/static/index.html tests/ui-api.test.ts
+git commit -m "feat(kcal-assistant): theme.js — temastämpel före första målningen"
+```
+
+---
+
+### Task 3: CSS — `light-dark()` palette + toggle styling
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/static/app.css:1-36` (palette block) + append `.theme-toggle` rules
+
+**Interfaces:**
+- Produces: `:root[data-theme="light"|"dark"]` forces a side; no attribute = OS. CSS class `.theme-toggle` for Task 4's button.
+
+- [ ] **Step 1: Rewrite the palette block** — replace lines 1-36 of `src/ui/static/app.css` (header comment, `:root`, and the whole `@media (prefers-color-scheme: light)` block) with:
+
+```css
+/* KCAL·DB — labbkvitto: precise mono numerals, hairline rules, dotted leaders.
+   Theme via light-dark(): color-scheme picks the side. No data-theme attribute
+   = follow the OS; theme.js stamps an explicit choice before first paint.
+   Strict CSP: no inline. */
+
+:root {
+  color-scheme: dark light;
+  --bg: light-dark(#f4efe5, #131110);
+  --surface: light-dark(#fbf8f1, #1b1815);
+  --surface-2: light-dark(#efe9dc, #221e1a);
+  --ink: light-dark(#27221a, #ece5d8);
+  --ink-2: light-dark(#6b6455, #a89f90);
+  --ink-3: light-dark(#99917f, #6f685c);
+  --hair: light-dark(#ddd5c4, #2f2a23);
+  --hair-2: light-dark(#c4bba6, #453e33);
+  --accent: light-dark(#9a7414, #e0b84b);
+  --accent-dim: light-dark(#c7a94e, #8a7330);
+  --ok: light-dark(#1e7a60, #3fa486);
+  --under: light-dark(#ab3f36, #c4534a);
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] { color-scheme: dark; }
+```
+
+- [ ] **Step 2: Audit for stragglers**
+
+Run: `grep -n "prefers-color-scheme" src/ui/static/app.css src/ui/app -r`
+Expected: no hits. Also confirm `grep -c "light-dark" src/ui/static/app.css` = 12 (one per themed variable). The scenario colors #0072b2/#e69f00 and ghost opacity stay theme-fixed by design.
+
+- [ ] **Step 3: Add the toggle styling** — append to `app.css` after the `.masthead-meta` rule (~line 75):
+
+```css
+.theme-toggle {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  background: none;
+  border: 1px solid var(--hair-2);
+  border-radius: 3px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+.theme-toggle:hover { color: var(--accent); border-color: var(--accent-dim); }
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `bun run build:ui && bun test`
+Expected: build clean, suite green (CSS is not bundled by build:ui, but the command pair is the release gate).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/static/app.css
+git commit -m "feat(kcal-assistant): light-dark()-palett + color-scheme-styrning"
+```
+
+---
+
+### Task 4: Masthead cycle button
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/index.tsx:44-56` (App component area)
+
+**Interfaces:**
+- Consumes: `data-theme` attribute + `kcal.theme` key (Task 2), `.theme-toggle` class (Task 3).
+
+- [ ] **Step 1: Implement** — in `src/ui/app/index.tsx`, above `function App()` add:
+
+```tsx
+type Theme = "system" | "light" | "dark";
+const THEME_LABEL: Record<Theme, string> = { system: "system", light: "ljust", dark: "mörkt" };
+const THEME_NEXT: Record<Theme, Theme> = { system: "light", light: "dark", dark: "system" };
+
+function loadTheme(): Theme {
+  try {
+    const t = localStorage.getItem("kcal.theme");
+    return t === "light" || t === "dark" ? t : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function applyTheme(t: Theme): void {
+  if (t === "system") delete document.documentElement.dataset.theme;
+  else document.documentElement.dataset.theme = t;
+  try {
+    if (t === "system") localStorage.removeItem("kcal.theme");
+    else localStorage.setItem("kcal.theme", t);
+  } catch {
+    // private mode etc — the attribute still applied, only persistence is lost
+  }
+}
+
+function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(loadTheme);
+  const cycle = () => {
+    const next = THEME_NEXT[theme];
+    applyTheme(next);
+    setTheme(next);
+  };
+  return (
+    <button className="theme-toggle" aria-label="växla tema" onClick={cycle}>
+      tema: {THEME_LABEL[theme]}
+    </button>
+  );
+}
+```
+
+  In the masthead JSX, after the `masthead-meta` span:
+
+```tsx
+        <ThemeToggle />
+```
+
+- [ ] **Step 2: Verify build + suite**
+
+Run: `bun run build:ui && bun test && bunx tsc --noEmit`
+Expected: all clean.
+
+- [ ] **Step 3: Quick dev-server sanity check** — from kcal-assistant/:
+
+```bash
+UI_DEV_NO_AUTH=1 MCP_TOKEN=dev DB_PATH=/tmp/kcal-theme-dev.db PORT=3998 bun run start & SERVER_PID=$!
+sleep 2 && curl -s http://localhost:3998/ui/static/theme.js | head -2 && curl -s http://localhost:3998/ui | grep -c theme.js; kill $SERVER_PID
+```
+
+Expected: theme.js source echoed; index.html references it once.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/app/index.tsx
+git commit -m "feat(kcal-assistant): temaväxlare i mastheaden (system/ljust/mörkt)"
+```
+
+---
+
+### Task 5: Fast-follows — loadPinned validation + tooltip suppression
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/views/Vikt.tsx:14-24` (loadPinned), `kcal-assistant/src/ui/app/components/WeightChart.tsx:145-165` (tooltip block)
+
+**Interfaces:**
+- Consumes: existing `PrognosParams { source, overrides }` and the tooltip's `kgAt(curve, t): number | null`.
+
+- [ ] **Step 1: Harden `loadPinned`** — replace the filter in `src/ui/app/views/Vikt.tsx` with:
+
+```tsx
+const OVERRIDE_KEYS = ["activity", "intake", "goal", "goal_date"] as const;
+
+function loadPinned(): PrognosParams[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((p): p is PrognosParams =>
+      p !== null && typeof p === "object" &&
+      (p.source === "targets" || p.source === "recent") &&
+      typeof p.overrides === "object" && p.overrides !== null &&
+      Object.entries(p.overrides).every(
+        ([k, v]) => (OVERRIDE_KEYS as readonly string[]).includes(k) && (v === undefined || typeof v === "string"),
+      ),
+    ).slice(0, 2);
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 2: Suppress empty scenario tooltip lines** — in `src/ui/app/components/WeightChart.tsx`, the tooltip currently sizes its rect with `34 + scenarios.length * 10` and maps all scenarios. Compute visible lines first (at component body level, right after the `kgAt` definition — the ternary guards the null-hover case):
+
+```tsx
+  const scenarioHits = hover
+    ? scenarios
+        .map((s) => ({ slot: s.slot, kg: kgAt(s.curve, hover.t) }))
+        .filter((s): s is { slot: 0 | 1; kg: number } => s.kg !== null)
+    : [];
+```
+
+  Then: rect height becomes `34 + scenarioHits.length * 10`, and the scenario `<text>` map iterates `scenarioHits` (`S{s.slot + 1} ≈ {sv(s.kg)} kg`, `y={13 + i * 10}`). A hovered date outside every pinned curve shows no scenario lines at all.
+
+- [ ] **Step 3: Verify build + suite, plus a manual corruption check**
+
+Run: `bun run build:ui && bun test && bunx tsc --noEmit`
+Then in the Task 4 dev server (or the Task 6 walk): set `localStorage["kcal.scenarios"] = '[{"source":"targets","overrides":{"activity":1.55}}]'` in the console, reload → Vikt renders with zero pinned scenarios (no crash).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/app/views/Vikt.tsx src/ui/app/components/WeightChart.tsx
+git commit -m "fix(kcal-assistant): validera scenario-storage + dölj tomma tooltip-rader"
+```
+
+---
+
+### Task 6: Browser walk, version bump, PR
+
+**Files:**
+- Modify: `kcal-assistant/package.json` (0.9.1), `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml:26` (image `v0.9.1`)
+
+- [ ] **Step 1: Browser walk** (dev server, seeded db from the v0.9.0 walk works):
+1. Toggle cycles system → ljust → mörkt with instant restyle on every view (Idag, Vikt, Recept).
+2. Reload with "mörkt" while OS is light: NO flash of light theme (theme.js stamp).
+3. "tema: system" follows a live OS appearance change.
+4. Corrupted `kcal.scenarios` (number value) → Vikt renders, pins dropped.
+5. Hover an actual dot with a pinned scenario whose curve doesn't cover that date → no "S≈" line; hover the projection → scenario line present.
+6. Console: no new errors beyond the known favicon 404 / Radix CSP notes.
+
+- [ ] **Step 2: Bump** — `package.json` `"version": "0.9.1"`; deployment.yaml image `rutbergphilip/kcal-assistant:v0.9.1`.
+
+- [ ] **Step 3: Final gates**
+
+Run: `bun test && bunx tsc --noEmit && bun run build:ui`
+Expected: all green.
+
+- [ ] **Step 4: Commit + PR**
+
+```bash
+git add package.json ../kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+git commit -m "feat(kcal-assistant): v0.9.1 — temaväxlare + fast-follows"
+git push -u origin kcal-v0.9.1-theme-switcher
+gh pr create --title "feat(kcal-assistant): v0.9.1 — temaväxlare + fast-follows" --body "$(cat <<'EOF'
+Temaväxlare per spec docs/superpowers/specs/2026-07-11-kcal-theme-switcher-design.md:
+
+- **Temaväxlare**: 3-lägescykel (system → ljust → mörkt) i mastheaden; light-dark()-palett styrd av color-scheme (ingen duplicerad variabelblock); externt blockerande theme.js i <head> ger noll-flash utan att bryta strikt CSP; valet i localStorage["kcal.theme"].
+- **Fast-follows från v0.9.0**: värde-validering av scenario-storage (korrupt localStorage kan inte krascha Vikt), tomma scenario-tooltiprader döljs, delad weeklyCurve-helper.
+
+UI-only: ingen migration, MCP oförändrat (24 verktyg). Ingen ny chatt behövs.
+
+Plan: docs/superpowers/plans/2026-07-11-kcal-theme-switcher.md
+
+https://claude.ai/code/session_018bdcBb7HJ6UUj8LXCt18qD
+EOF
+)"
+```
+
+After merge: CI builds → Flux deploys; verify pod v0.9.1, healthz 200, toggle live behind Authentik.

--- a/docs/superpowers/specs/2026-07-11-kcal-theme-switcher-design.md
+++ b/docs/superpowers/specs/2026-07-11-kcal-theme-switcher-design.md
@@ -1,0 +1,114 @@
+# kcal-assistant v0.9.1 — Temaväxlare (mörkt/ljust/system) + v0.9.0-fast-follows
+
+Date: 2026-07-11
+Status: design approved in brainstorming with Philip; this document is the spec for the implementation plan.
+Scope: one release (one PR), UI-only — no migration, no MCP changes (24 tools,
+schemas untouched, no new chat needed), no new API endpoints. The UI's
+read-only-except-profile-PUT posture is unchanged.
+
+## Goal
+
+A manual theme switcher for KCAL·DB. Today the UI is dark-first with light
+overrides via `@media (prefers-color-scheme: light)` — OS-following only.
+Philip wants a manual toggle: a **3-state cycle** (system → ljust → mörkt)
+where "system" preserves today's OS-following behavior. Bundled: three tiny
+ship-triaged fast-follows from the v0.9.0 final review.
+
+## 1. CSS: `light-dark()` + `color-scheme` (approach A, approved)
+
+Rewrite the `:root` palette block in `src/ui/static/app.css` so every themed
+variable holds both values via `light-dark(<light>, <dark>)`, taking the
+light values from today's media-query block and dark values from today's
+`:root`:
+
+```css
+:root {
+  color-scheme: dark light;              /* system: follow the OS */
+  --bg: light-dark(#f4efe5, #131110);
+  --surface: light-dark(#fbf8f1, #1b1815);
+  /* … all 12 themed vars; --mono/--sans stay as-is … */
+}
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"]  { color-scheme: dark; }
+```
+
+- The `@media (prefers-color-scheme: light)` block is DELETED — `light-dark()`
+  + `color-scheme` replace it entirely. No duplicated variables; system mode
+  keeps switching live at OS theme changes with zero JS.
+- Audit during implementation: grep for any other `prefers-color-scheme`
+  usage or hardcoded theme colors outside the variable block (the scenario
+  line colors #0072b2/#e69f00 and ghost opacity are deliberately theme-fixed).
+- `<meta name="color-scheme" content="dark light">` in index.html stays (the
+  CSS property governs; the meta is a pre-CSS hint).
+- Browser floor: `light-dark()` is 2024-era CSS — fine for this single-user
+  app on Philip's evergreen browsers.
+
+## 2. Zero-flash startup: `theme.js`
+
+Strict CSP forbids inline scripts, and `app.js` is a deferred end-of-body
+module — so a React-side stamp would flash the OS theme when the saved choice
+differs. Fix: a tiny EXTERNAL classic script, loaded blocking in `<head>` of
+`src/ui/static/index.html` (same-origin = CSP-clean):
+
+```html
+<script src="/ui/static/theme.js"></script>
+```
+
+```js
+// theme.js — stamp the saved theme before first paint. System = no attribute.
+try {
+  var t = localStorage.getItem("kcal.theme");
+  if (t === "light" || t === "dark") document.documentElement.dataset.theme = t;
+} catch (e) {}
+```
+
+Must be served exactly like `app.js`/`app.css` (same static handler, correct
+`text/javascript` content type) — the implementation verifies how
+`src/server.ts` serves `/ui/static/*` and registers the file if the handler
+whitelists names.
+
+## 3. Masthead cycle button
+
+In `src/ui/app/index.tsx`'s `App` masthead, right of the date span: a small
+mono-styled button cycling **system → ljust → mörkt → system**.
+
+- Label shows the current state: `tema: system` / `tema: ljust` /
+  `tema: mörkt`. `aria-label="växla tema"`.
+- State: `useState<"system" | "light" | "dark">` initialized from
+  `localStorage["kcal.theme"]` (absent/invalid → "system").
+- On click: advance the cycle; for explicit themes set
+  `localStorage["kcal.theme"]` + `document.documentElement.dataset.theme`;
+  for system REMOVE both (key deleted, attribute deleted) so the OS rules.
+  localStorage access wrapped in try/catch (private-mode safety), state still
+  updates so the button label never sticks.
+- Styling: new `.theme-toggle` class in app.css following the masthead's
+  kvitto conventions (mono font, hairline border, --ink-2 text, accent on
+  hover) — visually a sibling of the existing chip idiom, sized to not crowd
+  the masthead on mobile (`font-size` ≈ label-small, padding tight).
+
+## 4. Bundled v0.9.0 fast-follows (all ship-triaged in the final review)
+
+1. **`loadPinned` value-validation** (`src/ui/app/views/Vikt.tsx`): reject an
+   entry when any present override value is not a string or any key is
+   outside {activity, intake, goal, goal_date} — a hand-edited
+   `localStorage["kcal.scenarios"]` must never crash the Vikt render.
+2. **Suppress empty scenario tooltip lines** (`src/ui/app/components/WeightChart.tsx`):
+   when `kgAt` returns null for a hovered date, skip that scenario's tooltip
+   line entirely (today it renders "S1 ≈ — kg"); the tooltip rect height
+   counts only rendered lines.
+3. **Shared weekly-sampling helper**: export `weeklyCurve(curve)` from
+   `src/lib/forecast.ts`; `src/db/snapshots.ts` and `src/tools/profile.ts`
+   both use it (today the `i % 7 === 0 || i === curve.length - 1` one-liner
+   is duplicated). One trivial unit test pins the sampling.
+
+## Testing & rollout
+
+- Suite stays green (`bun test`, `bunx tsc --noEmit`); new unit test only for
+  `weeklyCurve`. Theme behavior and the two UI fast-follows are verified by a
+  browser walk: cycle changes theme instantly on every view, reload persists,
+  hard-reload shows NO wrong-theme flash with an explicit theme + opposite OS
+  setting, system mode follows an OS toggle live, corrupted
+  `kcal.scenarios` no longer breaks Vikt, no "S≈—" tooltip lines.
+- Release: `package.json` 0.9.1 + `deployment.yaml` image tag `v0.9.1` in the
+  same PR → merge → CI → Flux. Verify: pod v0.9.1, healthz 200, `/ui` gated,
+  toggle live behind Authentik.

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/snapshots.ts
+++ b/kcal-assistant/src/db/snapshots.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import type { ForecastPoint, ForecastResult } from "../lib/forecast";
+import { weeklyCurve, type ForecastPoint, type ForecastResult } from "../lib/forecast";
 
 export interface SnapshotRow {
   date: string;
@@ -12,10 +12,6 @@ export interface SnapshotRow {
   band_kcal: number;
   curve: ForecastPoint[];
 }
-
-// Weekly sampling mirrors get_forecast's token-lean curve.
-const weekly = (curve: ForecastPoint[]): ForecastPoint[] =>
-  curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
 
 export function saveSnapshot(db: Database, forecast: ForecastResult, today: string): void {
   db.run(
@@ -33,7 +29,7 @@ export function saveSnapshot(db: Database, forecast: ForecastResult, today: stri
       today, forecast.start.date, forecast.start.weight_kg,
       forecast.assumptions.intake_kcal, forecast.assumptions.intake_source,
       forecast.assumptions.tdee_start, forecast.assumptions.calibration_offset,
-      forecast.assumptions.band_kcal, JSON.stringify(weekly(forecast.curve)),
+      forecast.assumptions.band_kcal, JSON.stringify(weeklyCurve(forecast.curve)),
     ],
   );
 }

--- a/kcal-assistant/src/lib/forecast.ts
+++ b/kcal-assistant/src/lib/forecast.ts
@@ -110,6 +110,12 @@ export function computeBand(input: BandInput): { kcal: number; reasons: string[]
 
 const round2 = (x: number): number => Math.round(x * 100) / 100;
 
+// Weekly curve sampling shared by snapshot storage and the MCP get_forecast
+// response (token economy): every 7th point plus always the endpoint.
+export function weeklyCurve<T>(curve: T[]): T[] {
+  return curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+}
+
 function ageAt(birthDate: string, date: string): number {
   return Math.floor((toEpochDays(date) - toEpochDays(birthDate)) / 365.25);
 }

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -22,6 +22,7 @@ const STATIC_ROUTES: Record<string, { file: URL; type: string }> = {
   "/ui": { file: new URL("./ui/static/index.html", import.meta.url), type: "text/html; charset=utf-8" },
   "/ui/static/app.css": { file: new URL("./ui/static/app.css", import.meta.url), type: "text/css; charset=utf-8" },
   "/ui/static/app.js": { file: new URL("./ui/static/app.js", import.meta.url), type: "text/javascript; charset=utf-8" },
+  "/ui/static/theme.js": { file: new URL("./ui/static/theme.js", import.meta.url), type: "text/javascript; charset=utf-8" },
 };
 
 const API_ROUTE = /^\/ui\/api\/[a-z]+(\/[A-Za-z0-9-]+)?$/;

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -16,7 +16,7 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
-// Static assets: three hardcoded mappings — nothing filesystem-derived from
+// Static assets: four hardcoded mappings — nothing filesystem-derived from
 // the URL, so traversal is impossible by construction.
 const STATIC_ROUTES: Record<string, { file: URL; type: string }> = {
   "/ui": { file: new URL("./ui/static/index.html", import.meta.url), type: "text/html; charset=utf-8" },

--- a/kcal-assistant/src/tools/profile.ts
+++ b/kcal-assistant/src/tools/profile.ts
@@ -3,6 +3,7 @@ import type { Database } from "bun:sqlite";
 import { z } from "zod";
 import { setProfile } from "../db/profile";
 import { buildForecast } from "../db/forecast";
+import { weeklyCurve } from "../lib/forecast";
 import { dateSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
@@ -41,7 +42,7 @@ export function registerProfileTools(server: McpServer, db: Database): void {
       if (!view.forecast) return jsonResult(view);
       // Token-lean for the chat: weekly points, and no ghost curve.
       const { curve, ...rest } = view.forecast;
-      const weekly = curve.filter((_, i) => i % 7 === 0 || i === curve.length - 1);
+      const weekly = weeklyCurve(curve);
       return jsonResult({
         forecast: { ...rest, curve: weekly },
         ...(view.accuracy && { accuracy: view.accuracy }),

--- a/kcal-assistant/src/ui/app/components/WeightChart.tsx
+++ b/kcal-assistant/src/ui/app/components/WeightChart.tsx
@@ -66,6 +66,12 @@ export function WeightChart({ series, forecast, ghost = null, scenarios = NO_SCE
     return best;
   };
 
+  const scenarioHits = hover
+    ? scenarios
+        .map((s) => ({ slot: s.slot, kg: kgAt(s.curve, hover.t) }))
+        .filter((s): s is { slot: 0 | 1; kg: number } => s.kg !== null)
+    : [];
+
   const onPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
     if (!svg) return;
@@ -144,7 +150,7 @@ export function WeightChart({ series, forecast, ghost = null, scenarios = NO_SCE
             <line className="hover-crosshair" x1={X(hover.t)} x2={X(hover.t)} y1={M.top} y2={H - M.bottom} />
             <circle className="hover-dot" cx={X(hover.t)} cy={Y(hover.kg)} r={4.5} />
             <g transform={`translate(${tip.x},${tip.y})`}>
-              <rect className="hover-tip-bg" x={-58} y={-30} width={116} height={34 + scenarios.length * 10} rx={2} />
+              <rect className="hover-tip-bg" x={-58} y={-30} width={116} height={34 + scenarioHits.length * 10} rx={2} />
               <text className="hover-tip-date" x={0} y={-19} textAnchor="middle">{new Date(hover.t).toISOString().slice(0, 10)}</text>
               <text className="hover-tip-kg" x={0} y={-7} textAnchor="middle">
                 {hover.kind === "actual" ? `${sv(hover.kg)} kg` : `≈ ${sv(hover.kg)} kg`}
@@ -155,9 +161,9 @@ export function WeightChart({ series, forecast, ghost = null, scenarios = NO_SCE
               {hover.kind === "actual" ? (
                 <text className="hover-tip-band" x={0} y={2} textAnchor="middle">trend {sv(hover.trend)}</text>
               ) : null}
-              {scenarios.map((s, i) => (
+              {scenarioHits.map((s, i) => (
                 <text key={s.slot} className="hover-tip-band" x={0} y={13 + i * 10} textAnchor="middle">
-                  S{s.slot + 1} ≈ {sv(kgAt(s.curve, hover.t))} kg
+                  S{s.slot + 1} ≈ {sv(s.kg)} kg
                 </text>
               ))}
             </g>

--- a/kcal-assistant/src/ui/app/index.tsx
+++ b/kcal-assistant/src/ui/app/index.tsx
@@ -40,6 +40,44 @@ export function resolveRoute(hash: string): Route {
   return { tab: "idag", el: null };
 }
 
+type Theme = "system" | "light" | "dark";
+const THEME_LABEL: Record<Theme, string> = { system: "system", light: "ljust", dark: "mörkt" };
+const THEME_NEXT: Record<Theme, Theme> = { system: "light", light: "dark", dark: "system" };
+
+function loadTheme(): Theme {
+  try {
+    const t = localStorage.getItem("kcal.theme");
+    return t === "light" || t === "dark" ? t : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function applyTheme(t: Theme): void {
+  if (t === "system") delete document.documentElement.dataset.theme;
+  else document.documentElement.dataset.theme = t;
+  try {
+    if (t === "system") localStorage.removeItem("kcal.theme");
+    else localStorage.setItem("kcal.theme", t);
+  } catch {
+    // private mode etc — the attribute still applied, only persistence is lost
+  }
+}
+
+function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(loadTheme);
+  const cycle = () => {
+    const next = THEME_NEXT[theme];
+    applyTheme(next);
+    setTheme(next);
+  };
+  return (
+    <button className="theme-toggle" aria-label="växla tema" onClick={cycle}>
+      tema: {THEME_LABEL[theme]}
+    </button>
+  );
+}
+
 function App() {
   const hash = useHashRoute();
   const route = resolveRoute(hash);
@@ -51,6 +89,7 @@ function App() {
         <span className="masthead-meta">
           {new Date().toLocaleDateString("sv-SE", { weekday: "short", day: "numeric", month: "short" })}
         </span>
+        <ThemeToggle />
       </header>
       <main className="view" aria-live="polite">
         <Fragment key={hash}>{route.el}</Fragment>

--- a/kcal-assistant/src/ui/app/views/Vikt.tsx
+++ b/kcal-assistant/src/ui/app/views/Vikt.tsx
@@ -11,12 +11,19 @@ export function Vikt() {
 
 const STORAGE_KEY = "kcal.scenarios";
 
+const OVERRIDE_KEYS = ["activity", "intake", "goal", "goal_date"] as const;
+
 function loadPinned(): PrognosParams[] {
   try {
     const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
     if (!Array.isArray(raw)) return [];
     return raw.filter((p): p is PrognosParams =>
-      p && (p.source === "targets" || p.source === "recent") && typeof p.overrides === "object" && p.overrides !== null,
+      p !== null && typeof p === "object" &&
+      (p.source === "targets" || p.source === "recent") &&
+      typeof p.overrides === "object" && p.overrides !== null &&
+      Object.entries(p.overrides).every(
+        ([k, v]) => (OVERRIDE_KEYS as readonly string[]).includes(k) && (v === undefined || typeof v === "string"),
+      ),
     ).slice(0, 2);
   } catch {
     return [];

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -1,39 +1,27 @@
 /* KCAL·DB — labbkvitto: precise mono numerals, hairline rules, dotted leaders.
-   Dark-first; light theme via prefers-color-scheme. Strict CSP: no inline. */
+   Theme via light-dark(): color-scheme picks the side. No data-theme attribute
+   = follow the OS; theme.js stamps an explicit choice before first paint.
+   Strict CSP: no inline. */
 
 :root {
-  --bg: #131110;
-  --surface: #1b1815;
-  --surface-2: #221e1a;
-  --ink: #ece5d8;
-  --ink-2: #a89f90;
-  --ink-3: #6f685c;
-  --hair: #2f2a23;
-  --hair-2: #453e33;
-  --accent: #e0b84b;
-  --accent-dim: #8a7330;
-  --ok: #3fa486;
-  --under: #c4534a;
+  color-scheme: dark light;
+  --bg: light-dark(#f4efe5, #131110);
+  --surface: light-dark(#fbf8f1, #1b1815);
+  --surface-2: light-dark(#efe9dc, #221e1a);
+  --ink: light-dark(#27221a, #ece5d8);
+  --ink-2: light-dark(#6b6455, #a89f90);
+  --ink-3: light-dark(#99917f, #6f685c);
+  --hair: light-dark(#ddd5c4, #2f2a23);
+  --hair-2: light-dark(#c4bba6, #453e33);
+  --accent: light-dark(#9a7414, #e0b84b);
+  --accent-dim: light-dark(#c7a94e, #8a7330);
+  --ok: light-dark(#1e7a60, #3fa486);
+  --under: light-dark(#ab3f36, #c4534a);
   --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, monospace;
   --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #f4efe5;
-    --surface: #fbf8f1;
-    --surface-2: #efe9dc;
-    --ink: #27221a;
-    --ink-2: #6b6455;
-    --ink-3: #99917f;
-    --hair: #ddd5c4;
-    --hair-2: #c4bba6;
-    --accent: #9a7414;
-    --accent-dim: #c7a94e;
-    --ok: #1e7a60;
-    --under: #ab3f36;
-  }
-}
+:root[data-theme="light"] { color-scheme: light; }
+:root[data-theme="dark"] { color-scheme: dark; }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -73,6 +61,19 @@ body {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.theme-toggle {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  background: none;
+  border: 1px solid var(--hair-2);
+  border-radius: 3px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+.theme-toggle:hover { color: var(--accent); border-color: var(--accent-dim); }
 
 /* ---------- layout ---------- */
 .view {

--- a/kcal-assistant/src/ui/static/index.html
+++ b/kcal-assistant/src/ui/static/index.html
@@ -7,6 +7,7 @@
   <meta name="robots" content="noindex, nofollow">
   <title>KCAL·DB</title>
   <link rel="stylesheet" href="/ui/static/app.css">
+  <script src="/ui/static/theme.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/kcal-assistant/src/ui/static/theme.js
+++ b/kcal-assistant/src/ui/static/theme.js
@@ -1,0 +1,6 @@
+// Stamp the saved theme before first paint (CSP forbids inline scripts, and
+// app.js is a deferred module — too late). System preference = no attribute.
+try {
+  var t = localStorage.getItem("kcal.theme");
+  if (t === "light" || t === "dark") document.documentElement.dataset.theme = t;
+} catch (e) {}

--- a/kcal-assistant/tests/forecast.test.ts
+++ b/kcal-assistant/tests/forecast.test.ts
@@ -304,3 +304,16 @@ describe("band integration", () => {
       .toBeGreaterThan(narrow.curve[30]!.high - narrow.curve[30]!.low);
   });
 });
+
+import { weeklyCurve } from "../src/lib/forecast";
+
+describe("weeklyCurve", () => {
+  test("keeps every 7th point and always the last", () => {
+    const days = Array.from({ length: 16 }, (_, i) => i); // 0..15
+    expect(weeklyCurve(days)).toEqual([0, 7, 14, 15]);
+  });
+  test("single point and empty pass through", () => {
+    expect(weeklyCurve([42])).toEqual([42]);
+    expect(weeklyCurve([])).toEqual([]);
+  });
+});

--- a/kcal-assistant/tests/ui-api.test.ts
+++ b/kcal-assistant/tests/ui-api.test.ts
@@ -100,6 +100,7 @@ describe("read-only UI API", () => {
     expect(res.headers.get("content-security-policy")).toBe("default-src 'self'; img-src 'self' data:");
     expect((await get("/ui/static/app.js")).headers.get("content-type")).toContain("javascript");
     expect((await get("/ui/static/app.css")).headers.get("content-type")).toContain("text/css");
+    expect((await get("/ui/static/theme.js")).headers.get("content-type")).toContain("javascript");
   });
 
   test("invalid date 400 with fixed message; unknown API path 404; unknown recipe 404", async () => {

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.9.0
+          image: rutbergphilip/kcal-assistant:v0.9.1
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
Temaväxlare per spec docs/superpowers/specs/2026-07-11-kcal-theme-switcher-design.md:

- **Temaväxlare**: 3-lägescykel (system → ljust → mörkt) i mastheaden; light-dark()-palett styrd av color-scheme (ingen duplicerad variabelblock); externt blockerande theme.js i <head> ger noll-flash utan att bryta strikt CSP; valet i localStorage["kcal.theme"].
- **Fast-follows från v0.9.0**: värde-validering av scenario-storage (korrupt localStorage kan inte krascha Vikt), tomma scenario-tooltiprader döljs, delad weeklyCurve-helper.

UI-only: ingen migration, MCP oförändrat (24 verktyg). Ingen ny chatt behövs.

Kvalitet: 6 uppgifter, granskning per uppgift (alla Approved), slutlig helgrensgranskning MERGE-READY. 203/203 tester, tsc clean, browser-walk verifierad i båda teman.

Plan: docs/superpowers/plans/2026-07-11-kcal-theme-switcher.md

https://claude.ai/code/session_018bdcBb7HJ6UUj8LXCt18qD