### PR TITLE
feat: interactive week meal planner (kcal-assistant v0.11.0 + wall-hub Vecka)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-meal-planner.md
+++ b/docs/superpowers/plans/2026-07-18-meal-planner.md
@@ -1,0 +1,219 @@
+# Meal Planner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Week meal planner (Mon–Sun, slot-based, kcal+macros) in kcal-assistant, editable via MCP + KCAL·DB UI, confirmable per day (logs to goals), displayed on the wall-hub as a new page + Hem chip.
+
+**Architecture:** New plan tables (migration 6) with live `resolveItem` resolution; confirm copies planned meals into `meals` via the existing insert path. 3 new MCP tools; UI writes copy the `PUT /ui/api/profile` gate; wall panel reads/confirms through cluster-only `:3001` with Cilium L7 pinning.
+
+**Tech Stack:** Bun + bun:sqlite + zod + MCP SDK; React 19 (KCAL·DB); Lit (glass-cards); HA REST sensors + rest_command; Cilium L7.
+
+**Spec:** `docs/superpowers/specs/2026-07-18-meal-planner-design.md` — the authoritative behavior source. Every task implicitly includes it.
+
+## Global Constraints
+
+- Slots: `'frukost' | 'lunch' | 'middag' | 'mellis'` exactly.
+- Day types unchanged: `vilodag | gymdag | flexdag`; targets read live via `getTargetsFor`.
+- All macro math server-side; planned meals resolve LIVE (product edits propagate). Ad-hoc macros round via `roundMacros` at read (same as resolveItem does).
+- Recipe-based meal scaling: `per_serving × recipe_servings` when recipe.servings set, else `totals × recipe_servings`.
+- Reads never write (no `ensureDay` in read paths) — same guarantee as `readDay`.
+- Swedish copy everywhere in UI/errors ("Bekräfta", "redan bekräftad", "inget planerat", "dagen är redan bekräftad — ändringar påverkar inte loggen").
+- UI writes: `Sec-Fetch-Site: same-origin` + JSON content-type + strict shape coercion (mirror `coerceProfileBody`).
+- kcal-assistant version → `0.11.0` (27 tools). glass-cards: pure logic in testable modules.
+- Repo flow: feature branch + PR for kcal-assistant (CI builds image, Flux deploys).
+
+---
+
+### Task 1: db/plan.ts — schema, upsert, week read
+
+**Files:**
+- Modify: `kcal-assistant/src/db/migrations.ts` (append migration 6 — exact SQL in spec §Data model)
+- Create: `kcal-assistant/src/db/plan.ts`
+- Test: `kcal-assistant/tests/plan.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export type PlanSlot = "frukost" | "lunch" | "middag" | "mellis";
+export interface PlannedMealInput {
+  slot: PlanSlot; name: string;
+  recipe_id?: number; recipe_servings?: number;   // recipe-based (items must be absent)
+  items?: MealItemInput[];                        // item-based
+  post_gym_shake?: boolean; note?: string;
+}
+export interface PlanDayInput {
+  date: string; day_type?: string;
+  clear_slots?: PlanSlot[];
+  meals?: PlannedMealInput[];
+}
+export interface PlannedMealView extends Macros {
+  id: number; slot: PlanSlot; position: number; name: string;
+  recipe_id: number | null; recipe_servings: number | null;
+  post_gym_shake: boolean; note: string | null;
+  logged: boolean;                                 // logged_meal_id !== null
+  totals_incomplete?: true;
+  items?: PlannedItemView[];                       // when include_items
+}
+export interface PlanDayView {
+  date: string; weekday: string;                   // "måndag" … (sv-SE)
+  day_type: string; targets: DayTargets;
+  confirmed: boolean; confirmed_at: string | null;
+  meals: PlannedMealView[];                        // ordered slot (frukost,lunch,middag,mellis), position
+  totals: Macros;                                  // planned totals (ALL planned meals)
+  remaining: { kcal: number; protein_to_min: number; fat_to_min: number; carbs: number | null };
+  checks: { kcal_ok: boolean; protein_floor_ok: boolean; fat_floor_ok: boolean };
+  warning?: string;                                // set by upsert on confirmed days
+}
+export interface PlanWeekView {
+  start_date: string; end_date: string; days: PlanDayView[]; // len 7×weeks
+  week: { planned_days: number; confirmed_days: number; avg_planned_kcal: number | null; avg_target_kcal: number };
+}
+export function mondayOf(date: string): string;                    // toEpochDays-based; epochDay 0 = torsdag ⇒ ((d+3)%7+7)%7 offset
+export function getPlanWeek(db, opts?: { start?: string; weeks?: number; include_items?: boolean }): PlanWeekView;
+export function upsertPlanDays(db, days: PlanDayInput[], replace?: boolean): PlanDayView[]; // replace default true
+```
+
+Behavior details:
+- `upsertPlanDays` in ONE transaction: per day → validate date, `ensureDay`, optional `setDayType`-equivalent (`UPDATE days SET day_type`; validate via `getTargetsFor`), delete `clear_slots` meals, then per input meal: validate (recipe XOR items; recipe must exist; `recipe_servings` required with `recipe_id`, positive; items validated by attempting `resolveItem` — throw on invalid input shape but NOT on unresolvable product for ad-hoc macro rows), `replace=true` ⇒ delete existing meals in each slot mentioned in `meals` (once per slot, before inserts), insert with next `position`. Day confirmed ⇒ still applies but view gets `warning`.
+- `kcal_ok` = totals.kcal ≤ targets.kcal.
+- Meal macro resolution (shared `resolvePlannedMeal`): recipe-based → `getRecipe` (missing recipe ⇒ `totals_incomplete` + zero macros, reason "receptet har tagits bort"); item-based → per-item `resolveItem` with try/catch like `getRecipe` does (unresolved ⇒ skip from totals, flag).
+- `getPlanWeek` default start = `mondayOf(todayStockholm())`, weeks clamp 1–4.
+
+- [ ] Write failing tests: monday snapping (Wed→Mon, Mon→same, Sun→prior Mon, across DST 2026-03-29 + year boundary), upsert insert/replace/append(replace:false)/clear_slots, day_type set + invalid day_type throws, recipe XOR items error, recipe scaling per-serving and batch fallback, unresolved item flagged + excluded from totals, ordering, week aggregates, read-only getPlanWeek (no day rows created — copy `week.test.ts` non-mutation assertion style)
+- [ ] Run: `cd kcal-assistant && bun test tests/plan.test.ts` → FAIL (module missing)
+- [ ] Implement migration 6 + db/plan.ts
+- [ ] Run tests → PASS; run full `bun test` → no regressions (migration count assertions may need updating)
+- [ ] Commit `feat(plan): schema + upsert + week read`
+
+### Task 2: confirm / unconfirm
+
+**Files:** Modify `kcal-assistant/src/db/plan.ts`; Test: `kcal-assistant/tests/plan-confirm.test.ts`
+
+**Produces:**
+```ts
+export function confirmDay(db, date: string, slots?: PlanSlot[]): { day: DayView; plan: PlanDayView };
+export function unconfirmDay(db, date: string): { day: DayView; plan: PlanDayView };
+```
+- confirm: transaction; scope = planned meals on date (filtered by slots) with `logged_meal_id IS NULL`; any `totals_incomplete` in scope ⇒ throw listing meal names ("kan inte bekräfta: olösta poster i …"). Insert meals rows: item-based → one meal_item per resolved item (via existing `insertItems`-equivalent using resolved macros as explicit `macros` input so rounding isn't double-applied — pass `{description, grams, quantity, macros}`), recipe-based → single item `{description: "«name» (N port)", macros: scaled}`. Carry `post_gym_shake`. Set `logged_meal_id`. If zero in scope: all already logged ⇒ throw "redan bekräftad"; none exist ⇒ throw "inget planerat". After: if no unlogged planned meals remain on date ⇒ `plan_confirmed_at = datetime('now')`.
+- unconfirm: delete meals whose id ∈ date's `logged_meal_id`s; clear `plan_confirmed_at`; nothing logged ⇒ throw "inget att ångra".
+
+- [ ] Failing tests: whole-day confirm creates meals + day totals match planned totals, plan_confirmed_at set, idempotency (second confirm throws "redan bekräftad"), partial slot confirm (middag only ⇒ not confirmed_at; then rest ⇒ confirmed), unresolved blocks, unconfirm removes ONLY plan meals (manually logged meal survives), edit_meal-delete of a plan-logged meal clears pointer (FK) and day no longer "confirmed"? (plan_confirmed_at stays — assert current design: stamp remains until unconfirm; meal shows logged:false) — actually assert: pointer cleared via `ON DELETE SET NULL`, confirm can re-log that meal
+- [ ] Run → FAIL, implement, run → PASS, full suite, commit `feat(plan): confirm/unconfirm days`
+
+### Task 3: shopping list
+
+**Files:** Modify `kcal-assistant/src/db/plan.ts`; Test: `kcal-assistant/tests/plan-shopping.test.ts`
+
+**Produces:**
+```ts
+export interface ShoppingLine { product_id: number | null; description: string; grams: number | null; quantity: number | null; portion_name: string | null; }
+export function buildShoppingList(db, start: string, days: number): ShoppingLine[];
+```
+Aggregation over UNLOGGED planned meals in [start, start+days): recipe-based expand ingredients scaled by servings factor; group by product_id (sum grams; sum quantity only when same portion_name); ad-hoc/no-product lines listed individually by description. Sorted by description.
+
+- [ ] Failing tests (aggregation across meals + recipe expansion + logged excluded) → implement → PASS → commit `feat(plan): shopping list aggregation`
+
+### Task 4: MCP tools plan_week / get_plan / confirm_day
+
+**Files:** Create `kcal-assistant/src/tools/plan.ts`; Modify `kcal-assistant/src/mcp.ts` (register), `kcal-assistant/tests/server.test.ts` (tool count 24→27 if asserted); Test: `kcal-assistant/tests/plan-tools.test.ts`
+
+Zod inputs (reuse `dateSchema`, `dayTypeSchema`, `mealItemSchema`; `slotSchema = z.enum(["frukost","lunch","middag","mellis"])`):
+- `plan_week`: `{ days: z.array(dayInput).min(1), replace: z.boolean().optional() }` where dayInput = `{ date: dateSchema, day_type: dayTypeSchema.optional(), clear_slots: z.array(slotSchema).optional(), meals: z.array(plannedMealSchema).optional() }`. Handler → `upsertPlanDays`, returns compact days (NO items).
+- `get_plan`: `{ start: dateSchema.optional(), weeks: z.number().int().min(1).max(4).optional(), include_items: z.boolean().optional(), shopping_list: z.boolean().optional() }`.
+- `confirm_day`: `{ date: dateSchema, action: z.enum(["confirm","unconfirm"]), slots: z.array(slotSchema).optional() }`.
+Descriptions (Swedish-aware, mirroring existing tone) must tell Claude: plan_week is THE planning tool (batch a whole week in one call, day_type inline, replace semantics), get_plan before planning discussions, confirm_day = Philip's "lås dagen" → logs to goals.
+
+- [ ] Failing tests (register via buildMcpServer, call handlers through server like existing tool tests do — follow `tests/server.test.ts` pattern) → implement → PASS → commit `feat(plan): MCP tools (27 total)`
+
+### Task 5: UI API + server gate
+
+**Files:** Modify `kcal-assistant/src/ui/api.ts`, `kcal-assistant/src/server.ts:125-128` (method gate); Test: `kcal-assistant/tests/ui-api-plan.test.ts`, extend `kcal-assistant/tests/ui-auth.test.ts` matrix
+
+- `GET /ui/api/plan?start&weeks` → `getPlanWeek({include_items:true})` + `shopping_list` field (`buildShoppingList` over same range).
+- `PUT /ui/api/plan/<date>` → CSRF gate (same-origin + JSON) → strict coercion `coercePlanDayBody` (unknown key ⇒ error; meals validated shape-wise, values validated in db layer) → `upsertPlanDays(db,[{date,...body}], body.replace)` → `{ day: PlanDayView }`.
+- `PUT /ui/api/confirm/<date>` → CSRF gate → `{action, slots?}` → confirm/unconfirm → 200 `{day, plan}`; domain errors → 409 `{error}` ("redan bekräftad"/"inget planerat"/"inget att ångra"), other validation → 400.
+- server.ts gate becomes: allow PUT when pathname is `/ui/api/profile` or `/ui/api/confirm/<date>` or `/ui/api/plan/<date>` (regex `/^\/ui\/api\/(plan|confirm)\/\d{4}-\d{2}-\d{2}$/`).
+
+- [ ] Failing tests: happy paths, cross-site 403, wrong content-type 403, unknown field 400, bad date 400, GET plan snapping, 409s; auth matrix parity with profile → implement → PASS → commit `feat(plan): UI API writes`
+
+### Task 6: /internal/planner + confirm POST
+
+**Files:** Modify `kcal-assistant/src/ui/internal.ts` (add `buildInternalPlanner`), `kcal-assistant/src/server.ts` (internal server routes); Test: extend `kcal-assistant/tests/internal-summary.test.ts` or new `tests/internal-planner.test.ts` + security parity in `tests/server.test.ts` (404 on :3000 handler)
+
+```ts
+export interface InternalPlannerDay { date: string; weekday: string; day_type: string; confirmed: boolean;
+  meals: Array<{ slot: string; name: string; kcal: number; protein: number; fat: number; carbs: number; logged: boolean }>;
+  total_kcal: number; target_kcal: number; protein_ok: boolean; kcal_ok: boolean; }
+export interface InternalPlanner { status: "ok"; week_start: string; today: string; confirmed_days: number; days: InternalPlannerDay[]; }
+export function buildInternalPlanner(db): InternalPlanner;   // never throws; current week
+```
+- Internal server: `GET /internal/planner` → JSON no-store; `POST /internal/planner/confirm` body `{date}` (readBody 4KB, JSON, valid date) → `confirmDay(db, date)` → 200 `{ok:true, date}`; domain error → 409 `{error}`; invalid → 400. Main :3000 handler must NOT serve these (parity test).
+
+- [ ] Failing tests → implement → PASS → commit `feat(plan): internal planner endpoints`
+
+### Task 7: KCAL·DB Vecka view
+
+**Files:** Create `kcal-assistant/src/ui/app/views/Vecka.tsx`, `kcal-assistant/src/ui/app/components/PlanMealDialog.tsx`; Modify `kcal-assistant/src/ui/app/index.tsx` (TABS + route `#/vecka`), `kcal-assistant/src/ui/app/api.ts` (fetch helpers `putJson` if absent), `kcal-assistant/src/ui/static/app.css` only if the app uses css files (check — v0.8.0 is React; styles co-located)
+
+Behavior (spec §UI): week grid (7 cols desktop / stacked mobile via CSS grid auto-fit), header ‹ idag ›, per-day card: weekday+date, day-type `<select>` (PUT plan/<date> {day_type}), totals chip + floor warnings (⚠ when checks fail), slot sections, meal rows (name + kcal; expand → P/F/K + items), actions per meal: ta bort (PUT plan/<date> {clear via replace of slot minus meal — implement as meals rebuild: send slot's remaining meals with replace:true} — simpler: dedicated rebuild helper in view), flytta (day/slot pickers → two PUTs: remove + append with replace:false), portioner edit for recipe-based (rebuild slot), lägg till → dialog with tabs "Från recept" (recipes list via existing `/ui/api/recipes`, servings input) and "Snabb" (name + 4 macro inputs → ad-hoc item). Confirm button: dialog "Bekräfta måndag 20 juli? Måltiderna loggas." → PUT confirm; confirmed day: låst badge + "Ångra bekräftelse" (second dialog). Optimistic-free: refetch week after every write (small payload, simple). Shopping list: collapsible "Handlingslista" section below grid.
+Slot rebuild semantics note: since PUT replaces whole slots, the view always sends the complete desired slot contents — planned items round-trip via `items` in PlanDayView (include_items:true gives raw input? NO — items are RESOLVED view). ⇒ **PlanDayView.items must include raw input fields** (product_id, grams, quantity, portion_name, plus ad-hoc macros when stored) exactly like RecipeIngredientView does — Task 1 must expose these so the UI can rebuild slots losslessly. Recipe-based meals rebuild from recipe_id + recipe_servings.
+
+- [ ] Implement view + dialog; `bun run build:ui` (MUST use existing build script — `--production` gotcha) 
+- [ ] `bun test` full suite green; manual dev-server sanity (`UI_DEV_NO_AUTH=1 bun run dev:ui`) — verify grid renders with seeded plan, confirm flow, add-from-recipe
+- [ ] Commit `feat(plan): Vecka UI view`
+
+### Task 8: infra + version
+
+**Files:** Modify `kubernetes/apps/home-automation/kcal-assistant/networkpolicy.yaml` (add GET /internal/planner + POST /internal/planner/confirm to the :3001 L7 rules), `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml` (image tag v0.11.0), `kcal-assistant/package.json` (version 0.11.0), `.claude/ha-rest-sensors.yaml` (mirror: new sensor + rest_command block)
+
+New HA config blocks (to apply in Task 10, mirrored now):
+```yaml
+# appended to the kcal rest resource's sensor list? NO — separate resource (different endpoint):
+rest:
+  - resource: http://kcal-assistant.home-automation.svc.cluster.local:3001/internal/planner
+    scan_interval: 300
+    timeout: 10
+    sensor:
+      - name: "Kcal veckoplan"
+        unique_id: kcal_veckoplan
+        value_template: "{{ value_json.confirmed_days }}"
+        availability: "{{ value_json is defined and value_json.status == 'ok' }}"
+        json_attributes: [week_start, today, days]
+rest_command:
+  kcal_confirm_day:
+    url: http://kcal-assistant.home-automation.svc.cluster.local:3001/internal/planner/confirm
+    method: POST
+    content_type: application/json
+    payload: '{"date": "{{ date }}"}'
+```
+
+- [ ] Edit files; `bun test` green; commit `feat(plan): netpol + v0.11.0 + HA config mirrors`
+
+### Task 9: glass-cards planner page + Hem chip
+
+**Files:** Create `glass-cards/src/hub/planner-model.ts` (pure parse/derive: payload→typed week, today index, next unlogged meal for chip, per-day display rows), `glass-cards/src/hub/pages/hub-planner-page.ts`; Modify `glass-cards/src/hub/glass-hub.ts` (register page "Vecka", nav), `glass-cards/src/hub/hub-config.ts` (kcal.planner_entity), `glass-cards/src/hub/pages/hub-home-page.ts` (chip), `glass-cards/scripts/hub-config.mjs` (planner_entity: sensor.kcal_veckoplan); Test: `glass-cards/test/planner-model.test.ts` (vitest, follow energy-model test pattern)
+
+Page: 7 columns Mon–Sun, today highlighted (border accent), day-type letter chip (G amber-ish? NO — spec: reuse existing accents, kcal domain lavender; day-type chip: G=green/V=dim/F=teal per available tokens — pick in code from tokens.ts), confirmed ✓ badge, meals grouped by slot with kcal, total vs target footer, coral ⚠ on floor miss. Tap day → existing popup pattern (hub-room-popup style) with macro table + Bekräfta button → `hass.callService('rest_command','kcal_confirm_day',{date})` then `hass.callService('homeassistant','update_entity',{entity_id: plannerEntity})` after ~1.5s; button hidden when confirmed or day has no meals; offline state like kcal page. Hem chip: next unlogged planned meal today ("Middag · Lax · 720 kcal"), hidden when none; tap → navigate to planner page (same mechanism nav bar uses).
+
+- [ ] Failing vitest for planner-model → implement model → PASS
+- [ ] Implement page/chip/config/nav; `npm test` + `npm run build` green
+- [ ] Commit `feat(hub): Vecka planner page + Hem chip`
+
+### Task 10: deploy server + HA config
+
+- [ ] Push branch, open PR (kcal changes + k8s + docs), verify CI green, merge (Philip pre-approved; use gh; if merge blocked by auto-mode classifier, note and proceed via allowed path)
+- [ ] Wait for CI image + Flux (`cluster-apps` Kustomization lag ~min; pods label `app=kcal-assistant`); verify: pod tag v0.11.0, `/healthz` 200, MCP tools/list = 27, `kubectl exec` curl `GET :3001/internal/planner` → status ok, POST confirm on an empty day → 409 "inget planerat", routes 404 on :3000
+- [ ] Apply HA config: read current `/config/configuration.yaml` from HA pod, append blocks (idempotent check first), restart HA (Recreate; wait), verify `sensor.kcal_veckoplan` exists via API
+- [ ] Commit any doc deltas
+
+### Task 11: deploy hub + end-to-end verify
+
+- [ ] `npm run build && ./scripts/upload.sh && node scripts/deploy.mjs hub`
+- [ ] Seed a real plan for the current week via direct MCP call or bun script against prod? NO writes outside product paths — use the MCP endpoint with the prod token (it IS the product path) to plan a plausible week for verification, or leave seeding to Philip's chat. Minimal: plan today+tomorrow via MCP HTTP call so the panel shows content.
+- [ ] Claude-in-Chrome walk: wall-hub → Vecka page renders week, chip on Hem, popup + Bekräfta (verify sensor refresh), KCAL·DB /ui#/vecka (needs Philip's Authentik session — if absent, verify via dev-mode screenshots instead and note)
+- [ ] Update memory files (kcal-assistant-project.md, wall-hub-dashboard-project.md), final report
+
+## Self-review
+
+- Spec coverage: schema/upsert (T1), confirm (T2), shopping (T3), MCP (T4), UI API (T5), internal (T6), Vecka UI (T7), netpol/HA mirrors/version (T8), hub (T9), deploy+verify (T10-11). Future-ideas section untouched — correct.
+- Raw-input round-trip for UI slot rebuilds surfaced in T7 and fed back into T1's PlannedMealView items requirement (items expose raw input + resolved macros, RecipeIngredientView-style).
+- Type names consistent: PlanSlot/PlanDayInput/PlanDayView/PlanWeekView/confirmDay/unconfirmDay/buildShoppingList/buildInternalPlanner used identically across tasks.

--- a/docs/superpowers/specs/2026-07-18-meal-planner-design.md
+++ b/docs/superpowers/specs/2026-07-18-meal-planner-design.md
@@ -1,0 +1,201 @@
+# Meal Planner — kcal-assistant + wall-hub (2026-07-18)
+
+Interactive week meal planner for kcal-assistant, editable from Claude chat (MCP, primary)
+and the KCAL·DB UI, displayed on the wall-hub panel as a dedicated fullscreen page plus a
+Hem chip. Per-day confirm/lock logs the planned meals onto that date's goals.
+
+Philip pre-approved all design decisions (away from computer); this spec records the
+autonomous brainstorm outcome.
+
+## Goals
+
+- Week calendar Mon–Sun with frukost / lunch / middag / mellis per day, each meal specced
+  with kcal + protein/fat/carbs computed by the server (same math as logging).
+- Day types (gymdag/vilodag/flexdag) planned ahead, changeable any time; plan checks
+  (kcal budget, protein/fat floors) recompute live against the day's targets.
+- Per-day **Bekräfta/lås**: copies the planned meals into the real log for that date
+  (feeding day totals, veckosnitt, and the weight forecast's "recent" intake), marks the
+  day confirmed. Undoable (unconfirm removes only plan-originated meals).
+- Editable via MCP (most common), KCAL·DB UI (manual), and confirmable from the wall panel.
+
+## Non-goals (v1)
+
+- Forecast "plan" intake source (future idea; targets/recent/explicit stay as-is).
+- Full item-level meal composer in the UI (product search composition stays in chat).
+- Unconfirm from the wall panel (destructive; chat/UI only).
+- Notifications/reminders.
+
+## Data model (migration 6)
+
+Chosen over (a) reusing `meals` with a planned flag — would force every totals/forecast/
+summary reader to filter and risks double counting; (b) JSON blob per day — no live
+product resolution, weak integrity.
+
+```sql
+CREATE TABLE planned_meals (
+  id             INTEGER PRIMARY KEY,
+  day_date       TEXT NOT NULL REFERENCES days(date),
+  slot           TEXT NOT NULL CHECK (slot IN ('frukost','lunch','middag','mellis')),
+  position       INTEGER NOT NULL DEFAULT 0,
+  name           TEXT NOT NULL,
+  recipe_id      INTEGER REFERENCES recipes(id) ON DELETE SET NULL,
+  recipe_servings REAL,
+  post_gym_shake INTEGER NOT NULL DEFAULT 0,
+  logged_meal_id INTEGER REFERENCES meals(id) ON DELETE SET NULL,
+  note           TEXT,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_planned_meals_day ON planned_meals(day_date);
+
+CREATE TABLE planned_meal_items (      -- raw INPUT, shape = recipe_ingredients
+  id              INTEGER PRIMARY KEY,
+  planned_meal_id INTEGER NOT NULL REFERENCES planned_meals(id) ON DELETE CASCADE,
+  position        INTEGER NOT NULL,
+  product_id      INTEGER REFERENCES products(id) ON DELETE SET NULL,
+  description     TEXT NOT NULL,
+  grams REAL, quantity REAL, portion_name TEXT,
+  kcal REAL, protein REAL, fat REAL, carbs REAL,
+  CHECK ((kcal IS NULL) = (protein IS NULL) AND (kcal IS NULL) = (fat IS NULL)
+     AND (kcal IS NULL) = (carbs IS NULL))
+);
+CREATE INDEX idx_planned_items_meal ON planned_meal_items(planned_meal_id);
+
+ALTER TABLE days ADD COLUMN plan_confirmed_at TEXT;
+```
+
+Semantics:
+
+- A planned meal is **recipe-based** (`recipe_id` + `recipe_servings`, no items) or
+  **item-based** (items resolved live via `resolveItem`, exactly like recipe
+  ingredients). Providing both is an error.
+- Recipe scaling: `per_serving × recipe_servings` when the recipe defines servings,
+  else `totals × recipe_servings` (batches). Recipe edits/product corrections propagate
+  into the plan automatically (live resolution).
+- Unresolvable items (deleted product, missing per-100g) → per-item `unresolved` reason
+  + `totals_incomplete` on the meal; **confirm of that day is blocked** with a clear error.
+- Multiple meals per slot allowed (e.g. two mellis), ordered by `position`.
+- Day lock state = `days.plan_confirmed_at`. Locking is soft: plan edits on a confirmed
+  day succeed but return a varning ("dagen är redan bekräftad — ändringar påverkar inte
+  loggen"); the log is corrected via `edit_meal`/unconfirm as usual.
+
+### Confirm / unconfirm (db/plan.ts)
+
+- `confirmDay(date, slots?)`: transaction; for each planned meal in scope with
+  `logged_meal_id IS NULL` → resolve → insert a `meals` row (name, `post_gym_shake`
+  carried; recipe-based meals log ONE aggregate item "«Receptnamn» (N port)" with scaled
+  macros) via the existing `insertItems`/rounding path → set `logged_meal_id`. When no
+  unlogged planned meals remain for the date, stamp `plan_confirmed_at`. Idempotent:
+  already-logged meals are skipped; a fully confirmed day errors "redan bekräftad".
+  No planned meals at all → error "inget planerat".
+- `unconfirmDay(date)`: delete `meals` rows referenced by the date's
+  `logged_meal_id`s (cascade removes their items; FK SET NULL clears pointers), clear
+  `plan_confirmed_at`. Meals logged outside the plan are untouched. Deleting a
+  plan-logged meal manually via `edit_meal` also clears its pointer (FK), so the plan
+  shows it as un-logged again.
+
+### Week reads
+
+`getPlanWeek(db, startDate)` snaps to the Monday of `startDate`'s week (Stockholm
+"today" as default) and returns 7 days: date, day_type, targets, confirmed state,
+planned meals with slot/name/macros (+ items on request), logged-status per meal,
+day totals vs targets with floor checks, plus week aggregates (planned avg kcal vs
+avg target — kalori-cykling view). Read-only (no ensureDay), same guarantee as `readDay`.
+
+**Shopping list**: aggregation over the range's UNLOGGED planned meals — recipe-based
+meals expand ingredients × scale; totals grouped per product (summed grams/quantities),
+ad-hoc items listed by description. Exposed via `get_plan` flag and the UI.
+
+## MCP surface (24 → 27 tools)
+
+- `plan_week` — THE planning tool, batch upsert:
+  `{ days: [{ date, day_type?, clear_slots?, meals?: [{ slot, name, recipe_id?,
+  recipe_servings?, items?, post_gym_shake?, note? }] }], replace? }`.
+  `replace` default true: slots present in `meals` are replaced wholesale; false
+  appends. `clear_slots` empties slots. `day_type` set inline while planning. Returns
+  compact per-day summaries (totals, remaining, floor checks, varning on confirmed
+  days) so Claude sees immediately whether the week hits targets in ONE call.
+- `get_plan` — `{ start?, weeks? (1–4, default 1), include_items?, shopping_list? }`,
+  weeks snap to Mon–Sun. Compact by default (token economy).
+- `confirm_day` — `{ date, action: 'confirm' | 'unconfirm', slots? }` (slots only for
+  confirm). Returns the updated DayView + plan state.
+
+Existing `set_day_type` stays (mid-week changes); `log_meal`/`edit_meal` untouched.
+
+## UI API + Vecka view (KCAL·DB)
+
+Writes copy the proven `PUT /ui/api/profile` gate exactly: Authentik at edge +
+server-verified, `Sec-Fetch-Site: same-origin`, JSON content-type, 16 KB cap, strict
+shape coercion, shared validation with the MCP path (one truth in db/plan.ts).
+
+- `GET  /ui/api/plan?start=YYYY-MM-DD&weeks=1|2` — full detail incl. items + shopping list.
+- `PUT  /ui/api/plan/<date>` — body = one `plan_week` day (`day_type?/clear_slots?/meals?/replace?`).
+- `PUT  /ui/api/confirm/<date>` — body `{ action: 'confirm' | 'unconfirm', slots? }`.
+
+(Paths fit the existing `API_ROUTE` regex; `server.ts` method gate extended to allow
+these PUTs.)
+
+**Vecka view** (new nav entry): 7-column week grid (vertical day list on mobile), week
+nav ‹ idag ›. Per day: weekday + date header, day-type select (G/V/F color badge),
+totals chip (kcal + P) with warning icons when floors/budget miss, slot sections with
+meal rows (name, kcal, macros on expand), and the **Bekräfta 🔒** button (dialog;
+confirmed days render locked with "loggad" state and an Ångra bekräftelse action).
+Meal actions: delete, move (day/slot), edit recipe servings, add via
+**Från recept** (picker + servings) or **Snabb** (name + 4 macros). Full item
+composition deliberately stays in chat.
+
+## Wall-hub integration
+
+Data path (read): new cluster-only `GET /internal/planner` on :3001 → current week
+Mon–Sun, per day: date, day_type, confirmed, meals `{slot, name, kcal, protein, fat,
+carbs, logged}`, totals, target_kcal, checks. New REST sensor `sensor.kcal_veckoplan`
+(state = confirmed-days count "n/7"; attributes = days), scan 300 s, mirrored in
+`.claude/ha-rest-sensors.yaml`.
+
+Write path (panel confirm): hub calls
+`rest_command.kcal_confirm_day` (`POST /internal/planner/confirm` body `{date}`) then
+`homeassistant.update_entity` on the sensor for instant feedback. Cilium L7 policy
+gains exactly `GET /internal/planner` + `POST /internal/planner/confirm` for the host
+identity; HA remains the only non-nginx principal that can reach the pod. Risk accepted:
+anyone with HA UI access can confirm a day (single household; unconfirm not exposed).
+
+Hub UI:
+
+- **New 6th page "Vecka"** (fullscreen mode): 7 columns Mon–Sun, today highlighted,
+  day-type letter chip, confirmed ✓, meals by slot with kcal, day total vs target.
+  Tap a day → popup with macro detail + Bekräfta button (hidden when confirmed;
+  double-tap safe — server confirm is idempotent).
+- **Hem chip "Idag/Ikväll"**: next unlogged planned meal (e.g. "Middag · Lax 720");
+  tap navigates to Vecka. Kept to one chip so Hem's native-height fit is preserved.
+- Colors follow the hub system (kcal domain = lavender; day-type chips reuse existing
+  domain accents; coral only for floor-miss warnings).
+
+## Testing
+
+- Server (bun test): plan upsert/replace/append/clear; recipe scaling (per-serving +
+  batch fallback); unresolved-item flag + confirm block; confirm idempotency, partial
+  slot confirm, unconfirm removes only plan meals, FK pointer clearing; Monday snap
+  (Sunday + DST edges); shopping-list aggregation; tools (plan_week batch shape,
+  get_plan compactness); ui-api auth matrix for the new PUTs (cross-origin/
+  content-type/405) mirroring profile's tests; internal planner GET/POST + security parity
+  (routes absent on :3000).
+- glass-cards (vitest): planner payload parsing / week-model pure logic
+  (`planner-model.ts`, same pattern as energy-model).
+- Browser walk on the deployed hub via Claude-in-Chrome.
+
+## Deployment
+
+1. kcal-assistant PR: migration 6 + db/tools/api/internal + Vecka UI + tests;
+   version → **v0.11.0** + deployment.yaml image tag; networkpolicy.yaml L7 additions.
+   Merge → CI builds → Flux deploys.
+2. HA config: append REST sensor + `rest_command` to `/config/configuration.yaml`
+   (kubectl exec), mirror in `.claude/ha-rest-sensors.yaml`, reload/restart HA.
+3. glass-cards: `hub-planner-page` + Hem chip + `kcal.planner_entity` config;
+   `npm run build && ./scripts/upload.sh && node scripts/deploy.mjs hub`.
+4. Verify: 27 tools on /mcp, /internal/planner via exec, sensors populated, panel walk.
+5. Philip must **start a new Claude chat** to see the 3 new tools (connector caching).
+
+## Future ideas (explicitly deferred)
+
+Forecast intake source "plan"; copy-week UI button (chat covers it); planned-vs-actual
+deviation stats; panel unconfirm; item-level UI composer.

--- a/glass-cards/dist/glass-cards.js
+++ b/glass-cards/dist/glass-cards.js
@@ -1,4 +1,4 @@
-function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPropertyDescriptor(e,i):a;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)n=Reflect.decorate(t,e,i,a);else for(var o=t.length-1;o>=0;o--)(s=t[o])&&(n=(r<3?s(n):r>3?s(e,i,n):s(e,i))||n);return r>3&&n&&Object.defineProperty(e,i,n),n}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,i=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,a=Symbol(),s=new WeakMap;let r=class{constructor(t,e,i){if(this._$cssResult$=!0,i!==a)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(i&&void 0===t){const i=void 0!==e&&1===e.length;i&&(t=s.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),i&&s.set(e,t))}return t}toString(){return this.cssText}};const n=(t,...e)=>{const i=1===t.length?t[0]:e.reduce((e,i,a)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+t[a+1],t[0]);return new r(i,t,a)},o=i?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const i of t.cssRules)e+=i.cssText;return(t=>new r("string"==typeof t?t:t+"",void 0,a))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:h,getOwnPropertyNames:d,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,g=globalThis,b=g.trustedTypes,m=b?b.emptyScript:"",v=g.reactiveElementPolyfillSupport,f=(t,e)=>t,x={toAttribute(t,e){switch(e){case Boolean:t=t?m:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let i=t;switch(e){case Boolean:i=null!==t;break;case Number:i=null===t?null:Number(t);break;case Object:case Array:try{i=JSON.parse(t)}catch(t){i=null}}return i}},y=(t,e)=>!l(t,e),_={attribute:!0,type:String,converter:x,reflect:!1,useDefault:!1,hasChanged:y};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let w=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=_){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const i=Symbol(),a=this.getPropertyDescriptor(t,i,e);void 0!==a&&c(this.prototype,t,a)}}static getPropertyDescriptor(t,e,i){const{get:a,set:s}=h(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:a,set(e){const r=a?.call(this);s?.call(this,e),this.requestUpdate(t,r,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??_}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const t=u(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const t=this.properties,e=[...d(t),...p(t)];for(const i of e)this.createProperty(i,t[i])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,i]of e)this.elementProperties.set(t,i)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const i=this._$Eu(t,e);void 0!==i&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const i=new Set(t.flat(1/0).reverse());for(const t of i)e.unshift(o(t))}else void 0!==t&&e.push(o(t));return e}static _$Eu(t,e){const i=e.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const i of e.keys())this.hasOwnProperty(i)&&(t.set(i,this[i]),delete this[i]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,a)=>{if(i)t.adoptedStyleSheets=a.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const i of a){const a=document.createElement("style"),s=e.litNonce;void 0!==s&&a.setAttribute("nonce",s),a.textContent=i.cssText,t.appendChild(a)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,i){this._$AK(t,i)}_$ET(t,e){const i=this.constructor.elementProperties.get(t),a=this.constructor._$Eu(t,i);if(void 0!==a&&!0===i.reflect){const s=(void 0!==i.converter?.toAttribute?i.converter:x).toAttribute(e,i.type);this._$Em=t,null==s?this.removeAttribute(a):this.setAttribute(a,s),this._$Em=null}}_$AK(t,e){const i=this.constructor,a=i._$Eh.get(t);if(void 0!==a&&this._$Em!==a){const t=i.getPropertyOptions(a),s="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:x;this._$Em=a;const r=s.fromAttribute(e,t.type);this[a]=r??this._$Ej?.get(a)??r,this._$Em=null}}requestUpdate(t,e,i,a=!1,s){if(void 0!==t){const r=this.constructor;if(!1===a&&(s=this[t]),i??=r.getPropertyOptions(t),!((i.hasChanged??y)(s,e)||i.useDefault&&i.reflect&&s===this._$Ej?.get(t)&&!this.hasAttribute(r._$Eu(t,i))))return;this.C(t,e,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:i,reflect:a,wrapped:s},r){i&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,r??e??this[t]),!0!==s||void 0!==r)||(this._$AL.has(t)||(this.hasUpdated||i||(e=void 0),this._$AL.set(t,e)),!0===a&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,i]of t){const{wrapped:t}=i,a=this[e];!0!==t||this._$AL.has(e)||void 0===a||this.C(e,void 0,i,a)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};w.elementStyles=[],w.shadowRootOptions={mode:"open"},w[f("elementProperties")]=new Map,w[f("finalized")]=new Map,v?.({ReactiveElement:w}),(g.reactiveElementVersions??=[]).push("2.1.2");const k=globalThis,$=t=>t,C=k.trustedTypes,E=C?C.createPolicy("lit-html",{createHTML:t=>t}):void 0,S="$lit$",A=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+A,T=`<${M}>`,N=document,z=()=>N.createComment(""),P=t=>null===t||"object"!=typeof t&&"function"!=typeof t,F=Array.isArray,j="[ \t\n\f\r]",D=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,H=/-->/g,I=/>/g,O=RegExp(`>|${j}(?:([^\\s"'>=/]+)(${j}*=${j}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),R=/'/g,U=/"/g,B=/^(?:script|style|textarea|title)$/i,L=t=>(e,...i)=>({_$litType$:t,strings:e,values:i}),V=L(1),X=L(2),q=Symbol.for("lit-noChange"),G=Symbol.for("lit-nothing"),W=new WeakMap,Y=N.createTreeWalker(N,129);function K(t,e){if(!F(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==E?E.createHTML(e):e}const Z=(t,e)=>{const i=t.length-1,a=[];let s,r=2===e?"<svg>":3===e?"<math>":"",n=D;for(let e=0;e<i;e++){const i=t[e];let o,l,c=-1,h=0;for(;h<i.length&&(n.lastIndex=h,l=n.exec(i),null!==l);)h=n.lastIndex,n===D?"!--"===l[1]?n=H:void 0!==l[1]?n=I:void 0!==l[2]?(B.test(l[2])&&(s=RegExp("</"+l[2],"g")),n=O):void 0!==l[3]&&(n=O):n===O?">"===l[0]?(n=s??D,c=-1):void 0===l[1]?c=-2:(c=n.lastIndex-l[2].length,o=l[1],n=void 0===l[3]?O:'"'===l[3]?U:R):n===U||n===R?n=O:n===H||n===I?n=D:(n=O,s=void 0);const d=n===O&&t[e+1].startsWith("/>")?" ":"";r+=n===D?i+T:c>=0?(a.push(o),i.slice(0,c)+S+i.slice(c)+A+d):i+A+(-2===c?e:d)}return[K(t,r+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),a]};class Q{constructor({strings:t,_$litType$:e},i){let a;this.parts=[];let s=0,r=0;const n=t.length-1,o=this.parts,[l,c]=Z(t,e);if(this.el=Q.createElement(l,i),Y.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(a=Y.nextNode())&&o.length<n;){if(1===a.nodeType){if(a.hasAttributes())for(const t of a.getAttributeNames())if(t.endsWith(S)){const e=c[r++],i=a.getAttribute(t).split(A),n=/([.?@])?(.*)/.exec(e);o.push({type:1,index:s,name:n[2],strings:i,ctor:"."===n[1]?at:"?"===n[1]?st:"@"===n[1]?rt:it}),a.removeAttribute(t)}else t.startsWith(A)&&(o.push({type:6,index:s}),a.removeAttribute(t));if(B.test(a.tagName)){const t=a.textContent.split(A),e=t.length-1;if(e>0){a.textContent=C?C.emptyScript:"";for(let i=0;i<e;i++)a.append(t[i],z()),Y.nextNode(),o.push({type:2,index:++s});a.append(t[e],z())}}}else if(8===a.nodeType)if(a.data===M)o.push({type:2,index:s});else{let t=-1;for(;-1!==(t=a.data.indexOf(A,t+1));)o.push({type:7,index:s}),t+=A.length-1}s++}}static createElement(t,e){const i=N.createElement("template");return i.innerHTML=t,i}}function J(t,e,i=t,a){if(e===q)return e;let s=void 0!==a?i._$Co?.[a]:i._$Cl;const r=P(e)?void 0:e._$litDirective$;return s?.constructor!==r&&(s?._$AO?.(!1),void 0===r?s=void 0:(s=new r(t),s._$AT(t,i,a)),void 0!==a?(i._$Co??=[])[a]=s:i._$Cl=s),void 0!==s&&(e=J(t,s._$AS(t,e.values),s,a)),e}class tt{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,a=(t?.creationScope??N).importNode(e,!0);Y.currentNode=a;let s=Y.nextNode(),r=0,n=0,o=i[0];for(;void 0!==o;){if(r===o.index){let e;2===o.type?e=new et(s,s.nextSibling,this,t):1===o.type?e=new o.ctor(s,o.name,o.strings,this,t):6===o.type&&(e=new nt(s,this,t)),this._$AV.push(e),o=i[++n]}r!==o?.index&&(s=Y.nextNode(),r++)}return Y.currentNode=N,a}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class et{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,a){this.type=2,this._$AH=G,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=a,this._$Cv=a?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=J(this,t,e),P(t)?t===G||null==t||""===t?(this._$AH!==G&&this._$AR(),this._$AH=G):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>F(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==G&&P(this._$AH)?this._$AA.nextSibling.data=t:this.T(N.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,a="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=Q.createElement(K(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===a)this._$AH.p(e);else{const t=new tt(a,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=W.get(t.strings);return void 0===e&&W.set(t.strings,e=new Q(t)),e}k(t){F(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,a=0;for(const s of t)a===e.length?e.push(i=new et(this.O(z()),this.O(z()),this,this.options)):i=e[a],i._$AI(s),a++;a<e.length&&(this._$AR(i&&i._$AB.nextSibling,a),e.length=a)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=$(t).nextSibling;$(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class it{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,a,s){this.type=1,this._$AH=G,this._$AN=void 0,this.element=t,this.name=e,this._$AM=a,this.options=s,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=G}_$AI(t,e=this,i,a){const s=this.strings;let r=!1;if(void 0===s)t=J(this,t,e,0),r=!P(t)||t!==this._$AH&&t!==q,r&&(this._$AH=t);else{const a=t;let n,o;for(t=s[0],n=0;n<s.length-1;n++)o=J(this,a[i+n],e,n),o===q&&(o=this._$AH[n]),r||=!P(o)||o!==this._$AH[n],o===G?t=G:t!==G&&(t+=(o??"")+s[n+1]),this._$AH[n]=o}r&&!a&&this.j(t)}j(t){t===G?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class at extends it{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===G?void 0:t}}class st extends it{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==G)}}class rt extends it{constructor(t,e,i,a,s){super(t,e,i,a,s),this.type=5}_$AI(t,e=this){if((t=J(this,t,e,0)??G)===q)return;const i=this._$AH,a=t===G&&i!==G||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,s=t!==G&&(i===G||a);a&&this.element.removeEventListener(this.name,this,i),s&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class nt{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){J(this,t)}}const ot=k.litHtmlPolyfillSupport;ot?.(Q,et),(k.litHtmlVersions??=[]).push("3.3.2");const lt=globalThis;class ct extends w{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const a=i?.renderBefore??e;let s=a._$litPart$;if(void 0===s){const t=i?.renderBefore??null;a._$litPart$=s=new et(e.insertBefore(z(),t),t,void 0,i??{})}return s._$AI(t),s})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}}ct._$litElement$=!0,ct.finalized=!0,lt.litElementHydrateSupport?.({LitElement:ct});const ht=lt.litElementPolyfillSupport;ht?.({LitElement:ct}),(lt.litElementVersions??=[]).push("4.2.2");const dt=t=>(e,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},pt={attribute:!0,type:String,converter:x,reflect:!1,hasChanged:y},ut=(t=pt,e,i)=>{const{kind:a,metadata:s}=i;let r=globalThis.litPropertyMetadata.get(s);if(void 0===r&&globalThis.litPropertyMetadata.set(s,r=new Map),"setter"===a&&((t=Object.create(t)).wrapped=!0),r.set(i.name,t),"accessor"===a){const{name:a}=i;return{set(i){const s=e.get.call(this);e.set.call(this,i),this.requestUpdate(a,s,t,!0,i)},init(e){return void 0!==e&&this.C(a,void 0,t,e),e}}}if("setter"===a){const{name:a}=i;return function(i){const s=this[a];e.call(this,i),this.requestUpdate(a,s,t,!0,i)}}throw Error("Unsupported decorator location: "+a)};function gt(t){return(e,i)=>"object"==typeof i?ut(t,e,i):((t,e,i)=>{const a=e.hasOwnProperty(i);return e.constructor.createProperty(i,t),a?Object.getOwnPropertyDescriptor(e,i):void 0})(t,e,i)}function bt(t){return gt({...t,state:!0,attribute:!1})}let mt=class extends ct{constructor(){super(...arguments),this._cards=[],this._activeView=null,this._cardConfigs=[],this._boundHashChange=this._onHashChange.bind(this)}connectedCallback(){super.connectedCallback(),window.addEventListener("hashchange",this._boundHashChange),this._activeView=this._getViewFromHash()??this._config?.default_view??null}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("hashchange",this._boundHashChange)}_onHashChange(){const t=this._getViewFromHash();null!==t&&(this._activeView=t),location.hash&&"#"!==location.hash||(this._activeView=this._config?.default_view??null)}_getViewFromHash(){const t=location.hash.replace("#","");if(!t)return null;return(this._config?.views??[]).includes(t)?t:null}setConfig(t){this._config=t,this._activeView=this._getViewFromHash()??t.default_view??null,this._createCards()}set hass(t){this._hass=t,this._cards.forEach(e=>{e.hass=t})}get hass(){return this._hass}_createCards(){this._config.cards&&(this._cardConfigs=this._config.cards,this._cards=this._config.cards.map(t=>{const e=t.type?.startsWith("custom:")?t.type.replace("custom:",""):`hui-${t.type}-card`,i=document.createElement(e);return"function"==typeof i.setConfig&&i.setConfig(t),i}),this.requestUpdate())}render(){const t=this._cards.filter((t,e)=>{const i=this._cardConfigs[e];return!i||!i.view||i.view===this._activeView});return V`
+function t(t,e,i,a){var r,s=arguments.length,n=s<3?e:null===a?a=Object.getOwnPropertyDescriptor(e,i):a;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)n=Reflect.decorate(t,e,i,a);else for(var o=t.length-1;o>=0;o--)(r=t[o])&&(n=(s<3?r(n):s>3?r(e,i,n):r(e,i))||n);return s>3&&n&&Object.defineProperty(e,i,n),n}"function"==typeof SuppressedError&&SuppressedError;const e=globalThis,i=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,a=Symbol(),r=new WeakMap;let s=class{constructor(t,e,i){if(this._$cssResult$=!0,i!==a)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(i&&void 0===t){const i=void 0!==e&&1===e.length;i&&(t=r.get(e)),void 0===t&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),i&&r.set(e,t))}return t}toString(){return this.cssText}};const n=(t,...e)=>{const i=1===t.length?t[0]:e.reduce((e,i,a)=>e+(t=>{if(!0===t._$cssResult$)return t.cssText;if("number"==typeof t)return t;throw Error("Value passed to 'css' function must be a 'css' function result: "+t+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+t[a+1],t[0]);return new s(i,t,a)},o=i?t=>t:t=>t instanceof CSSStyleSheet?(t=>{let e="";for(const i of t.cssRules)e+=i.cssText;return(t=>new s("string"==typeof t?t:t+"",void 0,a))(e)})(t):t,{is:l,defineProperty:c,getOwnPropertyDescriptor:h,getOwnPropertyNames:d,getOwnPropertySymbols:p,getPrototypeOf:u}=Object,g=globalThis,b=g.trustedTypes,m=b?b.emptyScript:"",v=g.reactiveElementPolyfillSupport,f=(t,e)=>t,x={toAttribute(t,e){switch(e){case Boolean:t=t?m:null;break;case Object:case Array:t=null==t?t:JSON.stringify(t)}return t},fromAttribute(t,e){let i=t;switch(e){case Boolean:i=null!==t;break;case Number:i=null===t?null:Number(t);break;case Object:case Array:try{i=JSON.parse(t)}catch(t){i=null}}return i}},y=(t,e)=>!l(t,e),_={attribute:!0,type:String,converter:x,reflect:!1,useDefault:!1,hasChanged:y};Symbol.metadata??=Symbol("metadata"),g.litPropertyMetadata??=new WeakMap;let w=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??=[]).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=_){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const i=Symbol(),a=this.getPropertyDescriptor(t,i,e);void 0!==a&&c(this.prototype,t,a)}}static getPropertyDescriptor(t,e,i){const{get:a,set:r}=h(this.prototype,t)??{get(){return this[e]},set(t){this[e]=t}};return{get:a,set(e){const s=a?.call(this);r?.call(this,e),this.requestUpdate(t,s,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??_}static _$Ei(){if(this.hasOwnProperty(f("elementProperties")))return;const t=u(this);t.finalize(),void 0!==t.l&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(f("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(f("properties"))){const t=this.properties,e=[...d(t),...p(t)];for(const i of e)this.createProperty(i,t[i])}const t=this[Symbol.metadata];if(null!==t){const e=litPropertyMetadata.get(t);if(void 0!==e)for(const[t,i]of e)this.elementProperties.set(t,i)}this._$Eh=new Map;for(const[t,e]of this.elementProperties){const i=this._$Eu(t,e);void 0!==i&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const i=new Set(t.flat(1/0).reverse());for(const t of i)e.unshift(o(t))}else void 0!==t&&e.push(o(t));return e}static _$Eu(t,e){const i=e.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof t?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(t=>this.enableUpdating=t),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(t=>t(this))}addController(t){(this._$EO??=new Set).add(t),void 0!==this.renderRoot&&this.isConnected&&t.hostConnected?.()}removeController(t){this._$EO?.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const i of e.keys())this.hasOwnProperty(i)&&(t.set(i,this[i]),delete this[i]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((t,a)=>{if(i)t.adoptedStyleSheets=a.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(const i of a){const a=document.createElement("style"),r=e.litNonce;void 0!==r&&a.setAttribute("nonce",r),a.textContent=i.cssText,t.appendChild(a)}})(t,this.constructor.elementStyles),t}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(t=>t.hostConnected?.())}enableUpdating(t){}disconnectedCallback(){this._$EO?.forEach(t=>t.hostDisconnected?.())}attributeChangedCallback(t,e,i){this._$AK(t,i)}_$ET(t,e){const i=this.constructor.elementProperties.get(t),a=this.constructor._$Eu(t,i);if(void 0!==a&&!0===i.reflect){const r=(void 0!==i.converter?.toAttribute?i.converter:x).toAttribute(e,i.type);this._$Em=t,null==r?this.removeAttribute(a):this.setAttribute(a,r),this._$Em=null}}_$AK(t,e){const i=this.constructor,a=i._$Eh.get(t);if(void 0!==a&&this._$Em!==a){const t=i.getPropertyOptions(a),r="function"==typeof t.converter?{fromAttribute:t.converter}:void 0!==t.converter?.fromAttribute?t.converter:x;this._$Em=a;const s=r.fromAttribute(e,t.type);this[a]=s??this._$Ej?.get(a)??s,this._$Em=null}}requestUpdate(t,e,i,a=!1,r){if(void 0!==t){const s=this.constructor;if(!1===a&&(r=this[t]),i??=s.getPropertyOptions(t),!((i.hasChanged??y)(r,e)||i.useDefault&&i.reflect&&r===this._$Ej?.get(t)&&!this.hasAttribute(s._$Eu(t,i))))return;this.C(t,e,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(t,e,{useDefault:i,reflect:a,wrapped:r},s){i&&!(this._$Ej??=new Map).has(t)&&(this._$Ej.set(t,s??e??this[t]),!0!==r||void 0!==s)||(this._$AL.has(t)||(this.hasUpdated||i||(e=void 0),this._$AL.set(t,e)),!0===a&&this._$Em!==t&&(this._$Eq??=new Set).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}const t=this.scheduleUpdate();return null!=t&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[t,e]of this._$Ep)this[t]=e;this._$Ep=void 0}const t=this.constructor.elementProperties;if(t.size>0)for(const[e,i]of t){const{wrapped:t}=i,a=this[e];!0!==t||this._$AL.has(e)||void 0===a||this.C(e,void 0,i,a)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),this._$EO?.forEach(t=>t.hostUpdate?.()),this.update(e)):this._$EM()}catch(e){throw t=!1,this._$EM(),e}t&&this._$AE(e)}willUpdate(t){}_$AE(t){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&=this._$Eq.forEach(t=>this._$ET(t,this[t])),this._$EM()}updated(t){}firstUpdated(t){}};w.elementStyles=[],w.shadowRootOptions={mode:"open"},w[f("elementProperties")]=new Map,w[f("finalized")]=new Map,v?.({ReactiveElement:w}),(g.reactiveElementVersions??=[]).push("2.1.2");const k=globalThis,$=t=>t,C=k.trustedTypes,E=C?C.createPolicy("lit-html",{createHTML:t=>t}):void 0,S="$lit$",A=`lit$${Math.random().toFixed(9).slice(2)}$`,M="?"+A,T=`<${M}>`,N=document,z=()=>N.createComment(""),P=t=>null===t||"object"!=typeof t&&"function"!=typeof t,F=Array.isArray,D="[ \t\n\f\r]",j=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,H=/-->/g,I=/>/g,O=RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),R=/'/g,U=/"/g,B=/^(?:script|style|textarea|title)$/i,L=t=>(e,...i)=>({_$litType$:t,strings:e,values:i}),V=L(1),X=L(2),q=Symbol.for("lit-noChange"),G=Symbol.for("lit-nothing"),W=new WeakMap,Y=N.createTreeWalker(N,129);function K(t,e){if(!F(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==E?E.createHTML(e):e}const Z=(t,e)=>{const i=t.length-1,a=[];let r,s=2===e?"<svg>":3===e?"<math>":"",n=j;for(let e=0;e<i;e++){const i=t[e];let o,l,c=-1,h=0;for(;h<i.length&&(n.lastIndex=h,l=n.exec(i),null!==l);)h=n.lastIndex,n===j?"!--"===l[1]?n=H:void 0!==l[1]?n=I:void 0!==l[2]?(B.test(l[2])&&(r=RegExp("</"+l[2],"g")),n=O):void 0!==l[3]&&(n=O):n===O?">"===l[0]?(n=r??j,c=-1):void 0===l[1]?c=-2:(c=n.lastIndex-l[2].length,o=l[1],n=void 0===l[3]?O:'"'===l[3]?U:R):n===U||n===R?n=O:n===H||n===I?n=j:(n=O,r=void 0);const d=n===O&&t[e+1].startsWith("/>")?" ":"";s+=n===j?i+T:c>=0?(a.push(o),i.slice(0,c)+S+i.slice(c)+A+d):i+A+(-2===c?e:d)}return[K(t,s+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),a]};class Q{constructor({strings:t,_$litType$:e},i){let a;this.parts=[];let r=0,s=0;const n=t.length-1,o=this.parts,[l,c]=Z(t,e);if(this.el=Q.createElement(l,i),Y.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(a=Y.nextNode())&&o.length<n;){if(1===a.nodeType){if(a.hasAttributes())for(const t of a.getAttributeNames())if(t.endsWith(S)){const e=c[s++],i=a.getAttribute(t).split(A),n=/([.?@])?(.*)/.exec(e);o.push({type:1,index:r,name:n[2],strings:i,ctor:"."===n[1]?at:"?"===n[1]?rt:"@"===n[1]?st:it}),a.removeAttribute(t)}else t.startsWith(A)&&(o.push({type:6,index:r}),a.removeAttribute(t));if(B.test(a.tagName)){const t=a.textContent.split(A),e=t.length-1;if(e>0){a.textContent=C?C.emptyScript:"";for(let i=0;i<e;i++)a.append(t[i],z()),Y.nextNode(),o.push({type:2,index:++r});a.append(t[e],z())}}}else if(8===a.nodeType)if(a.data===M)o.push({type:2,index:r});else{let t=-1;for(;-1!==(t=a.data.indexOf(A,t+1));)o.push({type:7,index:r}),t+=A.length-1}r++}}static createElement(t,e){const i=N.createElement("template");return i.innerHTML=t,i}}function J(t,e,i=t,a){if(e===q)return e;let r=void 0!==a?i._$Co?.[a]:i._$Cl;const s=P(e)?void 0:e._$litDirective$;return r?.constructor!==s&&(r?._$AO?.(!1),void 0===s?r=void 0:(r=new s(t),r._$AT(t,i,a)),void 0!==a?(i._$Co??=[])[a]=r:i._$Cl=r),void 0!==r&&(e=J(t,r._$AS(t,e.values),r,a)),e}class tt{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,a=(t?.creationScope??N).importNode(e,!0);Y.currentNode=a;let r=Y.nextNode(),s=0,n=0,o=i[0];for(;void 0!==o;){if(s===o.index){let e;2===o.type?e=new et(r,r.nextSibling,this,t):1===o.type?e=new o.ctor(r,o.name,o.strings,this,t):6===o.type&&(e=new nt(r,this,t)),this._$AV.push(e),o=i[++n]}s!==o?.index&&(r=Y.nextNode(),s++)}return Y.currentNode=N,a}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class et{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,a){this.type=2,this._$AH=G,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=a,this._$Cv=a?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=J(this,t,e),P(t)?t===G||null==t||""===t?(this._$AH!==G&&this._$AR(),this._$AH=G):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>F(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==G&&P(this._$AH)?this._$AA.nextSibling.data=t:this.T(N.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,a="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=Q.createElement(K(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===a)this._$AH.p(e);else{const t=new tt(a,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=W.get(t.strings);return void 0===e&&W.set(t.strings,e=new Q(t)),e}k(t){F(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,a=0;for(const r of t)a===e.length?e.push(i=new et(this.O(z()),this.O(z()),this,this.options)):i=e[a],i._$AI(r),a++;a<e.length&&(this._$AR(i&&i._$AB.nextSibling,a),e.length=a)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=$(t).nextSibling;$(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class it{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,a,r){this.type=1,this._$AH=G,this._$AN=void 0,this.element=t,this.name=e,this._$AM=a,this.options=r,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=G}_$AI(t,e=this,i,a){const r=this.strings;let s=!1;if(void 0===r)t=J(this,t,e,0),s=!P(t)||t!==this._$AH&&t!==q,s&&(this._$AH=t);else{const a=t;let n,o;for(t=r[0],n=0;n<r.length-1;n++)o=J(this,a[i+n],e,n),o===q&&(o=this._$AH[n]),s||=!P(o)||o!==this._$AH[n],o===G?t=G:t!==G&&(t+=(o??"")+r[n+1]),this._$AH[n]=o}s&&!a&&this.j(t)}j(t){t===G?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class at extends it{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===G?void 0:t}}class rt extends it{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==G)}}class st extends it{constructor(t,e,i,a,r){super(t,e,i,a,r),this.type=5}_$AI(t,e=this){if((t=J(this,t,e,0)??G)===q)return;const i=this._$AH,a=t===G&&i!==G||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,r=t!==G&&(i===G||a);a&&this.element.removeEventListener(this.name,this,i),r&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class nt{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){J(this,t)}}const ot=k.litHtmlPolyfillSupport;ot?.(Q,et),(k.litHtmlVersions??=[]).push("3.3.2");const lt=globalThis;class ct extends w{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const a=i?.renderBefore??e;let r=a._$litPart$;if(void 0===r){const t=i?.renderBefore??null;a._$litPart$=r=new et(e.insertBefore(z(),t),t,void 0,i??{})}return r._$AI(t),r})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}}ct._$litElement$=!0,ct.finalized=!0,lt.litElementHydrateSupport?.({LitElement:ct});const ht=lt.litElementPolyfillSupport;ht?.({LitElement:ct}),(lt.litElementVersions??=[]).push("4.2.2");const dt=t=>(e,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(t,e)}):customElements.define(t,e)},pt={attribute:!0,type:String,converter:x,reflect:!1,hasChanged:y},ut=(t=pt,e,i)=>{const{kind:a,metadata:r}=i;let s=globalThis.litPropertyMetadata.get(r);if(void 0===s&&globalThis.litPropertyMetadata.set(r,s=new Map),"setter"===a&&((t=Object.create(t)).wrapped=!0),s.set(i.name,t),"accessor"===a){const{name:a}=i;return{set(i){const r=e.get.call(this);e.set.call(this,i),this.requestUpdate(a,r,t,!0,i)},init(e){return void 0!==e&&this.C(a,void 0,t,e),e}}}if("setter"===a){const{name:a}=i;return function(i){const r=this[a];e.call(this,i),this.requestUpdate(a,r,t,!0,i)}}throw Error("Unsupported decorator location: "+a)};function gt(t){return(e,i)=>"object"==typeof i?ut(t,e,i):((t,e,i)=>{const a=e.hasOwnProperty(i);return e.constructor.createProperty(i,t),a?Object.getOwnPropertyDescriptor(e,i):void 0})(t,e,i)}function bt(t){return gt({...t,state:!0,attribute:!1})}let mt=class extends ct{constructor(){super(...arguments),this._cards=[],this._activeView=null,this._cardConfigs=[],this._boundHashChange=this._onHashChange.bind(this)}connectedCallback(){super.connectedCallback(),window.addEventListener("hashchange",this._boundHashChange),this._activeView=this._getViewFromHash()??this._config?.default_view??null}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener("hashchange",this._boundHashChange)}_onHashChange(){const t=this._getViewFromHash();null!==t&&(this._activeView=t),location.hash&&"#"!==location.hash||(this._activeView=this._config?.default_view??null)}_getViewFromHash(){const t=location.hash.replace("#","");if(!t)return null;return(this._config?.views??[]).includes(t)?t:null}setConfig(t){this._config=t,this._activeView=this._getViewFromHash()??t.default_view??null,this._createCards()}set hass(t){this._hass=t,this._cards.forEach(e=>{e.hass=t})}get hass(){return this._hass}_createCards(){this._config.cards&&(this._cardConfigs=this._config.cards,this._cards=this._config.cards.map(t=>{const e=t.type?.startsWith("custom:")?t.type.replace("custom:",""):`hui-${t.type}-card`,i=document.createElement(e);return"function"==typeof i.setConfig&&i.setConfig(t),i}),this.requestUpdate())}render(){const t=this._cards.filter((t,e)=>{const i=this._cardConfigs[e];return!i||!i.view||i.view===this._activeView});return V`
       <div class="background"></div>
       <div class="content">
         ${t.map(t=>t)}
@@ -108,14 +108,14 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           0 0 20px var(--glass-accent-glow),
           0 0 60px rgba(79, 195, 247, 0.1);
       }
-    `}}t([gt({attribute:!1})],vt.prototype,"hass",void 0),t([gt({attribute:!1})],vt.prototype,"_config",void 0);let ft=class extends vt{get _buttonConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_handleTap(){const t=this._buttonConfig.tap_action?.action??"toggle";"toggle"===t&&this._config.entity?this.toggle(this._config.entity):"navigate"===t&&this._buttonConfig.tap_action?.navigation_path&&(window.location.hash=this._buttonConfig.tap_action.navigation_path)}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=!!t&&this.isOn(this._config.entity),i=this._config.name??t?.attributes.friendly_name??"",a=this._config.icon??t?.attributes.icon??"mdi:help-circle";let s="";if(!1!==this._buttonConfig.show_state&&t){const e=t.attributes.unit_of_measurement;s=e?`${t.state} ${e}`:"on"===t.state?"Pa":"off"===t.state?"Av":t.state}return V`
+    `}}t([gt({attribute:!1})],vt.prototype,"hass",void 0),t([gt({attribute:!1})],vt.prototype,"_config",void 0);let ft=class extends vt{get _buttonConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_handleTap(){const t=this._buttonConfig.tap_action?.action??"toggle";"toggle"===t&&this._config.entity?this.toggle(this._config.entity):"navigate"===t&&this._buttonConfig.tap_action?.navigation_path&&(window.location.hash=this._buttonConfig.tap_action.navigation_path)}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=!!t&&this.isOn(this._config.entity),i=this._config.name??t?.attributes.friendly_name??"",a=this._config.icon??t?.attributes.icon??"mdi:help-circle";let r="";if(!1!==this._buttonConfig.show_state&&t){const e=t.attributes.unit_of_measurement;r=e?`${t.state} ${e}`:"on"===t.state?"Pa":"off"===t.state?"Av":t.state}return V`
       <div class="glass button ${e?"active":""}" @click=${this._handleTap}>
         <div class="icon-wrap">
           <ha-icon .icon=${a}></ha-icon>
         </div>
         <div class="info">
           <div class="name">${i}</div>
-          ${s?V`<div class="state">${s}</div>`:""}
+          ${r?V`<div class="state">${r}</div>`:""}
         </div>
       </div>
     `}};ft.styles=[vt.glassStyles,n`
@@ -171,8 +171,8 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         text-overflow: ellipsis;
       }
       .active .state { color: var(--glass-text-secondary); }
-    `],ft=t([dt("glass-button")],ft);let xt=class extends vt{setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}get _chipConfig(){return this._config}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=this._chipConfig.chip_type??"custom";let i=this._config.icon??"",a="",s=!1;switch(e){case"person":{const e=t?.attributes.friendly_name??"",r=t?.state??"";i=i||"mdi:account",a=`${e} · ${"home"===r?"Hemma":"Borta"}`,s="home"===r;break}case"battery":{const e=t?.state??"?";i=i||"mdi:cellphone",a=`${e} %`,s=Number(e)>20;break}case"lights":{const e=t?.state??"0";i=i||"mdi:lightbulb-group",a=`${e} st`,s=Number(e)>0;break}default:i=i||"mdi:information",a=this._chipConfig.content??t?.state??""}return V`
-      <div class="chip ${s?"active":""}">
+    `],ft=t([dt("glass-button")],ft);let xt=class extends vt{setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}get _chipConfig(){return this._config}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=this._chipConfig.chip_type??"custom";let i=this._config.icon??"",a="",r=!1;switch(e){case"person":{const e=t?.attributes.friendly_name??"",s=t?.state??"";i=i||"mdi:account",a=`${e} · ${"home"===s?"Hemma":"Borta"}`,r="home"===s;break}case"battery":{const e=t?.state??"?";i=i||"mdi:cellphone",a=`${e} %`,r=Number(e)>20;break}case"lights":{const e=t?.state??"0";i=i||"mdi:lightbulb-group",a=`${e} st`,r=Number(e)>0;break}default:i=i||"mdi:information",a=this._chipConfig.content??t?.state??""}return V`
+      <div class="chip ${r?"active":""}">
         <ha-icon .icon=${i}></ha-icon>
         <span class="value">${a}</span>
       </div>
@@ -206,12 +206,12 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       .chip .value {
         font-variant-numeric: tabular-nums;
       }
-    `],xt=t([dt("glass-chip")],xt);let yt=class extends vt{get _headerConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.weather_entity&&e.push(t.weather_entity),t.chips&&t.chips.forEach(t=>{t.entity&&e.push(t.entity)}),this.setTrackedEntities(e)}_renderChip(t){const e=this.getEntity(t.entity);if(!e)return V``;let i=t.icon??"",a="",s=!1;switch(t.chip_type){case"person":i=i||"mdi:account";a=`${e.attributes.friendly_name??""} · ${"home"===e.state?"Hemma":"Borta"}`,s="home"===e.state;break;case"battery":i=i||"mdi:cellphone",a=`${e.state} %`,s=Number(e.state)>20;break;case"lights":i=i||"mdi:lightbulb-group",a=`${e.state} st`,s=Number(e.state)>0;break;default:i=i||"mdi:information",a=e.state}return V`
-      <div class="chip ${s?"active":""}">
+    `],xt=t([dt("glass-chip")],xt);let yt=class extends vt{get _headerConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.weather_entity&&e.push(t.weather_entity),t.chips&&t.chips.forEach(t=>{t.entity&&e.push(t.entity)}),this.setTrackedEntities(e)}_renderChip(t){const e=this.getEntity(t.entity);if(!e)return V``;let i=t.icon??"",a="",r=!1;switch(t.chip_type){case"person":i=i||"mdi:account";a=`${e.attributes.friendly_name??""} · ${"home"===e.state?"Hemma":"Borta"}`,r="home"===e.state;break;case"battery":i=i||"mdi:cellphone",a=`${e.state} %`,r=Number(e.state)>20;break;case"lights":i=i||"mdi:lightbulb-group",a=`${e.state} st`,r=Number(e.state)>0;break;default:i=i||"mdi:information",a=e.state}return V`
+      <div class="chip ${r?"active":""}">
         <ha-icon .icon=${i}></ha-icon>
         <span>${a}</span>
       </div>
-    `}render(){if(!this.hass||!this._config)return V``;const t=this.hass.user?.name??"",e=!1!==this._headerConfig.greeting?function(t){const e=(new Date).getHours();return e>=5&&e<10?`God morgon, ${t}`:e>=10&&e<17?`Hej, ${t}`:e>=17&&e<22?`God kvall, ${t}`:`God natt, ${t}`}(t):t,i=this._headerConfig.weather_entity?this.getEntity(this._headerConfig.weather_entity):void 0,a=i?.state??"",s=i?.attributes.temperature??"",r=i?.attributes.temperature_unit??"°C",n={"clear-night":"mdi:weather-night",cloudy:"mdi:weather-cloudy",fog:"mdi:weather-fog",hail:"mdi:weather-hail",lightning:"mdi:weather-lightning","lightning-rainy":"mdi:weather-lightning-rainy",partlycloudy:"mdi:weather-partly-cloudy",pouring:"mdi:weather-pouring",rainy:"mdi:weather-rainy",snowy:"mdi:weather-snowy","snowy-rainy":"mdi:weather-snowy-rainy",sunny:"mdi:weather-sunny",windy:"mdi:weather-windy","windy-variant":"mdi:weather-windy-variant",exceptional:"mdi:alert-circle-outline"}[a]??"mdi:weather-cloudy";return V`
+    `}render(){if(!this.hass||!this._config)return V``;const t=this.hass.user?.name??"",e=!1!==this._headerConfig.greeting?function(t){const e=(new Date).getHours();return e>=5&&e<10?`God morgon, ${t}`:e>=10&&e<17?`Hej, ${t}`:e>=17&&e<22?`God kvall, ${t}`:`God natt, ${t}`}(t):t,i=this._headerConfig.weather_entity?this.getEntity(this._headerConfig.weather_entity):void 0,a=i?.state??"",r=i?.attributes.temperature??"",s=i?.attributes.temperature_unit??"°C",n={"clear-night":"mdi:weather-night",cloudy:"mdi:weather-cloudy",fog:"mdi:weather-fog",hail:"mdi:weather-hail",lightning:"mdi:weather-lightning","lightning-rainy":"mdi:weather-lightning-rainy",partlycloudy:"mdi:weather-partly-cloudy",pouring:"mdi:weather-pouring",rainy:"mdi:weather-rainy",snowy:"mdi:weather-snowy","snowy-rainy":"mdi:weather-snowy-rainy",sunny:"mdi:weather-sunny",windy:"mdi:weather-windy","windy-variant":"mdi:weather-windy-variant",exceptional:"mdi:alert-circle-outline"}[a]??"mdi:weather-cloudy";return V`
       <div class="glass header">
         <div class="top-row">
           <div class="home-icon">
@@ -222,7 +222,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
             ${i?V`
               <div class="weather">
                 <ha-icon .icon=${n}></ha-icon>
-                ${{"clear-night":"Klart",cloudy:"Molnigt",fog:"Dimma",partlycloudy:"Delvis molnigt",rainy:"Regn",snowy:"Sno",sunny:"Soligt",windy:"Blasigt"}[a]??a} \u2022 ${s}${r}
+                ${{"clear-night":"Klart",cloudy:"Molnigt",fog:"Dimma",partlycloudy:"Delvis molnigt",rainy:"Regn",snowy:"Sno",sunny:"Soligt",windy:"Blasigt"}[a]??a} \u2022 ${r}${s}
               </div>
             `:""}
           </div>
@@ -303,14 +303,14 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         --mdc-icon-size: 16px;
         display: flex;
       }
-    `],yt=t([dt("glass-header")],yt);let _t=class extends vt{get _roomConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.entity&&e.push(t.entity),t.sub_buttons&&t.sub_buttons.forEach(t=>e.push(t.entity)),this.setTrackedEntities(e)}_handleCardTap(){this._roomConfig.popup_id&&(window.location.hash=this._roomConfig.popup_id)}_handleSubButtonTap(t,e){t.stopPropagation(),this.toggle(e)}render(){if(!this.hass||!this._config)return V``;const t=this._roomConfig.sub_buttons??[],e=t.map(t=>t.entity);this._config.entity&&!e.includes(this._config.entity)&&e.unshift(this._config.entity);const i=e.some(t=>this.isOn(t)),a=function(t,e){const i=function(t,e){return e.filter(e=>"on"===t[e]?.state).length}(t,e);return 0===i?"Av":1===i?"Pa":`${i} lampor pa`}(this.hass.states,e),s=this._config.icon??"mdi:home",r=this._config.name??"";return V`
+    `],yt=t([dt("glass-header")],yt);let _t=class extends vt{get _roomConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.entity&&e.push(t.entity),t.sub_buttons&&t.sub_buttons.forEach(t=>e.push(t.entity)),this.setTrackedEntities(e)}_handleCardTap(){this._roomConfig.popup_id&&(window.location.hash=this._roomConfig.popup_id)}_handleSubButtonTap(t,e){t.stopPropagation(),this.toggle(e)}render(){if(!this.hass||!this._config)return V``;const t=this._roomConfig.sub_buttons??[],e=t.map(t=>t.entity);this._config.entity&&!e.includes(this._config.entity)&&e.unshift(this._config.entity);const i=e.some(t=>this.isOn(t)),a=function(t,e){const i=function(t,e){return e.filter(e=>"on"===t[e]?.state).length}(t,e);return 0===i?"Av":1===i?"Pa":`${i} lampor pa`}(this.hass.states,e),r=this._config.icon??"mdi:home",s=this._config.name??"";return V`
       <div class="glass room-card ${i?"active":""}" @click=${this._handleCardTap}>
         <div class="top">
           <div class="room-icon">
-            <ha-icon .icon=${s}></ha-icon>
+            <ha-icon .icon=${r}></ha-icon>
           </div>
           <div class="room-info">
-            <div class="room-name">${r}</div>
+            <div class="room-name">${s}</div>
             <div class="room-status">${a}</div>
           </div>
         </div>
@@ -405,7 +405,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--glass-text-dim);
       }
       .sub-btn.on ha-icon { color: var(--glass-accent); }
-    `],_t=t([dt("glass-room-card")],_t);let wt=class extends vt{constructor(){super(...arguments),this._dragging=!1,this._dragValue=0,this._stopEvent=t=>{t.stopPropagation()},this._toggleLight=t=>{t.stopPropagation(),this._config?.entity&&this.toggle(this._config.entity)}}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_handleSliderInteraction(t){if(!this._config.entity)return;const e=this.getEntity(this._config.entity);if(!e||"off"===e.state)return void this.callService("light","turn_on",{brightness_pct:100},this._config.entity);const i=t.currentTarget.getBoundingClientRect(),a=t=>{const e=Math.max(0,Math.min(t-i.left,i.width)),a=Math.round(e/i.width*100);this._dragValue=Math.max(1,Math.min(100,a))},s="touches"in t?t.touches[0].clientX:t.clientX;a(s),this._dragging=!0;const r=t=>{const e="touches"in t?t.touches[0].clientX:t.clientX;a(e)},n=()=>{this._dragging=!1,this.callService("light","turn_on",{brightness_pct:this._dragValue},this._config.entity),document.removeEventListener("mousemove",r),document.removeEventListener("mouseup",n),document.removeEventListener("touchmove",r),document.removeEventListener("touchend",n)};document.addEventListener("mousemove",r),document.addEventListener("mouseup",n),document.addEventListener("touchmove",r,{passive:!0}),document.addEventListener("touchend",n)}render(){if(!this.hass||!this._config?.entity)return V``;const t=this.getEntity(this._config.entity);if(!t)return V``;const e="on"===t.state,i=this._dragging?this._dragValue:function(t){if(!t||"on"!==t.state)return 0;const e=t.attributes.brightness;return e?Math.round(e/255*100):100}(t),a=this._config.name??t.attributes.friendly_name??"",s=this._config.icon??t.attributes.icon??"mdi:lightbulb";return V`
+    `],_t=t([dt("glass-room-card")],_t);let wt=class extends vt{constructor(){super(...arguments),this._dragging=!1,this._dragValue=0,this._stopEvent=t=>{t.stopPropagation()},this._toggleLight=t=>{t.stopPropagation(),this._config?.entity&&this.toggle(this._config.entity)}}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_handleSliderInteraction(t){if(!this._config.entity)return;const e=this.getEntity(this._config.entity);if(!e||"off"===e.state)return void this.callService("light","turn_on",{brightness_pct:100},this._config.entity);const i=t.currentTarget.getBoundingClientRect(),a=t=>{const e=Math.max(0,Math.min(t-i.left,i.width)),a=Math.round(e/i.width*100);this._dragValue=Math.max(1,Math.min(100,a))},r="touches"in t?t.touches[0].clientX:t.clientX;a(r),this._dragging=!0;const s=t=>{const e="touches"in t?t.touches[0].clientX:t.clientX;a(e)},n=()=>{this._dragging=!1,this.callService("light","turn_on",{brightness_pct:this._dragValue},this._config.entity),document.removeEventListener("mousemove",s),document.removeEventListener("mouseup",n),document.removeEventListener("touchmove",s),document.removeEventListener("touchend",n)};document.addEventListener("mousemove",s),document.addEventListener("mouseup",n),document.addEventListener("touchmove",s,{passive:!0}),document.addEventListener("touchend",n)}render(){if(!this.hass||!this._config?.entity)return V``;const t=this.getEntity(this._config.entity);if(!t)return V``;const e="on"===t.state,i=this._dragging?this._dragValue:function(t){if(!t||"on"!==t.state)return 0;const e=t.attributes.brightness;return e?Math.round(e/255*100):100}(t),a=this._config.name??t.attributes.friendly_name??"",r=this._config.icon??t.attributes.icon??"mdi:lightbulb";return V`
       <div class="glass slider-card ${e?"on":"off"}">
         <div class="slider-header">
           <div class="slider-left">
@@ -420,7 +420,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
               @click=${this._toggleLight}
             >
               <span class="light-icon">
-                <ha-icon .icon=${s}></ha-icon>
+                <ha-icon .icon=${r}></ha-icon>
               </span>
             </button>
             <span class="light-name">${a}</span>
@@ -762,7 +762,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       transition: color 0.25s ease;
     }
     .nav-item.active .nav-label { color: rgba(255, 255, 255, 0.85); }
-  `,t([gt({attribute:!1})],Ct.prototype,"hass",void 0),t([gt({attribute:!1})],Ct.prototype,"_config",void 0),t([bt()],Ct.prototype,"_activeHash",void 0),Ct=t([dt("glass-nav-bar")],Ct);let Et=class extends vt{get _vacuumConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_getStatusText(t){return{cleaning:"Stader",docked:"Dockad",paused:"Pausad",returning:"Atergar",idle:"Inaktiv",error:"Fel",unavailable:"Otillganglig"}[t]??t}_start(){this._config.entity&&this.callService("vacuum","start",void 0,this._config.entity)}_stop(){this._config.entity&&this.callService("vacuum","return_to_base",void 0,this._config.entity)}_cleanRoom(t){this._config.entity&&null!=t.room_id&&this.callService("vacuum","send_command",{command:"app_segment_clean",params:[t.room_id]},this._config.entity)}render(){if(!this.hass||!this._config?.entity)return V``;const t=this.getEntity(this._config.entity);if(!t)return V``;const e=t.state,i="cleaning"===e,a="error"===e,s=t.attributes.battery_level,r=this._config.name??t.attributes.friendly_name??"Vacuum",n=this._config.icon??"mdi:robot-vacuum";return V`
+  `,t([gt({attribute:!1})],Ct.prototype,"hass",void 0),t([gt({attribute:!1})],Ct.prototype,"_config",void 0),t([bt()],Ct.prototype,"_activeHash",void 0),Ct=t([dt("glass-nav-bar")],Ct);let Et=class extends vt{get _vacuumConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_getStatusText(t){return{cleaning:"Stader",docked:"Dockad",paused:"Pausad",returning:"Atergar",idle:"Inaktiv",error:"Fel",unavailable:"Otillganglig"}[t]??t}_start(){this._config.entity&&this.callService("vacuum","start",void 0,this._config.entity)}_stop(){this._config.entity&&this.callService("vacuum","return_to_base",void 0,this._config.entity)}_cleanRoom(t){this._config.entity&&null!=t.room_id&&this.callService("vacuum","send_command",{command:"app_segment_clean",params:[t.room_id]},this._config.entity)}render(){if(!this.hass||!this._config?.entity)return V``;const t=this.getEntity(this._config.entity);if(!t)return V``;const e=t.state,i="cleaning"===e,a="error"===e,r=t.attributes.battery_level,s=this._config.name??t.attributes.friendly_name??"Vacuum",n=this._config.icon??"mdi:robot-vacuum";return V`
       <div
         class="glass vacuum-card ${i?"cleaning":""} ${a?"error":""}"
       >
@@ -771,15 +771,15 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
             <ha-icon .icon=${n}></ha-icon>
           </div>
           <div class="vacuum-info">
-            <div class="vacuum-name">${r}</div>
+            <div class="vacuum-name">${s}</div>
             <div class="vacuum-status">${this._getStatusText(e)}</div>
           </div>
-          ${null!=s?V`
+          ${null!=r?V`
                 <div class="vacuum-battery">
                   <ha-icon
-                    icon="mdi:battery${s>80?"":s>60?"-80":s>40?"-60":s>20?"-40":"-20"}"
+                    icon="mdi:battery${r>80?"":r>60?"-80":r>40?"-60":r>20?"-40":"-20"}"
                   ></ha-icon>
-                  ${s}%
+                  ${r}%
                 </div>
               `:""}
         </div>
@@ -927,7 +927,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       .room-btn:active {
         transform: scale(0.96);
       }
-    `],Et=t([dt("glass-vacuum-card")],Et);let St=class extends vt{get _infoConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.entity&&e.push(t.entity),t.secondary_entity&&e.push(t.secondary_entity),t.badge_entity&&e.push(t.badge_entity),this.setTrackedEntities(e)}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=this._config.name??t?.attributes.friendly_name??"",i=this._config.icon??t?.attributes.icon??"mdi:information";let a=t?.state??"";const s=t?.attributes.unit_of_measurement;s&&(a=`${a} ${s}`);const r=this._infoConfig.badge_entity?this.getEntity(this._infoConfig.badge_entity):void 0;return V`
+    `],Et=t([dt("glass-vacuum-card")],Et);let St=class extends vt{get _infoConfig(){return this._config}setConfig(t){super.setConfig(t);const e=[];t.entity&&e.push(t.entity),t.secondary_entity&&e.push(t.secondary_entity),t.badge_entity&&e.push(t.badge_entity),this.setTrackedEntities(e)}render(){if(!this.hass||!this._config)return V``;const t=this._config.entity?this.getEntity(this._config.entity):void 0,e=this._config.name??t?.attributes.friendly_name??"",i=this._config.icon??t?.attributes.icon??"mdi:information";let a=t?.state??"";const r=t?.attributes.unit_of_measurement;r&&(a=`${a} ${r}`);const s=this._infoConfig.badge_entity?this.getEntity(this._infoConfig.badge_entity):void 0;return V`
       <div class="glass info-card">
         <div class="info-icon">
           <ha-icon .icon=${i}></ha-icon>
@@ -936,12 +936,12 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <div class="info-name">${e}</div>
           <div class="info-value">${a}</div>
         </div>
-        ${r?V`
+        ${s?V`
               <div class="badge">
                 ${this._infoConfig.badge_icon?V`<ha-icon
                       .icon=${this._infoConfig.badge_icon}
                     ></ha-icon>`:""}
-                ${r.state}
+                ${s.state}
               </div>
             `:""}
       </div>
@@ -1027,11 +1027,11 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       --mdc-icon-size: 14px;
       color: rgba(255, 255, 255, 0.25);
     }
-  `,t([gt({attribute:!1})],At.prototype,"_config",void 0),At=t([dt("glass-section")],At);let Mt=class extends vt{get _departureConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_getDepartures(){if(!this._config?.entity)return[];return this.getEntityAttribute(this._config.entity,"departures")??[]}_isDelayed(t){if(!t.scheduled||!t.expected)return!1;const e=new Date(t.scheduled).getTime();return new Date(t.expected).getTime()-e>6e4}_isSoon(t){const e=t.display?.toLowerCase()??"",i=e.match(/^(\d+)\s*min/);return i?parseInt(i[1],10)<=5:"nu"===e}_getTimeClass(t){return this._isDelayed(t)?"time delayed":this._isSoon(t)?"time soon":"time"}getCardSize(){return 3}render(){if(!this.hass||!this._config?.entity)return V``;const t=this._getDepartures(),e=this._departureConfig.max_departures??6,i=t.slice(0,e),a=this._departureConfig.station_name??this._departureConfig.name??(t.length>0?t[0].stop_area?.name:void 0)??"Avgångar",s=this._departureConfig.icon??"mdi:train";return V`
+  `,t([gt({attribute:!1})],At.prototype,"_config",void 0),At=t([dt("glass-section")],At);let Mt=class extends vt{get _departureConfig(){return this._config}setConfig(t){super.setConfig(t),t.entity&&this.setTrackedEntities([t.entity])}_getDepartures(){if(!this._config?.entity)return[];return this.getEntityAttribute(this._config.entity,"departures")??[]}_isDelayed(t){if(!t.scheduled||!t.expected)return!1;const e=new Date(t.scheduled).getTime();return new Date(t.expected).getTime()-e>6e4}_isSoon(t){const e=t.display?.toLowerCase()??"",i=e.match(/^(\d+)\s*min/);return i?parseInt(i[1],10)<=5:"nu"===e}_getTimeClass(t){return this._isDelayed(t)?"time delayed":this._isSoon(t)?"time soon":"time"}getCardSize(){return 3}render(){if(!this.hass||!this._config?.entity)return V``;const t=this._getDepartures(),e=this._departureConfig.max_departures??6,i=t.slice(0,e),a=this._departureConfig.station_name??this._departureConfig.name??(t.length>0?t[0].stop_area?.name:void 0)??"Avgångar",r=this._departureConfig.icon??"mdi:train";return V`
       <div class="glass departure-card">
         <div class="departure-header">
           <div class="departure-icon">
-            <ha-icon .icon=${s}></ha-icon>
+            <ha-icon .icon=${r}></ha-icon>
           </div>
           <div class="station-name">${a}</div>
         </div>
@@ -1305,6 +1305,14 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
   `),clock:Pt(X`
     <circle cx="12" cy="12" r="8.5"></circle>
     <path d="M12 7.5V12l3 2"></path>
+  `),calendar:Pt(X`
+    <rect x="4" y="5.5" width="16" height="14.5" rx="2"></rect>
+    <path d="M4 10h16"></path>
+    <path d="M8 3.5v3"></path>
+    <path d="M16 3.5v3"></path>
+    <path d="M8.5 14h2"></path>
+    <path d="M13.5 14h2"></path>
+    <path d="M8.5 17h2"></path>
   `),expand:Pt(X`
     <path d="M8 4H5a1 1 0 0 0-1 1v3"></path>
     <path d="M16 4h3a1 1 0 0 1 1 1v3"></path>
@@ -1315,10 +1323,10 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
     <path d="M20 8h-3a1 1 0 0 1-1-1V4"></path>
     <path d="M4 16h3a1 1 0 0 1 1 1v3"></path>
     <path d="M20 16h-3a1 1 0 0 1-1 1v3"></path>
-  `)},jt=new Intl.DateTimeFormat("sv-SE",{weekday:"long",day:"numeric",month:"long"});class Dt extends vt{constructor(){super(...arguments),this._now=new Date}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},3e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}get _timeStr(){return`${String(this._now.getHours()).padStart(2,"0")}:${String(this._now.getMinutes()).padStart(2,"0")}`}get _dateStr(){return function(t){return t.length?t.charAt(0).toUpperCase()+t.slice(1):t}(jt.format(this._now))}get _weatherStr(){const t=this.weatherEntity?this.getEntity(this.weatherEntity):void 0;if(!t||!this.hass)return"";const e=this.hass.formatEntityState(t),i=t.attributes.temperature;return[e,"number"==typeof i?`${Math.round(i)}°`:""].filter(Boolean).join(" ")}render(){const t=this._weatherStr;return V`
+  `)},Dt={frukost:"Frukost",lunch:"Lunch",middag:"Middag",mellis:"Mellis"},jt=["frukost","lunch","middag","mellis"],Ht={gymdag:"G",vilodag:"V",flexdag:"F"};const It=/^\d{4}-\d{2}-\d{2}$/;function Ot(t){if(!t||"object"!=typeof t)return null;const e=t;if("frukost"!==(i=e.slot)&&"lunch"!==i&&"middag"!==i&&"mellis"!==i||"string"!=typeof e.name||""===e.name)return null;var i;const a=t=>"number"==typeof t&&Number.isFinite(t)?t:0;return{slot:e.slot,name:e.name,kcal:a(e.kcal),protein:a(e.protein),fat:a(e.fat),carbs:a(e.carbs),logged:!0===e.logged}}function Rt(t){if(!t||"object"!=typeof t)return null;const e=t;if("string"!=typeof e.date||!It.test(e.date))return null;const i=Array.isArray(e.meals)?e.meals.map(Ot).filter(t=>null!==t):[];return{date:e.date,weekday:"string"==typeof e.weekday?e.weekday:"",day_type:"string"==typeof e.day_type?e.day_type:"vilodag",confirmed:!0===e.confirmed,meals:i,total_kcal:"number"==typeof e.total_kcal?e.total_kcal:0,target_kcal:"number"==typeof e.target_kcal?e.target_kcal:0,protein_ok:!0===e.protein_ok,kcal_ok:!1!==e.kcal_ok}}function Ut(t){if(!t)return null;const{week_start:e,today:i,days:a}=t;if("string"!=typeof e||!It.test(e))return null;if(!Array.isArray(a))return null;const r=a.map(Rt).filter(t=>null!==t);return 0===r.length?null:{weekStart:e,today:"string"==typeof i&&It.test(i)?i:e,confirmedDays:r.filter(t=>t.confirmed).length,days:r}}const Bt=new Intl.DateTimeFormat("sv-SE",{weekday:"long",day:"numeric",month:"long"});class Lt extends vt{constructor(){super(...arguments),this._now=new Date}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},3e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}get _timeStr(){return`${String(this._now.getHours()).padStart(2,"0")}:${String(this._now.getMinutes()).padStart(2,"0")}`}get _dateStr(){return function(t){return t.length?t.charAt(0).toUpperCase()+t.slice(1):t}(Bt.format(this._now))}get _weatherStr(){const t=this.weatherEntity?this.getEntity(this.weatherEntity):void 0;if(!t||!this.hass)return"";const e=this.hass.formatEntityState(t),i=t.attributes.temperature;return[e,"number"==typeof i?`${Math.round(i)}°`:""].filter(Boolean).join(" ")}render(){const t=this._weatherStr;return V`
       <div class="time">${this._timeStr}</div>
       <div class="date">${this._dateStr}${t?V` · ${t}`:""}</div>
-    `}}Dt.styles=[Tt,n`
+    `}}Lt.styles=[Tt,n`
       :host {
         display: block;
       }
@@ -1336,12 +1344,12 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-muted);
         font-family: var(--hub-font-body);
       }
-    `],t([gt({attribute:!1})],Dt.prototype,"weatherEntity",void 0),t([bt()],Dt.prototype,"_now",void 0),customElements.define("hub-clock",Dt);class Ht extends ct{constructor(){super(...arguments),this.icon="",this.label="",this.tone="neutral",this.active=!1}render(){const t=Ft[this.icon];return V`
+    `],t([gt({attribute:!1})],Lt.prototype,"weatherEntity",void 0),t([bt()],Lt.prototype,"_now",void 0),customElements.define("hub-clock",Lt);class Vt extends ct{constructor(){super(...arguments),this.icon="",this.label="",this.tone="neutral",this.active=!1}render(){const t=Ft[this.icon];return V`
       <span class="chip tone-${this.tone} ${this.active?"active":""}">
         ${t?V`<span class="icon">${t}</span>`:""}
         <span class="label">${this.label}</span>
       </span>
-    `}}Ht.styles=[Tt,n`
+    `}}Vt.styles=[Tt,n`
       :host {
         display: inline-flex;
       }
@@ -1397,7 +1405,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         border-color: var(--hub-chip-border);
         color: var(--hub-text-muted);
       }
-    `],t([gt({attribute:!1})],Ht.prototype,"icon",void 0),t([gt({attribute:!1})],Ht.prototype,"label",void 0),t([gt({attribute:!1})],Ht.prototype,"tone",void 0),t([gt({type:Boolean})],Ht.prototype,"active",void 0),customElements.define("hub-status-chip",Ht);class It extends vt{constructor(){super(...arguments),this._longPressed=!1,this._downX=0,this._downY=0,this._onPointerDown=t=>{this._longPressed=!1,this._downX=t.clientX,this._downY=t.clientY,this._pressTimer=window.setTimeout(()=>{this._longPressed=!0,this.toggle(this.room.main_entity)},500)},this._onPointerMove=t=>{void 0!==this._pressTimer&&(zt(t.clientX-this._downX)||zt(t.clientY-this._downY))&&this._cancelPress()},this._cancelPress=()=>{void 0!==this._pressTimer&&(clearTimeout(this._pressTimer),this._pressTimer=void 0)},this._onClick=()=>{this._longPressed?this._longPressed=!1:this.dispatchEvent(new CustomEvent("hub-room-open",{detail:{roomId:this.room.id},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this._cancelPress()}get _lightsOn(){return this.room.lights.filter(t=>this.isOn(t.entity)).length}get _brightnessPct(){const t=this.getEntityAttribute(this.room.main_entity,"brightness");return"number"==typeof t?Math.round(t/255*100):null}get _subtitle(){const t=this._lightsOn;if(0===t)return"Släckt";const e=1===t?"1 lampa":`${t} lampor`,i=this._brightnessPct;return null!==i?`${e} · ${i} %`:e}render(){if(!this.hass||!this.room)return V``;const t=this._lightsOn>0,e=Ft[this.room.icon];return V`
+    `],t([gt({attribute:!1})],Vt.prototype,"icon",void 0),t([gt({attribute:!1})],Vt.prototype,"label",void 0),t([gt({attribute:!1})],Vt.prototype,"tone",void 0),t([gt({type:Boolean})],Vt.prototype,"active",void 0),customElements.define("hub-status-chip",Vt);class Xt extends vt{constructor(){super(...arguments),this._longPressed=!1,this._downX=0,this._downY=0,this._onPointerDown=t=>{this._longPressed=!1,this._downX=t.clientX,this._downY=t.clientY,this._pressTimer=window.setTimeout(()=>{this._longPressed=!0,this.toggle(this.room.main_entity)},500)},this._onPointerMove=t=>{void 0!==this._pressTimer&&(zt(t.clientX-this._downX)||zt(t.clientY-this._downY))&&this._cancelPress()},this._cancelPress=()=>{void 0!==this._pressTimer&&(clearTimeout(this._pressTimer),this._pressTimer=void 0)},this._onClick=()=>{this._longPressed?this._longPressed=!1:this.dispatchEvent(new CustomEvent("hub-room-open",{detail:{roomId:this.room.id},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this._cancelPress()}get _lightsOn(){return this.room.lights.filter(t=>this.isOn(t.entity)).length}get _brightnessPct(){const t=this.getEntityAttribute(this.room.main_entity,"brightness");return"number"==typeof t?Math.round(t/255*100):null}get _subtitle(){const t=this._lightsOn;if(0===t)return"Släckt";const e=1===t?"1 lampa":`${t} lampor`,i=this._brightnessPct;return null!==i?`${e} · ${i} %`:e}render(){if(!this.hass||!this.room)return V``;const t=this._lightsOn>0,e=Ft[this.room.icon];return V`
       <div
         class="tile ${t?"active":""}"
         @pointerdown=${this._onPointerDown}
@@ -1413,7 +1421,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <small class="subtitle">${this._subtitle}</small>
         </div>
       </div>
-    `}}It.styles=[Tt,n`
+    `}}Xt.styles=[Tt,n`
       :host {
         display: block;
       }
@@ -1475,20 +1483,20 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       .tile.active .subtitle {
         color: var(--hub-amber-muted);
       }
-    `],t([gt({attribute:!1})],It.prototype,"room",void 0),customElements.define("hub-room-tile",It);const Ot=new Set(["off","unavailable","unknown","standby","idle"]);function Rt(t,e){for(const i of e){const e=t[i.entity];if(e&&"playing"===e.state)return{entity:e,name:i.name}}for(const i of e){const e=t[i.entity];if(e&&!Ot.has(e.state))return{entity:e,name:i.name}}return null}function Ut(t,e){if(!t)return 0;const i=t.attributes,a="number"==typeof i.media_duration?i.media_duration:0;if(a<=0)return 0;let s="number"==typeof i.media_position?i.media_position:0;const r="string"==typeof i.media_position_updated_at?Date.parse(i.media_position_updated_at):NaN;return"playing"!==t.state||Number.isNaN(r)||(s+=(e-r)/1e3),Math.max(0,Math.min(100,s/a*100))}class Bt extends vt{constructor(){super(...arguments),this.players=[],this._now=Date.now()}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=Date.now()},1e3)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_goto(){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"media"},bubbles:!0,composed:!0}))}_togglePlay(t,e){t.stopPropagation(),this.callService("media_player","media_play_pause",void 0,e)}render(){if(!this.hass)return V``;const t=Rt(this.hass.states,this.players??[]);if(!t)return V`
+    `],t([gt({attribute:!1})],Xt.prototype,"room",void 0),customElements.define("hub-room-tile",Xt);const qt=new Set(["off","unavailable","unknown","standby","idle"]);function Gt(t,e){for(const i of e){const e=t[i.entity];if(e&&"playing"===e.state)return{entity:e,name:i.name}}for(const i of e){const e=t[i.entity];if(e&&!qt.has(e.state))return{entity:e,name:i.name}}return null}function Wt(t,e){if(!t)return 0;const i=t.attributes,a="number"==typeof i.media_duration?i.media_duration:0;if(a<=0)return 0;let r="number"==typeof i.media_position?i.media_position:0;const s="string"==typeof i.media_position_updated_at?Date.parse(i.media_position_updated_at):NaN;return"playing"!==t.state||Number.isNaN(s)||(r+=(e-s)/1e3),Math.max(0,Math.min(100,r/a*100))}class Yt extends vt{constructor(){super(...arguments),this.players=[],this._now=Date.now()}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=Date.now()},1e3)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_goto(){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"media"},bubbles:!0,composed:!0}))}_togglePlay(t,e){t.stopPropagation(),this.callService("media_player","media_play_pause",void 0,e)}render(){if(!this.hass)return V``;const t=Gt(this.hass.states,this.players??[]);if(!t)return V`
         <div class="np idle" @click=${this._goto}>
           <span class="idle-ic">${Ft.note}</span>
           <b class="title dim">Ingenting spelas</b>
         </div>
-      `;const e=t.entity,i="playing"===e.state,a=e.attributes.media_title||t.name,s=e.attributes.media_artist||t.name,r=e.attributes.entity_picture,n=Ut(e,this._now);return V`
+      `;const e=t.entity,i="playing"===e.state,a=e.attributes.media_title||t.name,r=e.attributes.media_artist||t.name,s=e.attributes.entity_picture,n=Wt(e,this._now);return V`
       <div class="np ${i?"playing":""}" @click=${this._goto}>
         <div
           class="art"
-          style=${r?`background-image:url('${r}')`:""}
+          style=${s?`background-image:url('${s}')`:""}
         ></div>
         <div class="meta">
           <b class="title">${a}</b>
-          <small class="sub">${s}</small>
+          <small class="sub">${r}</small>
           <div class="bar"><div class="fill" style="width:${n}%"></div></div>
         </div>
         <button
@@ -1499,7 +1507,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <span class="ppic">${i?Ft.pause:Ft.play}</span>
         </button>
       </div>
-    `}}Bt.styles=[Tt,n`
+    `}}Yt.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -1620,25 +1628,25 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-dim);
         font-weight: 500;
       }
-    `],t([gt({attribute:!1})],Bt.prototype,"players",void 0),t([bt()],Bt.prototype,"_now",void 0),customElements.define("hub-now-playing",Bt);const Lt=new Intl.NumberFormat("sv-SE");function Vt(t,e){return e>0?Math.max(0,Math.min(100,t/e*100)):0}class Xt extends vt{_goto(){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"kcal"},bubbles:!0,composed:!0}))}render(){if(!this.hass)return V``;const t=this.todayEntity?this.getEntity(this.todayEntity):void 0,e=t?Number(t.state):NaN;if(!t||"unavailable"===t.state||"unknown"===t.state||Number.isNaN(e))return V`
+    `],t([gt({attribute:!1})],Yt.prototype,"players",void 0),t([bt()],Yt.prototype,"_now",void 0),customElements.define("hub-now-playing",Yt);const Kt=new Intl.NumberFormat("sv-SE");function Zt(t,e){return e>0?Math.max(0,Math.min(100,t/e*100)):0}class Qt extends vt{_goto(){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"kcal"},bubbles:!0,composed:!0}))}render(){if(!this.hass)return V``;const t=this.todayEntity?this.getEntity(this.todayEntity):void 0,e=t?Number(t.state):NaN;if(!t||"unavailable"===t.state||"unknown"===t.state||Number.isNaN(e))return V`
         <div class="kc offline" @click=${this._goto}>
           <div class="ring" style="--pct:0"></div>
           <div class="meta"><b class="val">Kcal · offline</b></div>
         </div>
-      `;const i="number"==typeof t.attributes.kcal_target?t.attributes.kcal_target:0,a=Vt(e,i),s=function(t){const e=t.protein_g;return"number"==typeof e?`${Math.round(e)} g protein`:""}(t.attributes);return V`
+      `;const i="number"==typeof t.attributes.kcal_target?t.attributes.kcal_target:0,a=Zt(e,i),r=function(t){const e=t.protein_g;return"number"==typeof e?`${Math.round(e)} g protein`:""}(t.attributes);return V`
       <div class="kc" @click=${this._goto}>
         <div class="ring" style="--pct:${a}"></div>
         <div class="meta">
           <b class="val">
-            ${Lt.format(Math.round(e))}
+            ${Kt.format(Math.round(e))}
             <span class="target">
-              ${i>0?`/ ${Lt.format(i)} kcal`:"kcal"}
+              ${i>0?`/ ${Kt.format(i)} kcal`:"kcal"}
             </span>
           </b>
-          ${s?V`<small class="sub">${s}</small>`:G}
+          ${r?V`<small class="sub">${r}</small>`:G}
         </div>
       </div>
-    `}}function qt(t){const e=Date.parse(t.expected??t.scheduled??"");return Number.isNaN(e)?Number.POSITIVE_INFINITY:e}Xt.styles=[Tt,n`
+    `}}function Jt(t){const e=Date.parse(t.expected??t.scheduled??"");return Number.isNaN(e)?Number.POSITIVE_INFINITY:e}Qt.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -1704,7 +1712,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         overflow: hidden;
         text-overflow: ellipsis;
       }
-    `],t([gt({attribute:!1})],Xt.prototype,"todayEntity",void 0),customElements.define("hub-kcal-ring",Xt);const Gt=new Set(["unavailable","unknown",""]);class Wt extends vt{_pendeltag(){const t=this.config.transit?.pendeltag;if(!t)return V`<span class="sub dim">–</span>`;const e=this.getEntity(t.next_entity),i=function(t){if(!t||Gt.has(t))return null;const e=new Date(t);return Number.isNaN(e.getTime())?null:`${String(e.getHours()).padStart(2,"0")}:${String(e.getMinutes()).padStart(2,"0")}`}(e?.state);if(!i)return V`<span class="sub dim">–</span>`;const a=this.getEntity(t.count_entity),s=a&&!Number.isNaN(Number(a.state))?Number(a.state):null;return V`<span class="sub">Nästa ${i}${null===s?"":` · ${s} ${1===s?"avgång":"avgångar"}`}</span>`}_bus(){const t=this.config.transit?.bus;if(!t)return V`<span class="sub dim">Inga avgångar idag</span>`;const e=this.getEntity(t.entity),i=function(t,e,i){if(!Array.isArray(t))return[];const a=i?new RegExp(i,"i"):null;return t.filter(t=>t?.line?.designation===e).filter(t=>!(a&&t.destination&&a.test(t.destination))).sort((t,e)=>qt(t)-qt(e))}(e?.attributes.departures??[],t.line,t.exclude_destination).slice(0,3);return 0===i.length?V`<span class="sub dim">Inga avgångar idag</span>`:V`<span class="sub"
+    `],t([gt({attribute:!1})],Qt.prototype,"todayEntity",void 0),customElements.define("hub-kcal-ring",Qt);const te=new Set(["unavailable","unknown",""]);class ee extends vt{_pendeltag(){const t=this.config.transit?.pendeltag;if(!t)return V`<span class="sub dim">–</span>`;const e=this.getEntity(t.next_entity),i=function(t){if(!t||te.has(t))return null;const e=new Date(t);return Number.isNaN(e.getTime())?null:`${String(e.getHours()).padStart(2,"0")}:${String(e.getMinutes()).padStart(2,"0")}`}(e?.state);if(!i)return V`<span class="sub dim">–</span>`;const a=this.getEntity(t.count_entity),r=a&&!Number.isNaN(Number(a.state))?Number(a.state):null;return V`<span class="sub">Nästa ${i}${null===r?"":` · ${r} ${1===r?"avgång":"avgångar"}`}</span>`}_bus(){const t=this.config.transit?.bus;if(!t)return V`<span class="sub dim">Inga avgångar idag</span>`;const e=this.getEntity(t.entity),i=function(t,e,i){if(!Array.isArray(t))return[];const a=i?new RegExp(i,"i"):null;return t.filter(t=>t?.line?.designation===e).filter(t=>!(a&&t.destination&&a.test(t.destination))).sort((t,e)=>Jt(t)-Jt(e))}(e?.attributes.departures??[],t.line,t.exclude_destination).slice(0,3);return 0===i.length?V`<span class="sub dim">Inga avgångar idag</span>`:V`<span class="sub"
       >${i.map((t,e)=>V`${e>0?V`<span class="sep">·</span>`:""}<span
             class="dep ${t.state&&"EXPECTED"!==t.state?"delayed":""}"
             >${t.display??"–"}</span
@@ -1726,7 +1734,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}}Wt.styles=[Tt,n`
+    `}}ee.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -1803,27 +1811,27 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-dim);
         margin: 0 6px;
       }
-    `],t([gt({attribute:!1})],Wt.prototype,"config",void 0),customElements.define("hub-transit-card",Wt);const Yt=36e5,Kt=new Set(["unavailable","unknown","none",""]);function Zt(t){if(!Array.isArray(t))return[];const e=[];for(const i of t){if(!i||"object"!=typeof i)continue;const t=i,a="number"==typeof t.total?t.total:Number(t.total);if(!Number.isFinite(a)||"string"!=typeof t.startsAt)continue;const s=new Date(t.startsAt);Number.isNaN(s.getTime())||e.push({start:s,ore:100*a})}return e.sort((t,e)=>t.start.getTime()-e.start.getTime())}function Qt(t){if(t.length<3)return null;let e=1/0,i=-1;for(let a=0;a+3<=t.length;a++){let s=!0,r=t[a].ore;for(let e=a+1;e<a+3;e++){if(t[e].start.getTime()-t[e-1].start.getTime()!==Yt){s=!1;break}r+=t[e].ore}s&&r<e&&(e=r,i=a)}return i<0?null:{start:t[i].start,end:new Date(t[i+3-1].start.getTime()+Yt)}}function Jt(t,e,i){if(Kt.has(String(e??"").toLowerCase()))return{now:null,level:"normal",today:[],tomorrow:[],cheapestWindow:null};const a=Zt(t?.today),s=Zt(t?.tomorrow);if(0===a.length&&0===s.length)return{now:null,level:"normal",today:[],tomorrow:[],cheapestWindow:null};const r=[...a,...s].sort((t,e)=>t.start.getTime()-e.start.getTime()),n=i.getTime(),o=r.find(t=>t.start.getTime()<=n&&n<t.start.getTime()+Yt)??null;let l="normal";if(o&&a.length){const t=a.reduce((t,e)=>t+e.ore,0)/a.length;if(t>0){const e=o.ore/t;e<.85?l="låg":e>1.15&&(l="hög")}}const c=r.filter(t=>t.start.getTime()+Yt>n);return{now:o,level:l,today:a,tomorrow:s,cheapestWindow:Qt(c)}}const te={"låg":"lågt",normal:"normalt","hög":"högt"};class ee extends vt{constructor(){super(...arguments),this._now=new Date,this._open=()=>{this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"energi"},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},6e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_model(){const t=this.config.price_series_entity?this.getEntity(this.config.price_series_entity):void 0;return t?Jt(t.attributes,t.state,this._now):null}_currentOre(t){if(t?.now)return Math.round(t.now.ore);const e=this.config.price_entity?this.getEntity(this.config.price_entity):void 0;return e&&!Number.isNaN(Number(e.state))?Math.round(100*Number(e.state)):null}_bars(t){const e=function(t,e){const i=[...t.today,...t.tomorrow].sort((t,e)=>t.start.getTime()-e.start.getTime()),a=e.getTime(),s=t.cheapestWindow,r=s?s.start.getTime():null,n=s?s.end.getTime():null;return i.filter(t=>t.start.getTime()+Yt>a).slice(0,12).map(t=>{const e=t.start.getTime();return{start:t.start,ore:t.ore,current:e<=a&&a<e+Yt,cheap:null!==r&&e>=r&&e<n}})}(t,this._now);if(0===e.length)return V`<div class="waiting">Väntar på prisdata</div>`;const i=e.map(t=>t.ore),a=Math.min(...i),s=Math.max(...i)-a;return V`<div class="bars">
+    `],t([gt({attribute:!1})],ee.prototype,"config",void 0),customElements.define("hub-transit-card",ee);const ie=36e5,ae=new Set(["unavailable","unknown","none",""]);function re(t){if(!Array.isArray(t))return[];const e=[];for(const i of t){if(!i||"object"!=typeof i)continue;const t=i,a="number"==typeof t.total?t.total:Number(t.total);if(!Number.isFinite(a)||"string"!=typeof t.startsAt)continue;const r=new Date(t.startsAt);Number.isNaN(r.getTime())||e.push({start:r,ore:100*a})}return e.sort((t,e)=>t.start.getTime()-e.start.getTime())}function se(t){if(t.length<3)return null;let e=1/0,i=-1;for(let a=0;a+3<=t.length;a++){let r=!0,s=t[a].ore;for(let e=a+1;e<a+3;e++){if(t[e].start.getTime()-t[e-1].start.getTime()!==ie){r=!1;break}s+=t[e].ore}r&&s<e&&(e=s,i=a)}return i<0?null:{start:t[i].start,end:new Date(t[i+3-1].start.getTime()+ie)}}function ne(t,e,i){if(ae.has(String(e??"").toLowerCase()))return{now:null,level:"normal",today:[],tomorrow:[],cheapestWindow:null};const a=re(t?.today),r=re(t?.tomorrow);if(0===a.length&&0===r.length)return{now:null,level:"normal",today:[],tomorrow:[],cheapestWindow:null};const s=[...a,...r].sort((t,e)=>t.start.getTime()-e.start.getTime()),n=i.getTime(),o=s.find(t=>t.start.getTime()<=n&&n<t.start.getTime()+ie)??null;let l="normal";if(o&&a.length){const t=a.reduce((t,e)=>t+e.ore,0)/a.length;if(t>0){const e=o.ore/t;e<.85?l="låg":e>1.15&&(l="hög")}}const c=s.filter(t=>t.start.getTime()+ie>n);return{now:o,level:l,today:a,tomorrow:r,cheapestWindow:se(c)}}const oe={"låg":"lågt",normal:"normalt","hög":"högt"};class le extends vt{constructor(){super(...arguments),this._now=new Date,this._open=()=>{this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:"energi"},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},6e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_model(){const t=this.config.price_series_entity?this.getEntity(this.config.price_series_entity):void 0;return t?ne(t.attributes,t.state,this._now):null}_currentOre(t){if(t?.now)return Math.round(t.now.ore);const e=this.config.price_entity?this.getEntity(this.config.price_entity):void 0;return e&&!Number.isNaN(Number(e.state))?Math.round(100*Number(e.state)):null}_bars(t){const e=function(t,e){const i=[...t.today,...t.tomorrow].sort((t,e)=>t.start.getTime()-e.start.getTime()),a=e.getTime(),r=t.cheapestWindow,s=r?r.start.getTime():null,n=r?r.end.getTime():null;return i.filter(t=>t.start.getTime()+ie>a).slice(0,12).map(t=>{const e=t.start.getTime();return{start:t.start,ore:t.ore,current:e<=a&&a<e+ie,cheap:null!==s&&e>=s&&e<n}})}(t,this._now);if(0===e.length)return V`<div class="waiting">Väntar på prisdata</div>`;const i=e.map(t=>t.ore),a=Math.min(...i),r=Math.max(...i)-a;return V`<div class="bars">
       ${e.map(t=>{return V`<div
           class="bar ${t.current?"current":t.cheap?"cheap":""}"
-          style="height:${(e=t.ore,s>0?100*(.2+(e-a)/s*.8):60).toFixed(1)}%"
+          style="height:${(e=t.ore,r>0?100*(.2+(e-a)/r*.8):60).toFixed(1)}%"
         ></div>`;var e})}
-    </div>`}render(){if(!this.hass||!this.config)return V``;const t=this._model(),e=this._currentOre(t),i=!!t&&t.today.length>0,a=t?.now?t.level:"normal",s="låg"===a?"low":"hög"===a?"high":"",r=i&&!!t?.now&&"normal"!==a,n=t?.cheapestWindow,o=n?V`<span class="hint"
+    </div>`}render(){if(!this.hass||!this.config)return V``;const t=this._model(),e=this._currentOre(t),i=!!t&&t.today.length>0,a=t?.now?t.level:"normal",r="låg"===a?"low":"hög"===a?"high":"",s=i&&!!t?.now&&"normal"!==a,n=t?.cheapestWindow,o=n?V`<span class="hint"
           ><span class="ic">${Ft.clock}</span>Billigast ${n.start.getHours()}–${n.end.getHours()}</span
         >`:G;return V`
-      <button class="card" aria-label=${null===e?"Elpris, öppna energisidan":`Elpris ${e} öre just nu${r?`, ${te[a]}`:""}, öppna energisidan`} @click=${this._open}>
+      <button class="card" aria-label=${null===e?"Elpris, öppna energisidan":`Elpris ${e} öre just nu${s?`, ${oe[a]}`:""}, öppna energisidan`} @click=${this._open}>
         <div class="head">
           <div class="lead">
             <span class="ic">${Ft.bolt}</span>
-            <span class="num ${s}">${null===e?"—":e}</span>
+            <span class="num ${r}">${null===e?"—":e}</span>
             <span class="unit">öre</span>
-            ${r?V`<span class="level ${s}">· ${te[a]}</span>`:G}
+            ${s?V`<span class="level ${r}">· ${oe[a]}</span>`:G}
           </div>
           ${o}
         </div>
         ${i?this._bars(t):V`<div class="waiting">Väntar på prisdata</div>`}
       </button>
-    `}}ee.styles=[Tt,n`
+    `}}le.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -1948,17 +1956,19 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-dim);
         letter-spacing: 0.01em;
       }
-    `],t([gt({attribute:!1})],ee.prototype,"config",void 0),t([bt()],ee.prototype,"_now",void 0),customElements.define("hub-energy-strip",ee);const ie={cleaning:"Städar",returning:"Åker hem",paused:"Pausad",error:"Fel",idle:"Väntar"};class ae extends vt{get _chips(){const t=this.config,e=[],i=t.lights_count_entity?this.getEntity(t.lights_count_entity):void 0,a=i&&!Number.isNaN(Number(i.state))?Number(i.state):null;if(e.push({icon:"lamp",label:null===a?"—":`${a} ${1===a?"lampa":"lampor"}`,tone:"amber",active:(a??0)>0}),t.vacuum_entity){const i=this.getEntity(t.vacuum_entity);i&&"docked"!==i.state&&"unavailable"!==i.state&&"unknown"!==i.state&&e.push({icon:"vacuum",label:ie[i.state]??"Städar",tone:"error"===i.state?"coral":"neutral",active:!0})}if(t.person_entity){const i=this.getEntity(t.person_entity),a=(i?.attributes.friendly_name||"Philip").split(" ")[0],s="home"===i?.state;e.push({icon:"home",label:`${a} ${s?"hemma":"borta"}`,tone:"neutral",active:!1})}return e}render(){if(!this.hass||!this.config)return V``;const t=this.config;return V`
+    `],t([gt({attribute:!1})],le.prototype,"config",void 0),t([bt()],le.prototype,"_now",void 0),customElements.define("hub-energy-strip",le);const ce={cleaning:"Städar",returning:"Åker hem",paused:"Pausad",error:"Fel",idle:"Väntar"};class he extends vt{_gotoPage(t){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:t},bubbles:!0,composed:!0}))}get _chips(){const t=this.config,e=[],i=t.lights_count_entity?this.getEntity(t.lights_count_entity):void 0,a=i&&!Number.isNaN(Number(i.state))?Number(i.state):null;if(e.push({icon:"lamp",label:null===a?"—":`${a} ${1===a?"lampa":"lampor"}`,tone:"amber",active:(a??0)>0}),t.vacuum_entity){const i=this.getEntity(t.vacuum_entity);i&&"docked"!==i.state&&"unavailable"!==i.state&&"unknown"!==i.state&&e.push({icon:"vacuum",label:ce[i.state]??"Städar",tone:"error"===i.state?"coral":"neutral",active:!0})}if(t.kcal?.planner_entity){const i=this.getEntity(t.kcal.planner_entity),a=i&&"unavailable"!==i.state&&"unknown"!==i.state?Ut(i.attributes):null,r=a?function(t){const e=t.days.find(e=>e.date===t.today);if(!e)return null;for(const t of jt){const i=e.meals.find(e=>e.slot===t&&!e.logged);if(i)return{day:e,meal:i}}return null}(a):null;r&&e.push({icon:"calendar",label:`${Dt[r.meal.slot]} · ${r.meal.name}`,tone:"lavender",active:!0,goto:"vecka"})}if(t.person_entity){const i=this.getEntity(t.person_entity),a=(i?.attributes.friendly_name||"Philip").split(" ")[0],r="home"===i?.state;e.push({icon:"home",label:`${a} ${r?"hemma":"borta"}`,tone:"neutral",active:!1})}return e}render(){if(!this.hass||!this.config)return V``;const t=this.config;return V`
       <div class="page">
         <div class="top">
           <hub-clock .hass=${this.hass} .weatherEntity=${t.weather_entity}></hub-clock>
           <div class="chips">
             ${this._chips.map(t=>V`
                 <hub-status-chip
+                  style=${t.goto?"cursor:pointer":""}
                   .icon=${t.icon}
                   .label=${t.label}
                   .tone=${t.tone}
                   ?active=${t.active}
+                  @click=${t.goto?()=>this._gotoPage(t.goto):G}
                 ></hub-status-chip>
               `)}
           </div>
@@ -1986,7 +1996,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           ></hub-kcal-ring>
         </div>
       </div>
-    `}}ae.styles=[Tt,n`
+    `}}he.styles=[Tt,n`
       /* Host is a flex column that fills the page section but may grow past it:
          when the wall is too short for everything, the section (its own
          overflow-y:auto) scrolls instead of anything overlapping. */
@@ -2087,7 +2097,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           flex: 1;
         }
       }
-    `],t([gt({attribute:!1})],ae.prototype,"config",void 0),customElements.define("hub-home-page",ae);const se=new Set(["unavailable","unknown"]);function re(t){return!!t&&!se.has(t.state)}class ne extends vt{constructor(){super(...arguments),this._armed=!1,this._flash=!1,this._onAllOff=()=>{if(!this._armed)return this._armed=!0,void 0!==this._armTimer&&clearTimeout(this._armTimer),void(this._armTimer=window.setTimeout(()=>{this._armed=!1,this._armTimer=void 0},3e3));void 0!==this._armTimer&&clearTimeout(this._armTimer),this._armTimer=void 0,this._armed=!1,this._flash=!0,this.callService("light","turn_off",void 0,"all"),void 0!==this._flashTimer&&clearTimeout(this._flashTimer),this._flashTimer=window.setTimeout(()=>{this._flash=!1,this._flashTimer=void 0},200)}}disconnectedCallback(){super.disconnectedCallback(),this._clearTimers()}_clearTimers(){void 0!==this._armTimer&&clearTimeout(this._armTimer),void 0!==this._flashTimer&&clearTimeout(this._flashTimer),this._armTimer=void 0,this._flashTimer=void 0,this._armed=!1,this._flash=!1}_activateScene(t){this.callService("scene","turn_on",void 0,t)}_lightRow(t){return re(this.hass.states[t.entity])?V`
+    `],t([gt({attribute:!1})],he.prototype,"config",void 0),customElements.define("hub-home-page",he);const de=new Set(["unavailable","unknown"]);function pe(t){return!!t&&!de.has(t.state)}class ue extends vt{constructor(){super(...arguments),this._armed=!1,this._flash=!1,this._onAllOff=()=>{if(!this._armed)return this._armed=!0,void 0!==this._armTimer&&clearTimeout(this._armTimer),void(this._armTimer=window.setTimeout(()=>{this._armed=!1,this._armTimer=void 0},3e3));void 0!==this._armTimer&&clearTimeout(this._armTimer),this._armTimer=void 0,this._armed=!1,this._flash=!0,this.callService("light","turn_off",void 0,"all"),void 0!==this._flashTimer&&clearTimeout(this._flashTimer),this._flashTimer=window.setTimeout(()=>{this._flash=!1,this._flashTimer=void 0},200)}}disconnectedCallback(){super.disconnectedCallback(),this._clearTimers()}_clearTimers(){void 0!==this._armTimer&&clearTimeout(this._armTimer),void 0!==this._flashTimer&&clearTimeout(this._flashTimer),this._armTimer=void 0,this._flashTimer=void 0,this._armed=!1,this._flash=!1}_activateScene(t){this.callService("scene","turn_on",void 0,t)}_lightRow(t){return pe(this.hass.states[t.entity])?V`
       <glass-light-slider
         .hass=${this.hass}
         ._config=${{type:"glass-light-slider",entity:t.entity,name:t.name}}
@@ -2101,7 +2111,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       <button class="scene-chip" @click=${()=>this._activateScene(t.entity)}>
         ${t.name}
       </button>
-    `}_roomCard(t){const e=function(t,e){const i=t.lights.filter(t=>"on"===e[t.entity]?.state),a=i.length;if(0===a)return{onCount:0,pct:null,label:"Släckt"};const s=i.map(t=>e[t.entity]?.attributes.brightness).filter(t=>"number"==typeof t),r=s.length?Math.round(s.reduce((t,e)=>t+e,0)/s.length/255*100):null,n=1===a?"1 lampa":`${a} lampor`;return{onCount:a,pct:r,label:null!==r?`${n} · ${r} %`:n}}(t,this.hass.states),i=e.onCount>0,a=Ft[t.icon];return V`
+    `}_roomCard(t){const e=function(t,e){const i=t.lights.filter(t=>"on"===e[t.entity]?.state),a=i.length;if(0===a)return{onCount:0,pct:null,label:"Släckt"};const r=i.map(t=>e[t.entity]?.attributes.brightness).filter(t=>"number"==typeof t),s=r.length?Math.round(r.reduce((t,e)=>t+e,0)/r.length/255*100):null,n=1===a?"1 lampa":`${a} lampor`;return{onCount:a,pct:s,label:null!==s?`${n} · ${s} %`:n}}(t,this.hass.states),i=e.onCount>0,a=Ft[t.icon];return V`
       <div class="room ${i?"active":""}">
         <div class="room-head">
           <span class="room-ic">${a??""}</span>
@@ -2113,7 +2123,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         <div class="lights">${t.lights.map(t=>this._lightRow(t))}</div>
         ${t.scenes?.length?V`<div class="scenes">${t.scenes.map(t=>this._sceneChip(t))}</div>`:G}
       </div>
-    `}render(){if(!this.hass||!this.config)return V``;const t=this.config,e=function(t,e){let i=0,a=0;for(const s of t.rooms??[])for(const t of s.lights){const s=e[t.entity];re(s)&&(a+=1,"on"===s.state&&(i+=1))}return{on:i,total:a}}(t,this.hass.states);return V`
+    `}render(){if(!this.hass||!this.config)return V``;const t=this.config,e=function(t,e){let i=0,a=0;for(const r of t.rooms??[])for(const t of r.lights){const r=e[t.entity];pe(r)&&(a+=1,"on"===r.state&&(i+=1))}return{on:i,total:a}}(t,this.hass.states);return V`
       <div class="page">
         <div class="header">
           <div class="heading">
@@ -2149,7 +2159,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}}ne.styles=[Tt,n`
+    `}}ue.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -2376,15 +2386,15 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         border-color: var(--hub-amber-border);
         color: var(--hub-amber-text);
       }
-    `],t([gt({attribute:!1})],ne.prototype,"config",void 0),t([bt()],ne.prototype,"_armed",void 0),t([bt()],ne.prototype,"_flash",void 0),customElements.define("hub-lights-page",ne);class oe extends ct{_slots(){const t=this.model,e=t?.today??[],i=t?.tomorrow??[],a=t?.now?t.now.start.getTime():null,s=t?.cheapestWindow,r=s?s.start.getTime():null,n=s?s.end.getTime():null,o=t=>{const e=t.start.getTime();let i="future",s=null;return null!==a&&(e<a?i="past":e===a&&(i="current",s=String(Math.round(t.ore)))),null!==r&&e>=r&&e<n&&(i+=" cheap"),{kind:"bar",hour:t,cls:i,label:s}},l=e.map(o);if(i.length){l.push({kind:"divider"});for(const t of i)l.push(o(t))}return l}_bounds(){const t=[...this.model?.today??[],...this.model?.tomorrow??[]].map(t=>t.ore);return{min:Math.min(...t),max:Math.max(...t)}}_height(t,e,i){const a=i-e;return!Number.isFinite(a)||a<=0?60:100*(.14+(t-e)/a*.86)}_tint(t,e,i){const a=i-e,s=a>0?(i-t)/a:.5;return`color-mix(in srgb, var(--hub-green) ${Math.round(22+58*s)}%, var(--hub-track))`}_tick(t){const e=t.start.getHours();return V`<span class="tick ${0===e?"day":""}"
+    `],t([gt({attribute:!1})],ue.prototype,"config",void 0),t([bt()],ue.prototype,"_armed",void 0),t([bt()],ue.prototype,"_flash",void 0),customElements.define("hub-lights-page",ue);class ge extends ct{_slots(){const t=this.model,e=t?.today??[],i=t?.tomorrow??[],a=t?.now?t.now.start.getTime():null,r=t?.cheapestWindow,s=r?r.start.getTime():null,n=r?r.end.getTime():null,o=t=>{const e=t.start.getTime();let i="future",r=null;return null!==a&&(e<a?i="past":e===a&&(i="current",r=String(Math.round(t.ore)))),null!==s&&e>=s&&e<n&&(i+=" cheap"),{kind:"bar",hour:t,cls:i,label:r}},l=e.map(o);if(i.length){l.push({kind:"divider"});for(const t of i)l.push(o(t))}return l}_bounds(){const t=[...this.model?.today??[],...this.model?.tomorrow??[]].map(t=>t.ore);return{min:Math.min(...t),max:Math.max(...t)}}_height(t,e,i){const a=i-e;return!Number.isFinite(a)||a<=0?60:100*(.14+(t-e)/a*.86)}_tint(t,e,i){const a=i-e,r=a>0?(i-t)/a:.5;return`color-mix(in srgb, var(--hub-green) ${Math.round(22+58*r)}%, var(--hub-track))`}_tick(t){const e=t.start.getHours();return V`<span class="tick ${0===e?"day":""}"
       >${e%6==0?String(e).padStart(2,"0"):""}</span
     >`}render(){if(!this.model||0===this.model.today.length)return V``;const t=this._slots(),{min:e,max:i}=this._bounds(),a=t.map(t=>"divider"===t.kind?"8px":"minmax(0, 1fr)").join(" ");return V`
       <div class="chart">
         <div class="plot" style="grid-template-columns:${a}">
-          ${t.map(t=>{if("divider"===t.kind)return V`<div class="divider"></div>`;const a=this._height(t.hour.ore,e,i),s=t.cls.startsWith("future")?`background:${this._tint(t.hour.ore,e,i)}`:"";return V`
+          ${t.map(t=>{if("divider"===t.kind)return V`<div class="divider"></div>`;const a=this._height(t.hour.ore,e,i),r=t.cls.startsWith("future")?`background:${this._tint(t.hour.ore,e,i)}`:"";return V`
               <div class="cell ${t.cls}" style="--bar-h:${a}%">
                 ${t.label?V`<span class="cell-label">${t.label}</span>`:G}
-                <div class="bar" style="height:${a}%;${s}"></div>
+                <div class="bar" style="height:${a}%;${r}"></div>
               </div>
             `})}
         </div>
@@ -2392,7 +2402,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           ${t.map(t=>"divider"===t.kind?V`<span></span>`:this._tick(t.hour))}
         </div>
       </div>
-    `}}oe.styles=[Tt,n`
+    `}}ge.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -2469,7 +2479,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-muted);
         font-weight: 600;
       }
-    `],t([gt({attribute:!1})],oe.prototype,"model",void 0),customElements.define("hub-price-chart",oe);const le={"låg":"lågt",normal:"normalt","hög":"högt"};class ce extends vt{constructor(){super(...arguments),this._now=new Date}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},6e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_model(){const t=this.config.price_series_entity?this.getEntity(this.config.price_series_entity):void 0;return t?Jt(t.attributes,t.state,this._now):null}_currentOre(t){if(t?.now)return Math.round(t.now.ore);const e=this.config.price_entity?this.getEntity(this.config.price_entity):void 0;return e&&!Number.isNaN(Number(e.state))?Math.round(100*Number(e.state)):null}_chips(t){const e=this.config,i=[],a=e.co2_entity?this.getEntity(e.co2_entity):void 0;a&&!Number.isNaN(Number(a.state))&&i.push({icon:"leaf",label:`${Math.round(Number(a.state))} g CO₂`,tone:"green"});const s=e.fossil_entity?this.getEntity(e.fossil_entity):void 0;if(s&&!Number.isNaN(Number(s.state))){const t=Math.round(Number(s.state));i.push({icon:"leaf",label:`${t} % fossilt`,tone:t>=40?"coral":"green"})}const r=t?.cheapestWindow;if(r){const t=r.start.getHours(),e=r.end.getHours();i.push({icon:"clock",label:`Billigast ${t}–${e}`,tone:"green"})}return i}render(){if(!this.hass||!this.config)return V``;const t=this._model(),e=this._currentOre(t),i=t?.now?t.level:"normal",a=!!t&&t.today.length>0,s=this._chips(t);return V`
+    `],t([gt({attribute:!1})],ge.prototype,"model",void 0),customElements.define("hub-price-chart",ge);const be={"låg":"lågt",normal:"normalt","hög":"högt"};class me extends vt{constructor(){super(...arguments),this._now=new Date}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=new Date},6e4)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}_model(){const t=this.config.price_series_entity?this.getEntity(this.config.price_series_entity):void 0;return t?ne(t.attributes,t.state,this._now):null}_currentOre(t){if(t?.now)return Math.round(t.now.ore);const e=this.config.price_entity?this.getEntity(this.config.price_entity):void 0;return e&&!Number.isNaN(Number(e.state))?Math.round(100*Number(e.state)):null}_chips(t){const e=this.config,i=[],a=e.co2_entity?this.getEntity(e.co2_entity):void 0;a&&!Number.isNaN(Number(a.state))&&i.push({icon:"leaf",label:`${Math.round(Number(a.state))} g CO₂`,tone:"green"});const r=e.fossil_entity?this.getEntity(e.fossil_entity):void 0;if(r&&!Number.isNaN(Number(r.state))){const t=Math.round(Number(r.state));i.push({icon:"leaf",label:`${t} % fossilt`,tone:t>=40?"coral":"green"})}const s=t?.cheapestWindow;if(s){const t=s.start.getHours(),e=s.end.getHours();i.push({icon:"clock",label:`Billigast ${t}–${e}`,tone:"green"})}return i}render(){if(!this.hass||!this.config)return V``;const t=this._model(),e=this._currentOre(t),i=t?.now?t.level:"normal",a=!!t&&t.today.length>0,r=this._chips(t);return V`
       <div class="page">
         <div class="header">
           <div class="price">
@@ -2479,7 +2489,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <div class="subline">
             just nu${!!t?.now&&"normal"!==i?V` ·
                   <span class=${"låg"===i?"accent-low":"accent-high"}
-                    >${le[i]}</span
+                    >${be[i]}</span
                   >`:G}
           </div>
         </div>
@@ -2489,7 +2499,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         </div>
 
         <div class="chips">
-          ${s.map(t=>V`
+          ${r.map(t=>V`
               <hub-status-chip
                 .icon=${t.icon}
                 .label=${t.label}
@@ -2499,7 +2509,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
             `)}
         </div>
       </div>
-    `}}async function he(t){if(!t)return null;try{const i=await(e=t,new Promise((t,i)=>{const a=new Image;a.crossOrigin="anonymous",a.onload=()=>t(a),a.onerror=()=>i(new Error("image load failed")),a.src=e})),a=document.createElement("canvas");a.width=8,a.height=8;const s=a.getContext("2d");if(!s)return null;s.drawImage(i,0,0,8,8);const{data:r}=s.getImageData(0,0,8,8);let n=0,o=0,l=0,c=0;for(let t=0;t<r.length;t+=4){0!==r[t+3]&&(n+=r[t],o+=r[t+1],l+=r[t+2],c+=1)}return 0===c?null:[Math.round(n/c),Math.round(o/c),Math.round(l/c)]}catch{return null}var e}ce.styles=[Tt,n`
+    `}}async function ve(t){if(!t)return null;try{const i=await(e=t,new Promise((t,i)=>{const a=new Image;a.crossOrigin="anonymous",a.onload=()=>t(a),a.onerror=()=>i(new Error("image load failed")),a.src=e})),a=document.createElement("canvas");a.width=8,a.height=8;const r=a.getContext("2d");if(!r)return null;r.drawImage(i,0,0,8,8);const{data:s}=r.getImageData(0,0,8,8);let n=0,o=0,l=0,c=0;for(let t=0;t<s.length;t+=4){0!==s[t+3]&&(n+=s[t],o+=s[t+1],l+=s[t+2],c+=1)}return 0===c?null:[Math.round(n/c),Math.round(o/c),Math.round(l/c)]}catch{return null}var e}me.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -2578,8 +2588,8 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         gap: 8px;
         padding-bottom: 44px; /* clear the page dots */
       }
-    `],t([gt({attribute:!1})],ce.prototype,"config",void 0),t([bt()],ce.prototype,"_now",void 0),customElements.define("hub-energy-page",ce);const de=new Set(["unavailable","unknown"]);class pe extends vt{constructor(){super(...arguments),this.groupMaster=null,this._drag=null}_entity(){return this.hass?.states[this.player.entity]}_volume(){if(null!==this._drag)return this._drag;const t=this._entity()?.attributes.volume_level;return"number"==typeof t?t:0}_onInput(t){this._drag=Number(t.target.value)}_onChange(t){const e=Number(t.target.value);this._drag=null,this.callService("media_player","volume_set",{volume_level:e},this.player.entity)}_stop(t){t.stopPropagation()}_toggleGroup(t){this.groupMaster&&(t?this.callService("media_player","unjoin",void 0,this.player.entity):this.callService("media_player","join",{group_members:[this.player.entity]},this.groupMaster))}render(){if(!this.hass||!this.player)return V``;const t=this._entity(),e=!t||de.has(t.state),i=this._volume(),a=Math.round(100*i),s=!e&&i>0,r=this.player.entity===this.groupMaster,n=!r&&!!this.groupMaster&&(o=this.hass.states[this.groupMaster]?.attributes.group_members,l=this.player.entity,Array.isArray(o)&&o.includes(l));var o,l;const c=`linear-gradient(90deg, var(--hub-teal) 0 ${a}%, var(--hub-track) ${a}% 100%)`;return V`
-      <div class="row ${s?"active":""}">
+    `],t([gt({attribute:!1})],me.prototype,"config",void 0),t([bt()],me.prototype,"_now",void 0),customElements.define("hub-energy-page",me);const fe=new Set(["unavailable","unknown"]);class xe extends vt{constructor(){super(...arguments),this.groupMaster=null,this._drag=null}_entity(){return this.hass?.states[this.player.entity]}_volume(){if(null!==this._drag)return this._drag;const t=this._entity()?.attributes.volume_level;return"number"==typeof t?t:0}_onInput(t){this._drag=Number(t.target.value)}_onChange(t){const e=Number(t.target.value);this._drag=null,this.callService("media_player","volume_set",{volume_level:e},this.player.entity)}_stop(t){t.stopPropagation()}_toggleGroup(t){this.groupMaster&&(t?this.callService("media_player","unjoin",void 0,this.player.entity):this.callService("media_player","join",{group_members:[this.player.entity]},this.groupMaster))}render(){if(!this.hass||!this.player)return V``;const t=this._entity(),e=!t||fe.has(t.state),i=this._volume(),a=Math.round(100*i),r=!e&&i>0,s=this.player.entity===this.groupMaster,n=!s&&!!this.groupMaster&&(o=this.hass.states[this.groupMaster]?.attributes.group_members,l=this.player.entity,Array.isArray(o)&&o.includes(l));var o,l;const c=`linear-gradient(90deg, var(--hub-teal) 0 ${a}%, var(--hub-track) ${a}% 100%)`;return V`
+      <div class="row ${r?"active":""}">
         <span class="ic">${Ft.speaker}</span>
         <div class="main">
           <div class="top">
@@ -2605,7 +2615,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
                 />
               `}
         </div>
-        ${e||r?G:V`
+        ${e||s?G:V`
               <button
                 class="chip ${n?"on":""}"
                 @click=${()=>this._toggleGroup(n)}
@@ -2614,7 +2624,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
               </button>
             `}
       </div>
-    `}}pe.styles=[Tt,n`
+    `}}xe.styles=[Tt,n`
       :host {
         display: block;
       }
@@ -2761,19 +2771,19 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         font: 500 12.5px var(--hub-font-body);
         margin-left: auto;
       }
-    `],t([gt({attribute:!1})],pe.prototype,"player",void 0),t([gt({attribute:!1})],pe.prototype,"groupMaster",void 0),t([bt()],pe.prototype,"_drag",void 0),customElements.define("hub-volume-row",pe);const ue=new Set(["off","unavailable","unknown","standby","idle"]);function ge(t){const e=Number.isFinite(t)&&t>0?t:0,i=Math.floor(e/60),a=Math.floor(e%60);return`${i}:${String(a).padStart(2,"0")}`}class be extends vt{constructor(){super(...arguments),this._sel=null,this._rgb=null,this._now=Date.now()}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=Date.now()},1e3)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}get _players(){return this.config?.media_players??[]}_selId(){if(this._sel)return this._sel;const t=Rt(this.hass?.states??{},this._players);return t?.entity.entity_id??this._players[0]?.entity??null}_theme(){const t=this.getRootNode()?.host;return"dag"===t?.getAttribute("data-theme")?"dag":"natt"}updated(t){const e=this._selId(),i=e?this.hass?.states[e]?.attributes.entity_picture:void 0;i!==this._pic&&(this._pic=i,i?he(i).then(t=>{this._pic===i&&(this._rgb=t)}):this._rgb=null)}_transport(t,e){this.callService("media_player",t,void 0,e)}_hero(t,e){const i="playing"===t.state,a=t.attributes.media_title||e,s=t.attributes.media_artist||e,r=t.attributes.entity_picture,n="number"==typeof t.attributes.media_duration?t.attributes.media_duration:0,o=Ut(t,this._now),l=o/100*n,c=t.entity_id;return V`
+    `],t([gt({attribute:!1})],xe.prototype,"player",void 0),t([gt({attribute:!1})],xe.prototype,"groupMaster",void 0),t([bt()],xe.prototype,"_drag",void 0),customElements.define("hub-volume-row",xe);const ye=new Set(["off","unavailable","unknown","standby","idle"]);function _e(t){const e=Number.isFinite(t)&&t>0?t:0,i=Math.floor(e/60),a=Math.floor(e%60);return`${i}:${String(a).padStart(2,"0")}`}class we extends vt{constructor(){super(...arguments),this._sel=null,this._rgb=null,this._now=Date.now()}connectedCallback(){super.connectedCallback(),this._interval=window.setInterval(()=>{this._now=Date.now()},1e3)}disconnectedCallback(){super.disconnectedCallback(),void 0!==this._interval&&(clearInterval(this._interval),this._interval=void 0)}get _players(){return this.config?.media_players??[]}_selId(){if(this._sel)return this._sel;const t=Gt(this.hass?.states??{},this._players);return t?.entity.entity_id??this._players[0]?.entity??null}_theme(){const t=this.getRootNode()?.host;return"dag"===t?.getAttribute("data-theme")?"dag":"natt"}updated(t){const e=this._selId(),i=e?this.hass?.states[e]?.attributes.entity_picture:void 0;i!==this._pic&&(this._pic=i,i?ve(i).then(t=>{this._pic===i&&(this._rgb=t)}):this._rgb=null)}_transport(t,e){this.callService("media_player",t,void 0,e)}_hero(t,e){const i="playing"===t.state,a=t.attributes.media_title||e,r=t.attributes.media_artist||e,s=t.attributes.entity_picture,n="number"==typeof t.attributes.media_duration?t.attributes.media_duration:0,o=Wt(t,this._now),l=o/100*n,c=t.entity_id;return V`
       <div class="hero">
-        <div class="art" style=${r?`background-image:url('${r}')`:""}></div>
+        <div class="art" style=${s?`background-image:url('${s}')`:""}></div>
         <div class="meta">
           <div class="title">${a}</div>
-          <div class="artist">${s}</div>
+          <div class="artist">${r}</div>
         </div>
         ${n>0?V`
               <div class="progress">
                 <div class="bar"><div class="fill" style="width:${o}%"></div></div>
                 <div class="times">
-                  <span>${ge(l)}</span>
-                  <span>${ge(n)}</span>
+                  <span>${_e(l)}</span>
+                  <span>${_e(n)}</span>
                 </div>
               </div>
             `:G}
@@ -2806,7 +2816,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         <span class="qic">${Ft.note}</span>
         <span class="qtext">Ingenting spelas</span>
       </div>
-    `}render(){if(!this.hass||!this.config)return V``;const t=this._players,e=this.hass.states,i=this._selId(),a=i?e[i]:void 0,s=t.find(t=>t.entity===i)?.name??"",r=!!a&&!ue.has(a.state),n=function(t,e){for(const i of e)if("playing"===t[i.entity]?.state)return i.entity;return e[0]?.entity??null}(e,t),o=function(t,e){if(!t)return"none";const[i,a,s]=t;return`radial-gradient(80% 60% at 30% 20%, rgba(${i}, ${a}, ${s}, ${"natt"===e?"0.22":"0.12"}), transparent 70%)`}(this._rgb,this._theme());return V`
+    `}render(){if(!this.hass||!this.config)return V``;const t=this._players,e=this.hass.states,i=this._selId(),a=i?e[i]:void 0,r=t.find(t=>t.entity===i)?.name??"",s=!!a&&!ye.has(a.state),n=function(t,e){for(const i of e)if("playing"===t[i.entity]?.state)return i.entity;return e[0]?.entity??null}(e,t),o=function(t,e){if(!t)return"none";const[i,a,r]=t;return`radial-gradient(80% 60% at 30% 20%, rgba(${i}, ${a}, ${r}, ${"natt"===e?"0.22":"0.12"}), transparent 70%)`}(this._rgb,this._theme());return V`
       <div class="page">
         <div class="bleed" style=${`background:${o}`}></div>
         <div class="content">
@@ -2823,9 +2833,9 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
                 </div>
               `:G}
 
-          ${r?this._hero(a,s):this._quiet()}
+          ${s?this._hero(a,r):this._quiet()}
 
-          <div class="speakers ${r?"":"pushed"}">
+          <div class="speakers ${s?"":"pushed"}">
             ${t.map(t=>V`
                 <hub-volume-row
                   .hass=${this.hass}
@@ -2836,7 +2846,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}}be.styles=[Tt,n`
+    `}}we.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -3042,7 +3052,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       .speakers.pushed {
         margin-top: auto;
       }
-    `],t([gt({attribute:!1})],be.prototype,"config",void 0),t([bt()],be.prototype,"_sel",void 0),t([bt()],be.prototype,"_rgb",void 0),t([bt()],be.prototype,"_now",void 0),customElements.define("hub-media-page",be);let me=0;class ve extends ct{constructor(){super(...arguments),this.points=[],this.stroke="--hub-lavender",this.width=560,this.height=130,this._gid="hub-spark-"+me++}render(){const t=function(t,e,i,a=.1){const s=t.length;if(0===s)return[];if(1===s)return[{x:e,y:i/2}];const r=t.map(t=>t.value),n=Math.min(...r),o=Math.max(...r)-n,l=n-o*a,c=o*(1+2*a);return t.map((t,a)=>({x:a/(s-1)*e,y:o<=0?i/2:i-(t.value-l)/c*i}))}(this.points,this.width,this.height);if(0===t.length)return V``;const e=t.map(t=>`${t.x.toFixed(2)},${t.y.toFixed(2)}`).join(" "),i=t[t.length-1],a=t[0],s=t.length>=2,r=`${e} ${i.x.toFixed(2)},${this.height} ${a.x.toFixed(2)},${this.height}`;return V`
+    `],t([gt({attribute:!1})],we.prototype,"config",void 0),t([bt()],we.prototype,"_sel",void 0),t([bt()],we.prototype,"_rgb",void 0),t([bt()],we.prototype,"_now",void 0),customElements.define("hub-media-page",we);let ke=0;class $e extends ct{constructor(){super(...arguments),this.points=[],this.stroke="--hub-lavender",this.width=560,this.height=130,this._gid="hub-spark-"+ke++}render(){const t=function(t,e,i,a=.1){const r=t.length;if(0===r)return[];if(1===r)return[{x:e,y:i/2}];const s=t.map(t=>t.value),n=Math.min(...s),o=Math.max(...s)-n,l=n-o*a,c=o*(1+2*a);return t.map((t,a)=>({x:a/(r-1)*e,y:o<=0?i/2:i-(t.value-l)/c*i}))}(this.points,this.width,this.height);if(0===t.length)return V``;const e=t.map(t=>`${t.x.toFixed(2)},${t.y.toFixed(2)}`).join(" "),i=t[t.length-1],a=t[0],r=t.length>=2,s=`${e} ${i.x.toFixed(2)},${this.height} ${a.x.toFixed(2)},${this.height}`;return V`
       <div class="spark" style="--spark-stroke:var(${this.stroke})">
         ${X`
           <svg
@@ -3057,7 +3067,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
                 <stop class="grad-b" offset="100%"></stop>
               </linearGradient>
             </defs>
-            ${s?X`<polygon points="${r}" fill="url(#${this._gid})" stroke="none"></polygon>
+            ${r?X`<polygon points="${s}" fill="url(#${this._gid})" stroke="none"></polygon>
                        <polyline points="${e}" vector-effect="non-scaling-stroke"></polyline>`:G}
           </svg>
         `}
@@ -3066,7 +3076,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           style="left:${(i.x/this.width*100).toFixed(3)}%;top:${(i.y/this.height*100).toFixed(3)}%"
         ></span>
       </div>
-    `}}ve.styles=n`
+    `}}$e.styles=n`
     :host {
       display: block;
     }
@@ -3105,7 +3115,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       pointer-events: none;
       box-shadow: 0 0 0 5px color-mix(in srgb, var(--spark-stroke, #b99cf2) 16%, transparent);
     }
-  `,t([gt({attribute:!1})],ve.prototype,"points",void 0),t([gt()],ve.prototype,"stroke",void 0),t([gt({type:Number})],ve.prototype,"width",void 0),t([gt({type:Number})],ve.prototype,"height",void 0),customElements.define("hub-sparkline",ve);const fe=new Intl.NumberFormat("sv-SE"),xe=new Intl.NumberFormat("sv-SE",{minimumFractionDigits:1,maximumFractionDigits:1}),ye=new Intl.NumberFormat("sv-SE",{maximumFractionDigits:1}),_e=new Intl.DateTimeFormat("sv-SE",{day:"numeric",month:"short",timeZone:"UTC"}),we=new Intl.DateTimeFormat("sv-SE",{weekday:"long",day:"numeric",month:"long",timeZone:"UTC"});function ke(t){if(!t)return"";const e=new Date(`${t}T00:00:00Z`);return Number.isNaN(e.getTime())?"":_e.format(e).replace(/\.$/,"")}class $e extends vt{_meals(t){const e=t.attributes.meals;return Array.isArray(e)?e.filter(t=>!!t&&"object"==typeof t).map(t=>({name:"string"==typeof t.name?t.name:"",kcal:"number"==typeof t.kcal?t.kcal:Number(t.kcal)||0})).filter(t=>t.name):[]}_num(t){return"number"==typeof t?t:NaN}_offline(){return V`
+  `,t([gt({attribute:!1})],$e.prototype,"points",void 0),t([gt()],$e.prototype,"stroke",void 0),t([gt({type:Number})],$e.prototype,"width",void 0),t([gt({type:Number})],$e.prototype,"height",void 0),customElements.define("hub-sparkline",$e);const Ce=new Intl.NumberFormat("sv-SE"),Ee=new Intl.NumberFormat("sv-SE",{minimumFractionDigits:1,maximumFractionDigits:1}),Se=new Intl.NumberFormat("sv-SE",{maximumFractionDigits:1}),Ae=new Intl.DateTimeFormat("sv-SE",{day:"numeric",month:"short",timeZone:"UTC"}),Me=new Intl.DateTimeFormat("sv-SE",{weekday:"long",day:"numeric",month:"long",timeZone:"UTC"});function Te(t){if(!t)return"";const e=new Date(`${t}T00:00:00Z`);return Number.isNaN(e.getTime())?"":Ae.format(e).replace(/\.$/,"")}class Ne extends vt{_meals(t){const e=t.attributes.meals;return Array.isArray(e)?e.filter(t=>!!t&&"object"==typeof t).map(t=>({name:"string"==typeof t.name?t.name:"",kcal:"number"==typeof t.kcal?t.kcal:Number(t.kcal)||0})).filter(t=>t.name):[]}_num(t){return"number"==typeof t?t:NaN}_offline(){return V`
       <div class="page">
         <div class="offline">
           <div class="off-ring"></div>
@@ -3118,18 +3128,18 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <div class="w-num-row"><span class="w-num">${"−"}</span><span class="w-unit">kg</span></div>
           <div class="spark-wrap"><span class="spark-empty">Ingen viktdata</span></div>
         </section>
-      `;const a=e.attributes.weight_trend,s=Array.isArray(a)?a.filter(t=>!!t&&"object"==typeof t).map(t=>({date:String(t.date??""),value:Number(t.kg)})).filter(t=>Number.isFinite(t.value)):[],r=function(t){if(t.length<2)return null;const e=new Date(`${t[0].date}T00:00:00Z`).getTime(),i=new Date(`${t[t.length-1].date}T00:00:00Z`).getTime();return Number.isNaN(e)||Number.isNaN(i)?null:Math.round((i-e)/864e5)}(s),n=s.length>=2?s[s.length-1].value-s[0].value:null,o=null===n||null===r?null:`${n<0?"−":n>0?"+":""}${xe.format(Math.abs(n))} kg på ${r} ${1===r?"dag":"dagar"}`,l=e.attributes.forecast,c=l&&"object"==typeof l?l:null,h=c?function(t){const e="number"==typeof t.goal_kg?`Mål ${ye.format(t.goal_kg)} kg`:"",i=t.eta?ke(t.eta):"",a=t.eta_early&&t.eta_late?`${ke(t.eta_early)}–${ke(t.eta_late)}`:"";return[e,i?`ETA ${i}${a?` (${a})`:""}`:""].filter(Boolean).join(" · ")}(c):"",d=!!c?.on_track;return V`
+      `;const a=e.attributes.weight_trend,r=Array.isArray(a)?a.filter(t=>!!t&&"object"==typeof t).map(t=>({date:String(t.date??""),value:Number(t.kg)})).filter(t=>Number.isFinite(t.value)):[],s=function(t){if(t.length<2)return null;const e=new Date(`${t[0].date}T00:00:00Z`).getTime(),i=new Date(`${t[t.length-1].date}T00:00:00Z`).getTime();return Number.isNaN(e)||Number.isNaN(i)?null:Math.round((i-e)/864e5)}(r),n=r.length>=2?r[r.length-1].value-r[0].value:null,o=null===n||null===s?null:`${n<0?"−":n>0?"+":""}${Ee.format(Math.abs(n))} kg på ${s} ${1===s?"dag":"dagar"}`,l=e.attributes.forecast,c=l&&"object"==typeof l?l:null,h=c?function(t){const e="number"==typeof t.goal_kg?`Mål ${Se.format(t.goal_kg)} kg`:"",i=t.eta?Te(t.eta):"",a=t.eta_early&&t.eta_late?`${Te(t.eta_early)}–${Te(t.eta_late)}`:"";return[e,i?`ETA ${i}${a?` (${a})`:""}`:""].filter(Boolean).join(" · ")}(c):"",d=!!c?.on_track;return V`
       <section class="card">
         <span class="w-eyebrow">Vikt</span>
         <div class="w-num-row">
-          <span class="w-num">${xe.format(i)}</span>
+          <span class="w-num">${Ee.format(i)}</span>
           <span class="w-unit">kg</span>
         </div>
         ${o?V`<span class="w-delta">${o}</span>`:G}
 
         <div class="spark-wrap">
-          ${s.length>=2?V`<hub-sparkline
-                .points=${s}
+          ${r.length>=2?V`<hub-sparkline
+                .points=${r}
                 stroke="--hub-lavender"
                 .width=${560}
                 .height=${130}
@@ -3141,7 +3151,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           ${d?V`<span class="fc-chip">i fas ✓</span>`:G}
         </div>
       </section>
-    `}render(){if(!this.hass||!this.config)return V``;const t=this.config.kcal?.today_entity,e=t?this.getEntity(t):void 0,i=e?Number(e.state):NaN;if(!e||"unavailable"===e.state||"unknown"===e.state||Number.isNaN(i))return this._offline();const a=this._num(e.attributes.kcal_target),s=Vt(i,a),r=Number.isFinite(a)&&a>0,n=r?a-i:NaN,o=r?n>0?`${fe.format(Math.round(n))} kcal kvar`:0===n?"Målet nått":`${fe.format(Math.round(-n))} över målet`:null,l=this._num(e.attributes.protein_g),c=this._num(e.attributes.protein_target_g),h=Number.isFinite(l)&&Number.isFinite(c)&&c>0,d=h?Math.max(0,Math.min(100,l/c*100)):0,p=this._meals(e),u=e.attributes.date,g="string"!=typeof u||Number.isNaN(new Date(`${u}T00:00:00Z`).getTime())?"":we.format(new Date(`${u}T00:00:00Z`));return V`
+    `}render(){if(!this.hass||!this.config)return V``;const t=this.config.kcal?.today_entity,e=t?this.getEntity(t):void 0,i=e?Number(e.state):NaN;if(!e||"unavailable"===e.state||"unknown"===e.state||Number.isNaN(i))return this._offline();const a=this._num(e.attributes.kcal_target),r=Zt(i,a),s=Number.isFinite(a)&&a>0,n=s?a-i:NaN,o=s?n>0?`${Ce.format(Math.round(n))} kcal kvar`:0===n?"Målet nått":`${Ce.format(Math.round(-n))} över målet`:null,l=this._num(e.attributes.protein_g),c=this._num(e.attributes.protein_target_g),h=Number.isFinite(l)&&Number.isFinite(c)&&c>0,d=h?Math.max(0,Math.min(100,l/c*100)):0,p=this._meals(e),u=e.attributes.date,g="string"!=typeof u||Number.isNaN(new Date(`${u}T00:00:00Z`).getTime())?"":Me.format(new Date(`${u}T00:00:00Z`));return V`
       <div class="page">
         <div class="header">
           <h1 class="title">Kcal</h1>
@@ -3152,11 +3162,11 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <section class="card">
             <div class="ring-wrap">
               <div class="ring-glow"></div>
-              <div class="ring" style="--pct:${s}"></div>
+              <div class="ring" style="--pct:${r}"></div>
               <div class="ring-center">
-                <span class="kc-num">${fe.format(Math.round(i))}</span>
+                <span class="kc-num">${Ce.format(Math.round(i))}</span>
                 <span class="kc-target">
-                  ${r?`/ ${fe.format(a)} kcal`:"kcal"}
+                  ${s?`/ ${Ce.format(a)} kcal`:"kcal"}
                 </span>
               </div>
             </div>
@@ -3179,7 +3189,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
               ${p.length?p.map(t=>V`
                       <div class="meal">
                         <span class="meal-name">${t.name}</span>
-                        <span class="meal-kcal">${fe.format(Math.round(t.kcal))} kcal</span>
+                        <span class="meal-kcal">${Ce.format(Math.round(t.kcal))} kcal</span>
                       </div>
                     `):V`<div class="empty">Inga måltider loggade ännu</div>`}
             </div>
@@ -3188,7 +3198,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           ${this._weightCard()}
         </div>
       </div>
-    `}}$e.styles=[Tt,n`
+    `}}Ne.styles=[Tt,n`
       :host {
         display: block;
         height: 100%;
@@ -3481,17 +3491,362 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         color: var(--hub-text-muted);
         letter-spacing: 0.01em;
       }
-    `],t([gt({attribute:!1})],$e.prototype,"config",void 0),customElements.define("hub-kcal-page",$e);const Ce=X`
+    `],t([gt({attribute:!1})],Ne.prototype,"config",void 0),customElements.define("hub-kcal-page",Ne);const ze=new Intl.NumberFormat("sv-SE"),Pe=new Intl.DateTimeFormat("sv-SE",{weekday:"long",day:"numeric",month:"long",timeZone:"UTC"});class Fe extends vt{constructor(){super(...arguments),this._openDate=null,this._confirming=!1}_model(){const t=this.config?.kcal?.planner_entity;if(!t)return null;const e=this.getEntity(t);return e&&"unavailable"!==e.state&&"unknown"!==e.state?Ut(e.attributes):null}_confirm(t){this._confirming||t.confirmed||0===t.meals.length||(this._confirming=!0,this.callService("rest_command","kcal_confirm_day",{date:t.date}),window.setTimeout(()=>{const t=this.config?.kcal?.planner_entity;t&&this.callService("homeassistant","update_entity",void 0,t),this._confirming=!1,this._openDate=null},1500))}_dayPopup(t){const e=t.days.find(t=>t.date===this._openDate);if(!e)return G;const i=Pe.format(new Date(`${e.date}T00:00:00Z`)),a=!e.confirmed&&e.meals.some(t=>!t.logged);return V`
+      <div class="scrim" @click=${()=>this._openDate=null}>
+        <div class="popup" @click=${t=>t.stopPropagation()}>
+          <h2 class="popup-title">${i}</h2>
+          <div class="popup-sub">
+            ${e.day_type} · ${ze.format(e.total_kcal)} / ${ze.format(e.target_kcal)} kcal
+            ${e.confirmed?" · bekräftad ✓":""}
+          </div>
+          ${e.meals.map(t=>V`
+              <div class="pm">
+                <div>
+                  <span class="pm-slot">${Dt[t.slot]}${t.logged?" · loggad":""}</span>
+                  <span class="pm-name">${t.name}</span>
+                </div>
+                <span class="pm-macro">
+                  ${ze.format(t.kcal)} kcal<br />
+                  P ${ze.format(t.protein)} · F ${ze.format(t.fat)} · K ${ze.format(t.carbs)}
+                </span>
+              </div>
+            `)}
+          ${0===e.meals.length?V`<div class="empty-day">Inget planerat.</div>`:G}
+          <div class="popup-actions">
+            ${e.confirmed?V`<span class="confirmed-note">Dagen är låst ✓</span>`:G}
+            <button class="btn" @click=${()=>this._openDate=null}>Stäng</button>
+            ${a?V`
+                  <button class="btn primary" ?disabled=${this._confirming} @click=${()=>this._confirm(e)}>
+                    ${this._confirming?"Bekräftar…":"Bekräfta dagen"}
+                  </button>
+                `:G}
+          </div>
+        </div>
+      </div>
+    `}_dayCard(t,e){const i=jt.filter(e=>t.meals.some(t=>t.slot===e));return V`
+      <button
+        class="day${t.date===e?" today":""}${t.confirmed?" confirmed":""}"
+        @click=${()=>this._openDate=t.date}
+      >
+        <div class="day-head">
+          <span class="day-name">${t.weekday.slice(0,3)}</span>
+          <span class="day-date">${t.date.slice(8)}</span>
+          <span class="day-flex"></span>
+          ${t.confirmed?V`<span class="lock">✓</span>`:G}
+          <span class="type-chip ${t.day_type}">${a=t.day_type,Ht[a]??"·"}</span>
+        </div>
+        <div class="slots">
+          ${0===i.length?V`<span class="empty-day">—</span>`:G}
+          ${i.map(e=>V`
+              <div>
+                <span class="slot-label">${Dt[e]}</span>
+                ${t.meals.filter(t=>t.slot===e).map(t=>V`
+                      <div class="meal">
+                        <span class="meal-name${t.logged?" logged":""}">${t.name}</span>
+                        <span class="meal-kcal">${ze.format(t.kcal)} kcal</span>
+                      </div>
+                    `)}
+              </div>
+            `)}
+        </div>
+        <div class="day-foot">
+          ${t.meals.length>0?V`${ze.format(t.total_kcal)} / ${ze.format(t.target_kcal)}
+              ${t.kcal_ok&&t.protein_ok?G:V`<span class="warn"> ⚠</span>`}`:V`&nbsp;`}
+        </div>
+      </button>
+    `;var a}render(){if(!this.hass||!this.config)return V``;const t=this._model();return t?V`
+      <div class="page">
+        <div class="header">
+          <h1 class="title">Vecka</h1>
+          <span class="subtitle">${t.confirmedDays} / 7 bekräftade</span>
+        </div>
+        <div class="grid">${t.days.map(e=>this._dayCard(e,t.today))}</div>
+      </div>
+      ${this._openDate?this._dayPopup(t):G}
+    `:V`<div class="page"><div class="offline">Vecka · offline</div></div>`}}Fe.styles=[Tt,n`
+      :host {
+        display: block;
+        height: 100%;
+      }
+      .page {
+        box-sizing: border-box;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        padding: var(--hub-page-pad);
+        padding-bottom: clamp(48px, 6vh, 66px);
+      }
+
+      .header {
+        padding-right: 56px;
+        margin-bottom: clamp(14px, 2vh, 22px);
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .title {
+        margin: 0;
+        font: 200 clamp(30px, 4.4vw, 46px) var(--hub-font-display);
+        letter-spacing: -0.02em;
+        color: var(--hub-text);
+      }
+      .subtitle {
+        font: 500 14px var(--hub-font-body);
+        color: var(--hub-text-dim);
+      }
+
+      /* ── Week grid ─────────────────────────────────────────── */
+      .grid {
+        flex: 1;
+        min-height: 0;
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: clamp(8px, 1vw, 14px);
+      }
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .day {
+        box-sizing: border-box;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        padding: clamp(10px, 1.2vw, 16px);
+        border-radius: var(--hub-radius-lg);
+        background: var(--hub-lavender-bg);
+        border: 1px solid var(--hub-lavender-border);
+        box-shadow: var(--hub-shadow);
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+        text-align: left;
+        font: inherit;
+        color: inherit;
+      }
+      .day.today {
+        border-color: var(--hub-lavender);
+      }
+      .day.confirmed {
+        opacity: 0.78;
+      }
+
+      .day-head {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+      .day-name {
+        font: 600 13px var(--hub-font-body);
+        color: var(--hub-text);
+        text-transform: capitalize;
+      }
+      .day-date {
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-dim);
+        font-variant-numeric: tabular-nums;
+      }
+      .day-flex {
+        flex: 1;
+      }
+      .type-chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        font: 600 11px var(--hub-font-body);
+        background: var(--hub-chip-bg);
+        border: 1px solid var(--hub-chip-border);
+        color: var(--hub-text-muted);
+        flex-shrink: 0;
+      }
+      .type-chip.gymdag {
+        background: var(--hub-green-bg);
+        border-color: var(--hub-green-border);
+        color: var(--hub-green);
+      }
+      .type-chip.flexdag {
+        background: var(--hub-teal-bg);
+        border-color: var(--hub-teal-border);
+        color: var(--hub-teal);
+      }
+      .lock {
+        font: 600 12px var(--hub-font-body);
+        color: var(--hub-green);
+      }
+
+      .slots {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .slot-label {
+        font: 600 10px var(--hub-font-body);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--hub-text-dim);
+      }
+      .meal {
+        display: flex;
+        flex-direction: column;
+        margin-top: 2px;
+      }
+      .meal-name {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-text);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .meal-name.logged {
+        color: var(--hub-text-dim);
+      }
+      .meal-kcal {
+        font: 500 11px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .empty-day {
+        font: 400 12px var(--hub-font-body);
+        color: var(--hub-text-dim);
+      }
+
+      .day-foot {
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid color-mix(in srgb, var(--hub-lavender-border) 55%, transparent);
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .day-foot .warn {
+        color: var(--hub-coral);
+      }
+
+      /* ── Day popup ─────────────────────────────────────────── */
+      .scrim {
+        position: fixed;
+        inset: 0;
+        background: color-mix(in srgb, var(--hub-surface) 62%, transparent);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        z-index: 40;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .popup {
+        box-sizing: border-box;
+        width: min(560px, 94vw);
+        max-height: 86vh;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        padding: clamp(20px, 3vw, 32px);
+        border-radius: var(--hub-radius-lg);
+        background: var(--hub-card);
+        border: 1px solid var(--hub-lavender-border);
+        box-shadow: var(--hub-shadow);
+      }
+      .popup-title {
+        margin: 0 0 4px;
+        font: 300 clamp(24px, 3.4vw, 32px) var(--hub-font-display);
+        color: var(--hub-text);
+      }
+      .popup-title::first-letter {
+        text-transform: uppercase;
+      }
+      .popup-sub {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-text-dim);
+        margin-bottom: 14px;
+      }
+      .pm {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 12px;
+        padding: 9px 0;
+        border-top: 1px solid color-mix(in srgb, var(--hub-lavender-border) 55%, transparent);
+      }
+      .pm-name {
+        font: 500 15px var(--hub-font-body);
+        color: var(--hub-text);
+      }
+      .pm-slot {
+        font: 600 10px var(--hub-font-body);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--hub-text-dim);
+        display: block;
+      }
+      .pm-macro {
+        flex-shrink: 0;
+        text-align: right;
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .popup-actions {
+        margin-top: 18px;
+        display: flex;
+        gap: 12px;
+        justify-content: flex-end;
+      }
+      .btn {
+        font: 600 14px var(--hub-font-body);
+        padding: 12px 22px;
+        border-radius: var(--hub-radius-pill);
+        border: 1px solid var(--hub-chip-border);
+        background: var(--hub-chip-bg);
+        color: var(--hub-text-muted);
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .btn.primary {
+        background: var(--hub-lavender-bg);
+        border-color: var(--hub-lavender-border);
+        color: var(--hub-lavender-text);
+      }
+      .btn:disabled {
+        opacity: 0.5;
+      }
+      .confirmed-note {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-green);
+        align-self: center;
+        margin-right: auto;
+      }
+
+      /* ── Offline ───────────────────────────────────────────── */
+      .offline {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font: 300 clamp(26px, 4vw, 38px) var(--hub-font-display);
+        color: var(--hub-text-muted);
+      }
+    `],t([gt({attribute:!1})],Fe.prototype,"config",void 0),t([bt()],Fe.prototype,"_openDate",void 0),t([bt()],Fe.prototype,"_confirming",void 0),customElements.define("hub-planner-page",Fe);const De=X`
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
     <path d="M6 6l12 12M18 6L6 18"></path>
   </svg>
-`;class Ee extends vt{constructor(){super(...arguments),this.room=null,this._onScrim=t=>{t.target===t.currentTarget&&this._close()}}_close(){this.dispatchEvent(new CustomEvent("hub-popup-close",{bubbles:!0,composed:!0}))}render(){if(!this.room||!this.hass)return V``;const t=this.room;return V`
+`;class je extends vt{constructor(){super(...arguments),this.room=null,this._onScrim=t=>{t.target===t.currentTarget&&this._close()}}_close(){this.dispatchEvent(new CustomEvent("hub-popup-close",{bubbles:!0,composed:!0}))}render(){if(!this.room||!this.hass)return V``;const t=this.room;return V`
       <div class="scrim" @click=${this._onScrim}>
         <div class="card" role="dialog" aria-label=${t.name}>
           <div class="head">
             <span class="title">${t.name}</span>
             <button class="close" aria-label="Stäng" @click=${this._close}>
-              ${Ce}
+              ${De}
             </button>
           </div>
           <div class="lights">
@@ -3504,7 +3859,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           </div>
         </div>
       </div>
-    `}}Ee.styles=[Tt,n`
+    `}}je.styles=[Tt,n`
       :host {
         position: absolute;
         inset: 0;
@@ -3590,11 +3945,11 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
       glass-light-slider {
         display: block;
       }
-    `],t([gt({attribute:!1})],Ee.prototype,"room",void 0),customElements.define("hub-room-popup",Ee);const Se={hem:{label:"Hem",icon:"home",tone:"neutral"},ljus:{label:"Ljus",icon:"lamp",tone:"amber"},media:{label:"Media",icon:"note",tone:"teal"},energi:{label:"Energi",icon:"bolt",tone:"green"},kcal:{label:"Kcal",icon:"ring",tone:"lavender"}};class Ae extends ct{constructor(){super(...arguments),this.pages=[],this.active=0}_select(t){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:t},bubbles:!0,composed:!0}))}render(){return V`
+    `],t([gt({attribute:!1})],je.prototype,"room",void 0),customElements.define("hub-room-popup",je);const He={hem:{label:"Hem",icon:"home",tone:"neutral"},ljus:{label:"Ljus",icon:"lamp",tone:"amber"},media:{label:"Media",icon:"note",tone:"teal"},energi:{label:"Energi",icon:"bolt",tone:"green"},kcal:{label:"Kcal",icon:"ring",tone:"lavender"},vecka:{label:"Vecka",icon:"calendar",tone:"lavender"}};class Ie extends ct{constructor(){super(...arguments),this.pages=[],this.active=0}_select(t){this.dispatchEvent(new CustomEvent("hub-goto-page",{detail:{page:t},bubbles:!0,composed:!0}))}render(){return V`
       <nav>
         <div class="rail"></div>
         <div class="items">
-          ${this.pages.map((t,e)=>{const i=function(t){const e=Se[t];return e?{id:t,...e}:{id:t,label:t.charAt(0).toUpperCase()+t.slice(1),icon:"",tone:"neutral"}}(t),a=e===this.active,s=Ft[i.icon];return V`
+          ${this.pages.map((t,e)=>{const i=function(t){const e=He[t];return e?{id:t,...e}:{id:t,label:t.charAt(0).toUpperCase()+t.slice(1),icon:"",tone:"neutral"}}(t),a=e===this.active,r=Ft[i.icon];return V`
               <button
                 class="item tone-${i.tone} ${a?"active":""}"
                 aria-label=${i.label}
@@ -3602,7 +3957,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
                 @click=${()=>this._select(t)}
               >
                 <span class="pill">
-                  ${s?V`<span class="icon">${s}</span>`:G}
+                  ${r?V`<span class="icon">${r}</span>`:G}
                 </span>
                 <span class="label">${i.label}</span>
               </button>
@@ -3612,7 +3967,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
           <slot name="controls"></slot>
         </div>
       </nav>
-    `}}Ae.styles=[Tt,n`
+    `}}Ie.styles=[Tt,n`
       :host {
         position: absolute;
         left: 0;
@@ -3739,7 +4094,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         background: var(--hub-lavender-bg);
         border-color: var(--hub-lavender-border);
       }
-    `],t([gt({attribute:!1})],Ae.prototype,"pages",void 0),t([gt({type:Number})],Ae.prototype,"active",void 0),customElements.define("hub-nav-bar",Ae);const Me=["hem","ljus","media","energi","kcal"],Te={hem:"Hem",ljus:"Ljus",media:"Media",energi:"Energi",kcal:"Kcal"};const Ne=["auto","dag","natt"];let ze=0;class Pe extends vt{constructor(){super(...arguments),this.theme="natt",this.kiosk=new URLSearchParams(location.search).has("kiosk"),this._page=0,this._dragX=0,this._openRoom=null,this._override=function(){const t=localStorage.getItem(Nt);return"natt"===t||"dag"===t?t:"auto"}(),this._pointerActive=!1,this._dragging=!1,this._startX=0,this._startY=0,this._lastX=0,this._lastT=0,this._velocity=0,this._onRoomOpen=t=>{const e=t.detail?.roomId;this._openRoom=this._cfg?.rooms?.find(t=>t.id===e)??null},this._onGotoPage=t=>{const e=t.detail?.page;e&&this.goToPage(e)},this._onPopupClose=()=>{this._openRoom=null},this._onAnyInteraction=()=>{this._resetIdle()},this._onPointerDown=t=>{this._pointerActive=!0,this._dragging=!1,this._startX=t.clientX,this._startY=t.clientY,this._lastX=t.clientX,this._lastT=t.timeStamp,this._velocity=0,this._dragX=0},this._onPointerMove=t=>{if(!this._pointerActive)return;const e=t.clientX-this._startX,i=t.clientY-this._startY;if(!this._dragging){if(!zt(e)&&!zt(i))return;if(!function(t,e){return Math.abs(t)>Math.abs(e)}(e,i))return void(this._pointerActive=!1);this._dragging=!0,t.currentTarget.setPointerCapture?.(t.pointerId),this._lastX=t.clientX,this._lastT=t.timeStamp}const a=t.timeStamp-this._lastT;a>0&&(this._velocity=(t.clientX-this._lastX)/a),this._lastX=t.clientX,this._lastT=t.timeStamp,this._dragX=e},this._onPointerUp=t=>{if(!this._pointerActive)return;const e=this._dragging;if(this._pointerActive=!1,this._dragging=!1,e){t.currentTarget.releasePointerCapture?.(t.pointerId);const e=this.clientWidth||window.innerWidth;this._page=function(t,e,i,a,s){const r=.2*e,n=Math.abs(i)>.5;let o=a;return t<-r||n&&i<-.5?o=a+1:(t>r||n&&i>.5)&&(o=a-1),Math.max(0,Math.min(s-1,o))}(this._dragX,e,this._velocity,this._page,this._pages.length),ze=this._page}this._dragX=0,this._velocity=0}}setConfig(t){super.setConfig(t)}get _cfg(){return this._config}get _pages(){return this._cfg?.pages??Me}connectedCallback(){super.connectedCallback(),function(){if(document.getElementById("glass-hub-fonts"))return;const t=document.createElement("style");t.id="glass-hub-fonts",t.textContent="\n@font-face{font-family:'Outfit';src:url('/local/glass-cards/fonts/outfit-variable.woff2') format('woff2-variations');font-weight:100 900;font-display:swap;}\n@font-face{font-family:'Inter';src:url('/local/glass-cards/fonts/inter-variable.woff2') format('woff2-variations');font-weight:100 900;font-display:swap;}\n",document.head.appendChild(t)}(),this._applyTheme(),this._page=ze,this._resetIdle(),this._startKioskDrawerShim(),this.addEventListener("pointerdown",this._onAnyInteraction),this.addEventListener("hub-room-open",this._onRoomOpen),this.addEventListener("hub-goto-page",this._onGotoPage),this.addEventListener("hub-popup-close",this._onPopupClose)}disconnectedCallback(){super.disconnectedCallback(),this._clearIdle(),void 0!==this._kioskTimer&&(clearInterval(this._kioskTimer),this._kioskTimer=void 0),this.removeEventListener("pointerdown",this._onAnyInteraction),this.removeEventListener("hub-room-open",this._onRoomOpen),this.removeEventListener("hub-goto-page",this._onGotoPage),this.removeEventListener("hub-popup-close",this._onPopupClose)}willUpdate(t){t.has("hass")&&this._applyTheme()}goToPage(t){const e=this._pages.indexOf(t);e>=0&&(this._page=e,ze=e,this._dragX=0)}_applyTheme(){const t=this.hass?.states["sun.sun"]?.attributes?.elevation,e="number"==typeof t?t:null;this.theme=function(t,e,i=4){return"auto"!==e?e:null===t?"natt":t>i?"dag":"natt"}(e,this._override,this._cfg?.day_elevation??4)}_cycleTheme(){const t=Ne.indexOf(this._override);this._override=Ne[(t+1)%Ne.length],function(t){localStorage.setItem(Nt,t)}(this._override),this._applyTheme()}_toggleKiosk(){const t=new URLSearchParams(location.search);t.has("kiosk")?t.delete("kiosk"):t.set("kiosk","true");const e=t.toString();location.assign(location.pathname+(e?`?${e}`:""))}_resetIdle(){this._clearIdle();const t=this._cfg?.idle_return_s??120;this._idleTimer=window.setTimeout(()=>{0!==this._page&&this.goToPage(this._pages[0])},1e3*t)}_clearIdle(){void 0!==this._idleTimer&&(clearTimeout(this._idleTimer),this._idleTimer=void 0)}_startKioskDrawerShim(){if(!new URLSearchParams(location.search).has("kiosk"))return;const t=Date.now(),e=()=>{const t=document.querySelector("home-assistant")?.shadowRoot?.querySelector("home-assistant-main");if(!t)return!1;t.style.setProperty("--mdc-drawer-width","0px");const e=t.shadowRoot?.querySelector("ha-drawer");return e?.style.setProperty("--mdc-drawer-width","0px"),!0};e()||(this._kioskTimer=window.setInterval(()=>{(e()||Date.now()-t>5e3)&&(clearInterval(this._kioskTimer),this._kioskTimer=void 0)},250))}_themeGlyph(){return"auto"===this._override?V`<span class="glyph-auto">A</span>`:"dag"===this._override?X`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+    `],t([gt({attribute:!1})],Ie.prototype,"pages",void 0),t([gt({type:Number})],Ie.prototype,"active",void 0),customElements.define("hub-nav-bar",Ie);const Oe=["hem","ljus","media","energi","kcal","vecka"],Re={hem:"Hem",ljus:"Ljus",media:"Media",energi:"Energi",kcal:"Kcal",vecka:"Vecka"};const Ue=["auto","dag","natt"];let Be=0;class Le extends vt{constructor(){super(...arguments),this.theme="natt",this.kiosk=new URLSearchParams(location.search).has("kiosk"),this._page=0,this._dragX=0,this._openRoom=null,this._override=function(){const t=localStorage.getItem(Nt);return"natt"===t||"dag"===t?t:"auto"}(),this._pointerActive=!1,this._dragging=!1,this._startX=0,this._startY=0,this._lastX=0,this._lastT=0,this._velocity=0,this._onRoomOpen=t=>{const e=t.detail?.roomId;this._openRoom=this._cfg?.rooms?.find(t=>t.id===e)??null},this._onGotoPage=t=>{const e=t.detail?.page;e&&this.goToPage(e)},this._onPopupClose=()=>{this._openRoom=null},this._onAnyInteraction=()=>{this._resetIdle()},this._onPointerDown=t=>{this._pointerActive=!0,this._dragging=!1,this._startX=t.clientX,this._startY=t.clientY,this._lastX=t.clientX,this._lastT=t.timeStamp,this._velocity=0,this._dragX=0},this._onPointerMove=t=>{if(!this._pointerActive)return;const e=t.clientX-this._startX,i=t.clientY-this._startY;if(!this._dragging){if(!zt(e)&&!zt(i))return;if(!function(t,e){return Math.abs(t)>Math.abs(e)}(e,i))return void(this._pointerActive=!1);this._dragging=!0,t.currentTarget.setPointerCapture?.(t.pointerId),this._lastX=t.clientX,this._lastT=t.timeStamp}const a=t.timeStamp-this._lastT;a>0&&(this._velocity=(t.clientX-this._lastX)/a),this._lastX=t.clientX,this._lastT=t.timeStamp,this._dragX=e},this._onPointerUp=t=>{if(!this._pointerActive)return;const e=this._dragging;if(this._pointerActive=!1,this._dragging=!1,e){t.currentTarget.releasePointerCapture?.(t.pointerId);const e=this.clientWidth||window.innerWidth;this._page=function(t,e,i,a,r){const s=.2*e,n=Math.abs(i)>.5;let o=a;return t<-s||n&&i<-.5?o=a+1:(t>s||n&&i>.5)&&(o=a-1),Math.max(0,Math.min(r-1,o))}(this._dragX,e,this._velocity,this._page,this._pages.length),Be=this._page}this._dragX=0,this._velocity=0}}setConfig(t){super.setConfig(t)}get _cfg(){return this._config}get _pages(){return this._cfg?.pages??Oe}connectedCallback(){super.connectedCallback(),function(){if(document.getElementById("glass-hub-fonts"))return;const t=document.createElement("style");t.id="glass-hub-fonts",t.textContent="\n@font-face{font-family:'Outfit';src:url('/local/glass-cards/fonts/outfit-variable.woff2') format('woff2-variations');font-weight:100 900;font-display:swap;}\n@font-face{font-family:'Inter';src:url('/local/glass-cards/fonts/inter-variable.woff2') format('woff2-variations');font-weight:100 900;font-display:swap;}\n",document.head.appendChild(t)}(),this._applyTheme(),this._page=Be,this._resetIdle(),this._startKioskDrawerShim(),this.addEventListener("pointerdown",this._onAnyInteraction),this.addEventListener("hub-room-open",this._onRoomOpen),this.addEventListener("hub-goto-page",this._onGotoPage),this.addEventListener("hub-popup-close",this._onPopupClose)}disconnectedCallback(){super.disconnectedCallback(),this._clearIdle(),void 0!==this._kioskTimer&&(clearInterval(this._kioskTimer),this._kioskTimer=void 0),this.removeEventListener("pointerdown",this._onAnyInteraction),this.removeEventListener("hub-room-open",this._onRoomOpen),this.removeEventListener("hub-goto-page",this._onGotoPage),this.removeEventListener("hub-popup-close",this._onPopupClose)}willUpdate(t){t.has("hass")&&this._applyTheme()}goToPage(t){const e=this._pages.indexOf(t);e>=0&&(this._page=e,Be=e,this._dragX=0)}_applyTheme(){const t=this.hass?.states["sun.sun"]?.attributes?.elevation,e="number"==typeof t?t:null;this.theme=function(t,e,i=4){return"auto"!==e?e:null===t?"natt":t>i?"dag":"natt"}(e,this._override,this._cfg?.day_elevation??4)}_cycleTheme(){const t=Ue.indexOf(this._override);this._override=Ue[(t+1)%Ue.length],function(t){localStorage.setItem(Nt,t)}(this._override),this._applyTheme()}_toggleKiosk(){const t=new URLSearchParams(location.search);t.has("kiosk")?t.delete("kiosk"):t.set("kiosk","true");const e=t.toString();location.assign(location.pathname+(e?`?${e}`:""))}_resetIdle(){this._clearIdle();const t=this._cfg?.idle_return_s??120;this._idleTimer=window.setTimeout(()=>{0!==this._page&&this.goToPage(this._pages[0])},1e3*t)}_clearIdle(){void 0!==this._idleTimer&&(clearTimeout(this._idleTimer),this._idleTimer=void 0)}_startKioskDrawerShim(){if(!new URLSearchParams(location.search).has("kiosk"))return;const t=Date.now(),e=()=>{const t=document.querySelector("home-assistant")?.shadowRoot?.querySelector("home-assistant-main");if(!t)return!1;t.style.setProperty("--mdc-drawer-width","0px");const e=t.shadowRoot?.querySelector("ha-drawer");return e?.style.setProperty("--mdc-drawer-width","0px"),!0};e()||(this._kioskTimer=window.setInterval(()=>{(e()||Date.now()-t>5e3)&&(clearInterval(this._kioskTimer),this._kioskTimer=void 0)},250))}_themeGlyph(){return"auto"===this._override?V`<span class="glyph-auto">A</span>`:"dag"===this._override?X`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
         stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="4" fill="currentColor" stroke="none"></circle>
         <line x1="12" y1="2" x2="12" y2="5"></line>
@@ -3778,7 +4133,10 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
                         ></hub-media-page>`:"kcal"===t?V`<hub-kcal-page
                             .hass=${this.hass}
                             .config=${this._cfg}
-                          ></hub-kcal-page>`:V`<h1 class="page-placeholder">${function(t){return Te[t]??t.charAt(0).toUpperCase()+t.slice(1)}(t)}</h1>`}
+                          ></hub-kcal-page>`:"vecka"===t?V`<hub-planner-page
+                              .hass=${this.hass}
+                              .config=${this._cfg}
+                            ></hub-planner-page>`:V`<h1 class="page-placeholder">${function(t){return Re[t]??t.charAt(0).toUpperCase()+t.slice(1)}(t)}</h1>`}
             </section>
           `)}
       </div>
@@ -3806,7 +4164,7 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
             .hass=${this.hass}
             .room=${this._openRoom}
           ></hub-room-popup>`:G}
-    `}}Pe.styles=[Tt,n`
+    `}}Le.styles=[Tt,n`
       :host {
         position: absolute;
         inset: 0;
@@ -3883,4 +4241,4 @@ function t(t,e,i,a){var s,r=arguments.length,n=r<3?e:null===a?a=Object.getOwnPro
         font-weight: 500;
         font-size: 20px;
       }
-    `],t([gt({reflect:!0,attribute:"data-theme"})],Pe.prototype,"theme",void 0),t([gt({reflect:!0,type:Boolean})],Pe.prototype,"kiosk",void 0),t([bt()],Pe.prototype,"_page",void 0),t([bt()],Pe.prototype,"_dragX",void 0),t([bt()],Pe.prototype,"_openRoom",void 0),customElements.define("glass-hub",Pe);const Fe=window;Fe.customCards=Fe.customCards||[],Fe.customCards.push({type:"glass-background",name:"Glass Background",description:"Animated gradient background"},{type:"glass-button",name:"Glass Button",description:"Toggle/info button"},{type:"glass-chip",name:"Glass Chip",description:"Small status pill"},{type:"glass-header",name:"Glass Header",description:"Greeting, weather, status chips"},{type:"glass-room-card",name:"Glass Room Card",description:"Room with sub-buttons and popup"},{type:"glass-light-slider",name:"Glass Light Slider",description:"Brightness slider with glow"},{type:"glass-popup",name:"Glass Popup",description:"Modal overlay"},{type:"glass-nav-bar",name:"Glass Nav Bar",description:"Bottom navigation"},{type:"glass-vacuum-card",name:"Glass Vacuum Card",description:"Vacuum controls"},{type:"glass-info-row",name:"Glass Info Row",description:"Information display"},{type:"glass-section",name:"Glass Section",description:"Section header label"},{type:"glass-departure-card",name:"Glass Departure Card",description:"Train departure list"},{type:"glass-hub",name:"Glass Hub",description:"Full-screen wall hub"}),console.info("%c GLASS CARDS %c v0.1.0 ","color: white; background: #4FC3F7; font-weight: bold; padding: 2px 6px; border-radius: 4px 0 0 4px;","color: #4FC3F7; background: rgba(79,195,247,0.1); padding: 2px 6px; border-radius: 0 4px 4px 0;");
+    `],t([gt({reflect:!0,attribute:"data-theme"})],Le.prototype,"theme",void 0),t([gt({reflect:!0,type:Boolean})],Le.prototype,"kiosk",void 0),t([bt()],Le.prototype,"_page",void 0),t([bt()],Le.prototype,"_dragX",void 0),t([bt()],Le.prototype,"_openRoom",void 0),customElements.define("glass-hub",Le);const Ve=window;Ve.customCards=Ve.customCards||[],Ve.customCards.push({type:"glass-background",name:"Glass Background",description:"Animated gradient background"},{type:"glass-button",name:"Glass Button",description:"Toggle/info button"},{type:"glass-chip",name:"Glass Chip",description:"Small status pill"},{type:"glass-header",name:"Glass Header",description:"Greeting, weather, status chips"},{type:"glass-room-card",name:"Glass Room Card",description:"Room with sub-buttons and popup"},{type:"glass-light-slider",name:"Glass Light Slider",description:"Brightness slider with glow"},{type:"glass-popup",name:"Glass Popup",description:"Modal overlay"},{type:"glass-nav-bar",name:"Glass Nav Bar",description:"Bottom navigation"},{type:"glass-vacuum-card",name:"Glass Vacuum Card",description:"Vacuum controls"},{type:"glass-info-row",name:"Glass Info Row",description:"Information display"},{type:"glass-section",name:"Glass Section",description:"Section header label"},{type:"glass-departure-card",name:"Glass Departure Card",description:"Train departure list"},{type:"glass-hub",name:"Glass Hub",description:"Full-screen wall hub"}),console.info("%c GLASS CARDS %c v0.1.0 ","color: white; background: #4FC3F7; font-weight: bold; padding: 2px 6px; border-radius: 4px 0 0 4px;","color: #4FC3F7; background: rgba(79,195,247,0.1); padding: 2px 6px; border-radius: 0 4px 4px 0;");

--- a/glass-cards/scripts/hub-config.mjs
+++ b/glass-cards/scripts/hub-config.mjs
@@ -29,7 +29,7 @@ export const hubDashboard = {
         media_players: [
           { entity: 'media_player.arc_sub', name: 'Vardagsrum (Arc)' },
         ],
-        kcal: { today_entity: 'sensor.kcal_idag', forecast_entity: 'sensor.kcal_viktprognos' },
+        kcal: { today_entity: 'sensor.kcal_idag', forecast_entity: 'sensor.kcal_viktprognos', planner_entity: 'sensor.kcal_veckoplan' },
         rooms: [
           { id: 'vardagsrum', name: 'Vardagsrum', icon: 'sofa', main_entity: 'light.vardagsrum',
             lights: [ { entity: 'light.vardagsrum', name: 'Taklampa' }, { entity: 'light.tv', name: 'TV-lampa' } ] },

--- a/glass-cards/src/hub/glass-hub.ts
+++ b/glass-cards/src/hub/glass-hub.ts
@@ -17,10 +17,11 @@ import './pages/hub-lights-page.js';
 import './pages/hub-energy-page.js';
 import './pages/hub-media-page.js';
 import './pages/hub-kcal-page.js';
+import './pages/hub-planner-page.js';
 import './widgets/hub-room-popup.js';
 import './widgets/hub-nav-bar.js';
 
-const DEFAULT_PAGES = ['hem', 'ljus', 'media', 'energi', 'kcal'];
+const DEFAULT_PAGES = ['hem', 'ljus', 'media', 'energi', 'kcal', 'vecka'];
 
 const PAGE_TITLES: Record<string, string> = {
   hem: 'Hem',
@@ -28,6 +29,7 @@ const PAGE_TITLES: Record<string, string> = {
   media: 'Media',
   energi: 'Energi',
   kcal: 'Kcal',
+  vecka: 'Vecka',
 };
 
 function pageTitle(id: string): string {
@@ -431,7 +433,12 @@ export class GlassHub extends GlassBaseElement {
                             .hass=${this.hass}
                             .config=${this._cfg}
                           ></hub-kcal-page>`
-                        : html`<h1 class="page-placeholder">${pageTitle(id)}</h1>`}
+                        : id === 'vecka'
+                          ? html`<hub-planner-page
+                              .hass=${this.hass}
+                              .config=${this._cfg}
+                            ></hub-planner-page>`
+                          : html`<h1 class="page-placeholder">${pageTitle(id)}</h1>`}
             </section>
           `,
         )}

--- a/glass-cards/src/hub/hub-config.ts
+++ b/glass-cards/src/hub/hub-config.ts
@@ -25,7 +25,7 @@ export interface HubConfig extends LovelaceCardConfig {
   };
   rooms: HubRoom[];
   media_players: { entity: string; name: string }[];
-  kcal?: { today_entity: string; forecast_entity: string };
+  kcal?: { today_entity: string; forecast_entity: string; planner_entity?: string };
   scenes?: { entity: string; name: string; icon: string }[];
   idle_return_s?: number;           // default 120
   day_elevation?: number;           // default 4

--- a/glass-cards/src/hub/pages/hub-home-page.ts
+++ b/glass-cards/src/hub/pages/hub-home-page.ts
@@ -1,9 +1,10 @@
-import { html, css } from 'lit';
+import { html, css, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import { GlassBaseElement } from '../../glass-base-element.js';
 import { hubTokens } from '../../styles/tokens.js';
 import type { HubChipTone } from '../widgets/hub-status-chip.js';
 import type { HubConfig } from '../hub-config.js';
+import { buildPlannerModel, nextMeal, SLOT_LABELS } from '../planner-model.js';
 import '../widgets/hub-clock.js';
 import '../widgets/hub-status-chip.js';
 import '../widgets/hub-room-tile.js';
@@ -17,6 +18,7 @@ interface ChipDescriptor {
   label: string;
   tone: HubChipTone;
   active: boolean;
+  goto?: string; // tap navigates to this hub page
 }
 
 const VAC_LABELS: Record<string, string> = {
@@ -136,6 +138,12 @@ export class HubHomePage extends GlassBaseElement {
     `,
   ];
 
+  private _gotoPage(page: string): void {
+    this.dispatchEvent(
+      new CustomEvent('hub-goto-page', { detail: { page }, bubbles: true, composed: true }),
+    );
+  }
+
   private get _chips(): ChipDescriptor[] {
     const cfg = this.config;
     const chips: ChipDescriptor[] = [];
@@ -159,6 +167,26 @@ export class HubHomePage extends GlassBaseElement {
           label: VAC_LABELS[v.state] ?? 'Städar',
           tone: v.state === 'error' ? 'coral' : 'neutral',
           active: true,
+        });
+      }
+    }
+
+    // Next planned meal today — the meal planner's presence on Hem. Hidden
+    // when nothing is planned or everything is already logged.
+    if (cfg.kcal?.planner_entity) {
+      const entity = this.getEntity(cfg.kcal.planner_entity);
+      const model =
+        entity && entity.state !== 'unavailable' && entity.state !== 'unknown'
+          ? buildPlannerModel(entity.attributes as Record<string, unknown>)
+          : null;
+      const next = model ? nextMeal(model) : null;
+      if (next) {
+        chips.push({
+          icon: 'calendar',
+          label: `${SLOT_LABELS[next.meal.slot]} · ${next.meal.name}`,
+          tone: 'lavender',
+          active: true,
+          goto: 'vecka',
         });
       }
     }
@@ -190,10 +218,12 @@ export class HubHomePage extends GlassBaseElement {
             ${this._chips.map(
               (c) => html`
                 <hub-status-chip
+                  style=${c.goto ? 'cursor:pointer' : ''}
                   .icon=${c.icon}
                   .label=${c.label}
                   .tone=${c.tone}
                   ?active=${c.active}
+                  @click=${c.goto ? () => this._gotoPage(c.goto!) : nothing}
                 ></hub-status-chip>
               `,
             )}

--- a/glass-cards/src/hub/pages/hub-planner-page.ts
+++ b/glass-cards/src/hub/pages/hub-planner-page.ts
@@ -1,0 +1,438 @@
+import { html, css, nothing, type TemplateResult } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { GlassBaseElement } from '../../glass-base-element.js';
+import { hubTokens } from '../../styles/tokens.js';
+import {
+  buildPlannerModel,
+  dayTypeLetter,
+  SLOT_LABELS,
+  SLOT_ORDER,
+  type PlannerDay,
+  type PlannerModel,
+} from '../planner-model.js';
+import type { HubConfig } from '../hub-config.js';
+
+const NUM_FMT = new Intl.NumberFormat('sv-SE');
+const LONG_DATE = new Intl.DateTimeFormat('sv-SE', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+  timeZone: 'UTC',
+});
+
+/** Time to let the confirm POST land before refreshing the REST sensor. */
+const REFRESH_DELAY_MS = 1500;
+
+export class HubPlannerPage extends GlassBaseElement {
+  @property({ attribute: false }) config!: HubConfig;
+
+  @state() private _openDate: string | null = null;
+  @state() private _confirming = false;
+
+  static styles = [
+    hubTokens,
+    css`
+      :host {
+        display: block;
+        height: 100%;
+      }
+      .page {
+        box-sizing: border-box;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        padding: var(--hub-page-pad);
+        padding-bottom: clamp(48px, 6vh, 66px);
+      }
+
+      .header {
+        padding-right: 56px;
+        margin-bottom: clamp(14px, 2vh, 22px);
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .title {
+        margin: 0;
+        font: 200 clamp(30px, 4.4vw, 46px) var(--hub-font-display);
+        letter-spacing: -0.02em;
+        color: var(--hub-text);
+      }
+      .subtitle {
+        font: 500 14px var(--hub-font-body);
+        color: var(--hub-text-dim);
+      }
+
+      /* ── Week grid ─────────────────────────────────────────── */
+      .grid {
+        flex: 1;
+        min-height: 0;
+        display: grid;
+        grid-template-columns: repeat(7, 1fr);
+        gap: clamp(8px, 1vw, 14px);
+      }
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .day {
+        box-sizing: border-box;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        padding: clamp(10px, 1.2vw, 16px);
+        border-radius: var(--hub-radius-lg);
+        background: var(--hub-lavender-bg);
+        border: 1px solid var(--hub-lavender-border);
+        box-shadow: var(--hub-shadow);
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+        text-align: left;
+        font: inherit;
+        color: inherit;
+      }
+      .day.today {
+        border-color: var(--hub-lavender);
+      }
+      .day.confirmed {
+        opacity: 0.78;
+      }
+
+      .day-head {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+      .day-name {
+        font: 600 13px var(--hub-font-body);
+        color: var(--hub-text);
+        text-transform: capitalize;
+      }
+      .day-date {
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-dim);
+        font-variant-numeric: tabular-nums;
+      }
+      .day-flex {
+        flex: 1;
+      }
+      .type-chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        font: 600 11px var(--hub-font-body);
+        background: var(--hub-chip-bg);
+        border: 1px solid var(--hub-chip-border);
+        color: var(--hub-text-muted);
+        flex-shrink: 0;
+      }
+      .type-chip.gymdag {
+        background: var(--hub-green-bg);
+        border-color: var(--hub-green-border);
+        color: var(--hub-green);
+      }
+      .type-chip.flexdag {
+        background: var(--hub-teal-bg);
+        border-color: var(--hub-teal-border);
+        color: var(--hub-teal);
+      }
+      .lock {
+        font: 600 12px var(--hub-font-body);
+        color: var(--hub-green);
+      }
+
+      .slots {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .slot-label {
+        font: 600 10px var(--hub-font-body);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--hub-text-dim);
+      }
+      .meal {
+        display: flex;
+        flex-direction: column;
+        margin-top: 2px;
+      }
+      .meal-name {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-text);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .meal-name.logged {
+        color: var(--hub-text-dim);
+      }
+      .meal-kcal {
+        font: 500 11px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .empty-day {
+        font: 400 12px var(--hub-font-body);
+        color: var(--hub-text-dim);
+      }
+
+      .day-foot {
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid color-mix(in srgb, var(--hub-lavender-border) 55%, transparent);
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .day-foot .warn {
+        color: var(--hub-coral);
+      }
+
+      /* ── Day popup ─────────────────────────────────────────── */
+      .scrim {
+        position: fixed;
+        inset: 0;
+        background: color-mix(in srgb, var(--hub-surface) 62%, transparent);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        z-index: 40;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .popup {
+        box-sizing: border-box;
+        width: min(560px, 94vw);
+        max-height: 86vh;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        padding: clamp(20px, 3vw, 32px);
+        border-radius: var(--hub-radius-lg);
+        background: var(--hub-card);
+        border: 1px solid var(--hub-lavender-border);
+        box-shadow: var(--hub-shadow);
+      }
+      .popup-title {
+        margin: 0 0 4px;
+        font: 300 clamp(24px, 3.4vw, 32px) var(--hub-font-display);
+        color: var(--hub-text);
+      }
+      .popup-title::first-letter {
+        text-transform: uppercase;
+      }
+      .popup-sub {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-text-dim);
+        margin-bottom: 14px;
+      }
+      .pm {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 12px;
+        padding: 9px 0;
+        border-top: 1px solid color-mix(in srgb, var(--hub-lavender-border) 55%, transparent);
+      }
+      .pm-name {
+        font: 500 15px var(--hub-font-body);
+        color: var(--hub-text);
+      }
+      .pm-slot {
+        font: 600 10px var(--hub-font-body);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--hub-text-dim);
+        display: block;
+      }
+      .pm-macro {
+        flex-shrink: 0;
+        text-align: right;
+        font: 500 12px var(--hub-font-body);
+        color: var(--hub-text-muted);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .popup-actions {
+        margin-top: 18px;
+        display: flex;
+        gap: 12px;
+        justify-content: flex-end;
+      }
+      .btn {
+        font: 600 14px var(--hub-font-body);
+        padding: 12px 22px;
+        border-radius: var(--hub-radius-pill);
+        border: 1px solid var(--hub-chip-border);
+        background: var(--hub-chip-bg);
+        color: var(--hub-text-muted);
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .btn.primary {
+        background: var(--hub-lavender-bg);
+        border-color: var(--hub-lavender-border);
+        color: var(--hub-lavender-text);
+      }
+      .btn:disabled {
+        opacity: 0.5;
+      }
+      .confirmed-note {
+        font: 500 13px var(--hub-font-body);
+        color: var(--hub-green);
+        align-self: center;
+        margin-right: auto;
+      }
+
+      /* ── Offline ───────────────────────────────────────────── */
+      .offline {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font: 300 clamp(26px, 4vw, 38px) var(--hub-font-display);
+        color: var(--hub-text-muted);
+      }
+    `,
+  ];
+
+  private _model(): PlannerModel | null {
+    const id = this.config?.kcal?.planner_entity;
+    if (!id) return null;
+    const entity = this.getEntity(id);
+    if (!entity || entity.state === 'unavailable' || entity.state === 'unknown') return null;
+    return buildPlannerModel(entity.attributes as Record<string, unknown>);
+  }
+
+  private _confirm(day: PlannerDay): void {
+    if (this._confirming || day.confirmed || day.meals.length === 0) return;
+    this._confirming = true;
+    this.callService('rest_command', 'kcal_confirm_day', { date: day.date });
+    // Give the POST a moment to land, then refresh the sensor for feedback.
+    window.setTimeout(() => {
+      const id = this.config?.kcal?.planner_entity;
+      if (id) this.callService('homeassistant', 'update_entity', undefined, id);
+      this._confirming = false;
+      this._openDate = null;
+    }, REFRESH_DELAY_MS);
+  }
+
+  private _dayPopup(model: PlannerModel): TemplateResult | typeof nothing {
+    const day = model.days.find((d) => d.date === this._openDate);
+    if (!day) return nothing;
+    const dateLabel = LONG_DATE.format(new Date(`${day.date}T00:00:00Z`));
+    const canConfirm = !day.confirmed && day.meals.some((m) => !m.logged);
+    return html`
+      <div class="scrim" @click=${() => (this._openDate = null)}>
+        <div class="popup" @click=${(e: Event) => e.stopPropagation()}>
+          <h2 class="popup-title">${dateLabel}</h2>
+          <div class="popup-sub">
+            ${day.day_type} · ${NUM_FMT.format(day.total_kcal)} / ${NUM_FMT.format(day.target_kcal)} kcal
+            ${day.confirmed ? ' · bekräftad ✓' : ''}
+          </div>
+          ${day.meals.map(
+            (m) => html`
+              <div class="pm">
+                <div>
+                  <span class="pm-slot">${SLOT_LABELS[m.slot]}${m.logged ? ' · loggad' : ''}</span>
+                  <span class="pm-name">${m.name}</span>
+                </div>
+                <span class="pm-macro">
+                  ${NUM_FMT.format(m.kcal)} kcal<br />
+                  P ${NUM_FMT.format(m.protein)} · F ${NUM_FMT.format(m.fat)} · K ${NUM_FMT.format(m.carbs)}
+                </span>
+              </div>
+            `,
+          )}
+          ${day.meals.length === 0 ? html`<div class="empty-day">Inget planerat.</div>` : nothing}
+          <div class="popup-actions">
+            ${day.confirmed ? html`<span class="confirmed-note">Dagen är låst ✓</span>` : nothing}
+            <button class="btn" @click=${() => (this._openDate = null)}>Stäng</button>
+            ${canConfirm
+              ? html`
+                  <button class="btn primary" ?disabled=${this._confirming} @click=${() => this._confirm(day)}>
+                    ${this._confirming ? 'Bekräftar…' : 'Bekräfta dagen'}
+                  </button>
+                `
+              : nothing}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private _dayCard(day: PlannerDay, today: string): TemplateResult {
+    const slots = SLOT_ORDER.filter((slot) => day.meals.some((m) => m.slot === slot));
+    return html`
+      <button
+        class="day${day.date === today ? ' today' : ''}${day.confirmed ? ' confirmed' : ''}"
+        @click=${() => (this._openDate = day.date)}
+      >
+        <div class="day-head">
+          <span class="day-name">${day.weekday.slice(0, 3)}</span>
+          <span class="day-date">${day.date.slice(8)}</span>
+          <span class="day-flex"></span>
+          ${day.confirmed ? html`<span class="lock">✓</span>` : nothing}
+          <span class="type-chip ${day.day_type}">${dayTypeLetter(day.day_type)}</span>
+        </div>
+        <div class="slots">
+          ${slots.length === 0 ? html`<span class="empty-day">—</span>` : nothing}
+          ${slots.map(
+            (slot) => html`
+              <div>
+                <span class="slot-label">${SLOT_LABELS[slot]}</span>
+                ${day.meals
+                  .filter((m) => m.slot === slot)
+                  .map(
+                    (m) => html`
+                      <div class="meal">
+                        <span class="meal-name${m.logged ? ' logged' : ''}">${m.name}</span>
+                        <span class="meal-kcal">${NUM_FMT.format(m.kcal)} kcal</span>
+                      </div>
+                    `,
+                  )}
+              </div>
+            `,
+          )}
+        </div>
+        <div class="day-foot">
+          ${day.meals.length > 0
+            ? html`${NUM_FMT.format(day.total_kcal)} / ${NUM_FMT.format(day.target_kcal)}
+              ${!day.kcal_ok || !day.protein_ok ? html`<span class="warn"> ⚠</span>` : nothing}`
+            : html`&nbsp;`}
+        </div>
+      </button>
+    `;
+  }
+
+  render(): TemplateResult {
+    if (!this.hass || !this.config) return html``;
+    const model = this._model();
+    if (!model) {
+      return html`<div class="page"><div class="offline">Vecka · offline</div></div>`;
+    }
+    return html`
+      <div class="page">
+        <div class="header">
+          <h1 class="title">Vecka</h1>
+          <span class="subtitle">${model.confirmedDays} / 7 bekräftade</span>
+        </div>
+        <div class="grid">${model.days.map((d) => this._dayCard(d, model.today))}</div>
+      </div>
+      ${this._openDate ? this._dayPopup(model) : nothing}
+    `;
+  }
+}
+
+customElements.define('hub-planner-page', HubPlannerPage);

--- a/glass-cards/src/hub/planner-model.ts
+++ b/glass-cards/src/hub/planner-model.ts
@@ -1,0 +1,118 @@
+// Transforms the kcal-veckoplan REST sensor (kcal-assistant /internal/planner)
+// into the shape the Vecka page and the Hem chip render. The sensor exposes
+// `week_start` / `today` / `days`; day/meal shapes mirror InternalPlannerDay
+// on the server. Malformed or unavailable data → null (page shows offline).
+
+export type PlannerSlot = 'frukost' | 'lunch' | 'middag' | 'mellis';
+
+export interface PlannerMeal {
+  slot: PlannerSlot;
+  name: string;
+  kcal: number;
+  protein: number;
+  fat: number;
+  carbs: number;
+  logged: boolean;
+}
+
+export interface PlannerDay {
+  date: string;
+  weekday: string;
+  day_type: string;
+  confirmed: boolean;
+  meals: PlannerMeal[];
+  total_kcal: number;
+  target_kcal: number;
+  protein_ok: boolean;
+  kcal_ok: boolean;
+}
+
+export interface PlannerModel {
+  weekStart: string;
+  today: string;
+  confirmedDays: number;
+  days: PlannerDay[];
+}
+
+export const SLOT_LABELS: Record<PlannerSlot, string> = {
+  frukost: 'Frukost',
+  lunch: 'Lunch',
+  middag: 'Middag',
+  mellis: 'Mellis',
+};
+
+export const SLOT_ORDER: readonly PlannerSlot[] = ['frukost', 'lunch', 'middag', 'mellis'];
+
+const DAY_TYPE_LETTER: Record<string, string> = { gymdag: 'G', vilodag: 'V', flexdag: 'F' };
+
+export function dayTypeLetter(dayType: string): string {
+  return DAY_TYPE_LETTER[dayType] ?? '·';
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isSlot(value: unknown): value is PlannerSlot {
+  return value === 'frukost' || value === 'lunch' || value === 'middag' || value === 'mellis';
+}
+
+function parseMeal(raw: unknown): PlannerMeal | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const m = raw as Record<string, unknown>;
+  if (!isSlot(m.slot) || typeof m.name !== 'string' || m.name === '') return null;
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+  return {
+    slot: m.slot,
+    name: m.name,
+    kcal: num(m.kcal),
+    protein: num(m.protein),
+    fat: num(m.fat),
+    carbs: num(m.carbs),
+    logged: m.logged === true,
+  };
+}
+
+function parseDay(raw: unknown): PlannerDay | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const d = raw as Record<string, unknown>;
+  if (typeof d.date !== 'string' || !DATE_RE.test(d.date)) return null;
+  const meals = Array.isArray(d.meals)
+    ? d.meals.map(parseMeal).filter((m): m is PlannerMeal => m !== null)
+    : [];
+  return {
+    date: d.date,
+    weekday: typeof d.weekday === 'string' ? d.weekday : '',
+    day_type: typeof d.day_type === 'string' ? d.day_type : 'vilodag',
+    confirmed: d.confirmed === true,
+    meals,
+    total_kcal: typeof d.total_kcal === 'number' ? d.total_kcal : 0,
+    target_kcal: typeof d.target_kcal === 'number' ? d.target_kcal : 0,
+    protein_ok: d.protein_ok === true,
+    kcal_ok: d.kcal_ok !== false,
+  };
+}
+
+export function buildPlannerModel(attributes: Record<string, unknown> | undefined): PlannerModel | null {
+  if (!attributes) return null;
+  const { week_start, today, days } = attributes;
+  if (typeof week_start !== 'string' || !DATE_RE.test(week_start)) return null;
+  if (!Array.isArray(days)) return null;
+  const parsed = days.map(parseDay).filter((d): d is PlannerDay => d !== null);
+  if (parsed.length === 0) return null;
+  return {
+    weekStart: week_start,
+    today: typeof today === 'string' && DATE_RE.test(today) ? today : week_start,
+    confirmedDays: parsed.filter((d) => d.confirmed).length,
+    days: parsed,
+  };
+}
+
+/** The Hem chip: today's first unlogged planned meal, or null (chip hidden). */
+export function nextMeal(model: PlannerModel): { day: PlannerDay; meal: PlannerMeal } | null {
+  const day = model.days.find((d) => d.date === model.today);
+  if (!day) return null;
+  for (const slot of SLOT_ORDER) {
+    const meal = day.meals.find((m) => m.slot === slot && !m.logged);
+    if (meal) return { day, meal };
+  }
+  return null;
+}

--- a/glass-cards/src/hub/widgets/hub-nav-bar.ts
+++ b/glass-cards/src/hub/widgets/hub-nav-bar.ts
@@ -21,6 +21,7 @@ const NAV_MAP: Record<string, Omit<NavItem, 'id'>> = {
   media: { label: 'Media', icon: 'note', tone: 'teal' },
   energi: { label: 'Energi', icon: 'bolt', tone: 'green' },
   kcal: { label: 'Kcal', icon: 'ring', tone: 'lavender' },
+  vecka: { label: 'Vecka', icon: 'calendar', tone: 'lavender' },
 };
 
 /** Page id → tab bar item (label, icon, domain tone). Unknown ids fall back to

--- a/glass-cards/src/hub/widgets/icons.ts
+++ b/glass-cards/src/hub/widgets/icons.ts
@@ -116,6 +116,15 @@ export const icons: Record<string, TemplateResult> = {
     <circle cx="12" cy="12" r="8.5"></circle>
     <path d="M12 7.5V12l3 2"></path>
   `),
+  calendar: wrap(svg`
+    <rect x="4" y="5.5" width="16" height="14.5" rx="2"></rect>
+    <path d="M4 10h16"></path>
+    <path d="M8 3.5v3"></path>
+    <path d="M16 3.5v3"></path>
+    <path d="M8.5 14h2"></path>
+    <path d="M13.5 14h2"></path>
+    <path d="M8.5 17h2"></path>
+  `),
   expand: wrap(svg`
     <path d="M8 4H5a1 1 0 0 0-1 1v3"></path>
     <path d="M16 4h3a1 1 0 0 1 1 1v3"></path>

--- a/glass-cards/test/planner-model.test.ts
+++ b/glass-cards/test/planner-model.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlannerModel, nextMeal, dayTypeLetter } from '../src/hub/planner-model';
+
+const day = (date: string, overrides: Record<string, unknown> = {}) => ({
+  date,
+  weekday: 'måndag',
+  day_type: 'vilodag',
+  confirmed: false,
+  meals: [],
+  total_kcal: 0,
+  target_kcal: 2000,
+  protein_ok: false,
+  kcal_ok: true,
+  ...overrides,
+});
+
+const meal = (slot: string, name: string, overrides: Record<string, unknown> = {}) => ({
+  slot,
+  name,
+  kcal: 500,
+  protein: 40,
+  fat: 15,
+  carbs: 45,
+  logged: false,
+  ...overrides,
+});
+
+describe('buildPlannerModel', () => {
+  it('parses a valid payload and counts confirmed days', () => {
+    const model = buildPlannerModel({
+      week_start: '2026-07-13',
+      today: '2026-07-15',
+      days: [
+        day('2026-07-13', { confirmed: true }),
+        day('2026-07-14'),
+        day('2026-07-15', { meals: [meal('middag', 'Lax')] }),
+      ],
+    });
+    expect(model).not.toBeNull();
+    expect(model!.weekStart).toBe('2026-07-13');
+    expect(model!.today).toBe('2026-07-15');
+    expect(model!.confirmedDays).toBe(1);
+    expect(model!.days[2].meals[0].name).toBe('Lax');
+  });
+
+  it('rejects malformed payloads', () => {
+    expect(buildPlannerModel(undefined)).toBeNull();
+    expect(buildPlannerModel({})).toBeNull();
+    expect(buildPlannerModel({ week_start: 'nyss', days: [] })).toBeNull();
+    expect(buildPlannerModel({ week_start: '2026-07-13', days: 'nej' })).toBeNull();
+    expect(buildPlannerModel({ week_start: '2026-07-13', days: [{ date: 'trasig' }] })).toBeNull();
+  });
+
+  it('drops broken meals but keeps the day', () => {
+    const model = buildPlannerModel({
+      week_start: '2026-07-13',
+      today: '2026-07-13',
+      days: [day('2026-07-13', { meals: [meal('middag', 'Hel'), { slot: 'brunch', name: 'Fel' }, null] })],
+    });
+    expect(model!.days[0].meals).toHaveLength(1);
+  });
+});
+
+describe('nextMeal', () => {
+  it('returns the first unlogged meal today in slot order', () => {
+    const model = buildPlannerModel({
+      week_start: '2026-07-13',
+      today: '2026-07-13',
+      days: [
+        day('2026-07-13', {
+          meals: [
+            meal('middag', 'Lax'),
+            meal('frukost', 'Gröt', { logged: true }),
+            meal('lunch', 'Sallad'),
+          ],
+        }),
+      ],
+    })!;
+    expect(nextMeal(model)!.meal.name).toBe('Sallad');
+  });
+
+  it('returns null when everything is logged or today is missing', () => {
+    const allLogged = buildPlannerModel({
+      week_start: '2026-07-13',
+      today: '2026-07-13',
+      days: [day('2026-07-13', { meals: [meal('middag', 'Lax', { logged: true })] })],
+    })!;
+    expect(nextMeal(allLogged)).toBeNull();
+
+    const otherWeek = buildPlannerModel({
+      week_start: '2026-07-13',
+      today: '2026-07-20',
+      days: [day('2026-07-13', { meals: [meal('middag', 'Lax')] })],
+    })!;
+    expect(nextMeal(otherWeek)).toBeNull();
+  });
+});
+
+describe('dayTypeLetter', () => {
+  it('maps the three day types and falls back to a dot', () => {
+    expect(dayTypeLetter('gymdag')).toBe('G');
+    expect(dayTypeLetter('vilodag')).toBe('V');
+    expect(dayTypeLetter('flexdag')).toBe('F');
+    expect(dayTypeLetter('festdag')).toBe('·');
+  });
+});

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -165,6 +165,41 @@ const MIGRATIONS: string[] = [
     curve_json         TEXT NOT NULL
   );
   `,
+  // 6: week meal planner — planned meals per date+slot, raw-input items
+  // (recipe_ingredients shape, resolved live), day confirm state. Confirm
+  // copies planned meals into `meals` and records the link in logged_meal_id.
+  `
+  CREATE TABLE planned_meals (
+    id              INTEGER PRIMARY KEY,
+    day_date        TEXT NOT NULL REFERENCES days(date),
+    slot            TEXT NOT NULL CHECK (slot IN ('frukost','lunch','middag','mellis')),
+    position        INTEGER NOT NULL DEFAULT 0,
+    name            TEXT NOT NULL,
+    recipe_id       INTEGER REFERENCES recipes(id) ON DELETE SET NULL,
+    recipe_servings REAL,
+    post_gym_shake  INTEGER NOT NULL DEFAULT 0,
+    logged_meal_id  INTEGER REFERENCES meals(id) ON DELETE SET NULL,
+    note            TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX idx_planned_meals_day ON planned_meals(day_date);
+
+  CREATE TABLE planned_meal_items (
+    id              INTEGER PRIMARY KEY,
+    planned_meal_id INTEGER NOT NULL REFERENCES planned_meals(id) ON DELETE CASCADE,
+    position        INTEGER NOT NULL,
+    product_id      INTEGER REFERENCES products(id) ON DELETE SET NULL,
+    description     TEXT NOT NULL,
+    grams REAL, quantity REAL, portion_name TEXT,
+    kcal REAL, protein REAL, fat REAL, carbs REAL,
+    CHECK ((kcal IS NULL) = (protein IS NULL) AND (kcal IS NULL) = (fat IS NULL)
+       AND (kcal IS NULL) = (carbs IS NULL))
+  );
+  CREATE INDEX idx_planned_items_meal ON planned_meal_items(planned_meal_id);
+
+  ALTER TABLE days ADD COLUMN plan_confirmed_at TEXT;
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/plan.ts
+++ b/kcal-assistant/src/db/plan.ts
@@ -1,0 +1,416 @@
+import type { Database } from "bun:sqlite";
+import { type Macros, scaleMacros, sumMacros } from "../lib/macros";
+import { resolveItem, type MealItemInput, type DayView, getDay } from "./meals";
+import { getRecipe, reconstructInput, type IngredientRow } from "./recipes";
+import { getTargetsFor, type DayTargets } from "./preferences";
+import { todayStockholm, isValidDate, toEpochDays, epochDaysToDate, addDays } from "../lib/dates";
+
+export type PlanSlot = "frukost" | "lunch" | "middag" | "mellis";
+
+export const PLAN_SLOTS: readonly PlanSlot[] = ["frukost", "lunch", "middag", "mellis"];
+
+const WEEKDAYS = ["måndag", "tisdag", "onsdag", "torsdag", "fredag", "lördag", "söndag"] as const;
+
+export interface PlannedMealInput {
+  slot: PlanSlot;
+  name: string;
+  recipe_id?: number;
+  recipe_servings?: number;
+  items?: MealItemInput[];
+  post_gym_shake?: boolean;
+  note?: string;
+}
+
+export interface PlanDayInput {
+  date: string;
+  day_type?: string;
+  clear_slots?: PlanSlot[];
+  meals?: PlannedMealInput[];
+}
+
+export interface PlannedItemView {
+  product_id: number | null;
+  description: string;
+  grams: number | null;
+  quantity: number | null;
+  portion_name: string | null;
+  /** Raw ad-hoc input macros (only on ad-hoc rows) — lets the UI rebuild slots losslessly. */
+  macros?: Macros;
+  kcal?: number;
+  protein?: number;
+  fat?: number;
+  carbs?: number;
+  unresolved?: true;
+  reason?: string;
+}
+
+export interface PlannedMealView extends Macros {
+  id: number;
+  slot: PlanSlot;
+  position: number;
+  name: string;
+  recipe_id: number | null;
+  recipe_servings: number | null;
+  post_gym_shake: boolean;
+  note: string | null;
+  logged: boolean;
+  totals_incomplete?: true;
+  items?: PlannedItemView[];
+}
+
+export interface PlanDayView {
+  date: string;
+  weekday: string;
+  day_type: string;
+  targets: DayTargets;
+  confirmed: boolean;
+  confirmed_at: string | null;
+  meals: PlannedMealView[];
+  totals: Macros;
+  remaining: { kcal: number; protein_to_min: number; fat_to_min: number; carbs: number | null };
+  checks: { kcal_ok: boolean; protein_floor_ok: boolean; fat_floor_ok: boolean };
+  warning?: string;
+}
+
+export interface PlanWeekView {
+  start_date: string;
+  end_date: string;
+  days: PlanDayView[];
+  week: {
+    planned_days: number;
+    confirmed_days: number;
+    avg_planned_kcal: number | null;
+    avg_target_kcal: number;
+  };
+}
+
+/** Monday of the week containing `date`. Epoch day 0 (1970-01-01) was a Thursday. */
+export function mondayOf(date: string): string {
+  const days = toEpochDays(date);
+  const weekdayIndex = (((days + 3) % 7) + 7) % 7; // 0 = Monday
+  return epochDaysToDate(days - weekdayIndex);
+}
+
+export function weekdayName(date: string): string {
+  const index = (((toEpochDays(date) + 3) % 7) + 7) % 7;
+  return WEEKDAYS[index]!;
+}
+
+function assertSlot(slot: string): asserts slot is PlanSlot {
+  if (!PLAN_SLOTS.includes(slot as PlanSlot)) {
+    throw new Error(`Ogiltig måltidslucka: ${slot} (giltiga: ${PLAN_SLOTS.join(", ")})`);
+  }
+}
+
+interface PlannedMealRow {
+  id: number;
+  day_date: string;
+  slot: PlanSlot;
+  position: number;
+  name: string;
+  recipe_id: number | null;
+  recipe_servings: number | null;
+  post_gym_shake: number;
+  logged_meal_id: number | null;
+  note: string | null;
+}
+
+interface PlannedItemRow extends IngredientRow {
+  id: number;
+}
+
+interface ResolvedPlannedMeal {
+  macros: Macros;
+  incomplete: boolean;
+  items: PlannedItemView[];
+  /** For confirm: the meal_items to insert (explicit macros — rounding already applied once). */
+  loggableItems: MealItemInput[];
+  incompleteReasons: string[];
+}
+
+// Live resolution, mirroring getRecipe: product edits propagate into the plan;
+// unresolvable rows are flagged and contribute nothing to the totals.
+function resolvePlannedMeal(db: Database, meal: PlannedMealRow): ResolvedPlannedMeal {
+  if (meal.recipe_id !== null || meal.recipe_servings !== null) {
+    const servings = meal.recipe_servings ?? 1;
+    const recipe = meal.recipe_id !== null ? getRecipe(db, meal.recipe_id) : null;
+    if (!recipe) {
+      return {
+        macros: { kcal: 0, protein: 0, fat: 0, carbs: 0 },
+        incomplete: true,
+        items: [],
+        loggableItems: [],
+        incompleteReasons: ["receptet har tagits bort"],
+      };
+    }
+    const base = recipe.servings !== null && recipe.servings > 0 ? recipe.per_serving! : recipe.totals;
+    const macros = scaleMacros(base, servings);
+    const unit = recipe.servings !== null && recipe.servings > 0 ? "port" : "sats";
+    const description = `${recipe.name} (${servings} ${unit})`;
+    return {
+      macros,
+      incomplete: recipe.totals_incomplete === true,
+      items: [],
+      loggableItems: [{ description, macros }],
+      incompleteReasons: recipe.totals_incomplete ? [`receptet "${recipe.name}" har olösta ingredienser`] : [],
+    };
+  }
+
+  const rows = db
+    .query<PlannedItemRow, [number]>(
+      "SELECT id, product_id, description, grams, quantity, portion_name, kcal, protein, fat, carbs FROM planned_meal_items WHERE planned_meal_id = ? ORDER BY position, id",
+    )
+    .all(meal.id);
+
+  const items: PlannedItemView[] = [];
+  const loggableItems: MealItemInput[] = [];
+  const resolved: Macros[] = [];
+  const incompleteReasons: string[] = [];
+
+  for (const row of rows) {
+    const isAdhoc = row.kcal !== null;
+    const base: PlannedItemView = {
+      product_id: row.product_id,
+      description: row.description,
+      grams: row.grams,
+      quantity: row.quantity,
+      portion_name: row.portion_name,
+    };
+    if (isAdhoc) {
+      base.macros = { kcal: row.kcal!, protein: row.protein!, fat: row.fat!, carbs: row.carbs! };
+    }
+    if (!isAdhoc && row.product_id === null) {
+      items.push({ ...base, unresolved: true, reason: "produkten har tagits bort" });
+      incompleteReasons.push(`${row.description}: produkten har tagits bort`);
+      continue;
+    }
+    try {
+      const r = resolveItem(db, reconstructInput(row));
+      items.push({ ...base, description: r.description, ...r.macros });
+      resolved.push(r.macros);
+      loggableItems.push({
+        description: r.description,
+        grams: r.grams ?? undefined,
+        quantity: r.quantity ?? undefined,
+        product_id: r.product_id ?? undefined,
+        macros: r.macros,
+      });
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      items.push({ ...base, unresolved: true, reason });
+      incompleteReasons.push(`${row.description}: ${reason}`);
+    }
+  }
+
+  return {
+    macros: sumMacros(resolved),
+    incomplete: incompleteReasons.length > 0,
+    items,
+    loggableItems,
+    incompleteReasons,
+  };
+}
+
+function readPlannedMealRows(db: Database, date: string): PlannedMealRow[] {
+  return db
+    .query<PlannedMealRow, [string]>(
+      `SELECT id, day_date, slot, position, name, recipe_id, recipe_servings, post_gym_shake, logged_meal_id, note
+       FROM planned_meals WHERE day_date = ?
+       ORDER BY CASE slot WHEN 'frukost' THEN 0 WHEN 'lunch' THEN 1 WHEN 'middag' THEN 2 ELSE 3 END, position, id`,
+    )
+    .all(date);
+}
+
+// Read-only (no ensureDay) — the UI/internal read guarantee depends on this.
+export function readPlanDay(db: Database, date: string, includeItems = false): PlanDayView {
+  if (!isValidDate(date)) throw new Error(`Invalid date: ${date} (expected YYYY-MM-DD)`);
+  const dayRow = db
+    .query<{ day_type: string; plan_confirmed_at: string | null }, [string]>(
+      "SELECT day_type, plan_confirmed_at FROM days WHERE date = ?",
+    )
+    .get(date);
+  const dayType = dayRow?.day_type ?? "vilodag";
+  const targets = getTargetsFor(db, dayType);
+  const confirmedAt = dayRow?.plan_confirmed_at ?? null;
+
+  const meals: PlannedMealView[] = readPlannedMealRows(db, date).map((row) => {
+    const r = resolvePlannedMeal(db, row);
+    return {
+      id: row.id,
+      slot: row.slot,
+      position: row.position,
+      name: row.name,
+      recipe_id: row.recipe_id,
+      recipe_servings: row.recipe_servings,
+      post_gym_shake: row.post_gym_shake === 1,
+      note: row.note,
+      logged: row.logged_meal_id !== null,
+      ...(r.incomplete && { totals_incomplete: true as const }),
+      ...(includeItems && { items: r.items }),
+      ...r.macros,
+    };
+  });
+
+  const totals = sumMacros(meals);
+  const r1 = (x: number) => Math.round(x * 10) / 10;
+  return {
+    date,
+    weekday: weekdayName(date),
+    day_type: dayType,
+    targets,
+    confirmed: confirmedAt !== null,
+    confirmed_at: confirmedAt,
+    meals,
+    totals,
+    remaining: {
+      kcal: targets.kcal - totals.kcal,
+      protein_to_min: Math.max(0, r1(targets.protein_min - totals.protein)),
+      fat_to_min: Math.max(0, r1(targets.fat_min - totals.fat)),
+      carbs: targets.carbs === null ? null : r1(targets.carbs - totals.carbs),
+    },
+    checks: {
+      kcal_ok: totals.kcal <= targets.kcal,
+      protein_floor_ok: totals.protein >= targets.protein_min,
+      fat_floor_ok: totals.fat >= targets.fat_min,
+    },
+  };
+}
+
+function validatePlannedMeal(db: Database, meal: PlannedMealInput): void {
+  assertSlot(meal.slot);
+  if (!meal.name || meal.name.trim() === "") throw new Error("En planerad måltid behöver ett namn");
+  const hasRecipe = meal.recipe_id !== undefined;
+  const hasItems = meal.items !== undefined;
+  if (hasRecipe === hasItems) {
+    throw new Error(`"${meal.name}": ange antingen recipe_id + recipe_servings ELLER items`);
+  }
+  if (hasRecipe) {
+    if (meal.recipe_servings === undefined || !(meal.recipe_servings > 0)) {
+      throw new Error(`"${meal.name}": recipe_servings måste vara ett positivt tal`);
+    }
+    if (!getRecipe(db, meal.recipe_id!)) throw new Error(`Recept ${meal.recipe_id} finns inte`);
+  } else {
+    if (meal.items!.length === 0) throw new Error(`"${meal.name}" behöver minst en item`);
+    for (const item of meal.items!) resolveItem(db, item); // fail-early validation
+  }
+}
+
+function insertPlannedMeal(db: Database, date: string, meal: PlannedMealInput): void {
+  const next = db
+    .query<{ p: number | null }, [string, string]>(
+      "SELECT max(position) AS p FROM planned_meals WHERE day_date = ? AND slot = ?",
+    )
+    .get(date, meal.slot);
+  const position = (next?.p ?? -1) + 1;
+  const result = db.run(
+    `INSERT INTO planned_meals (day_date, slot, position, name, recipe_id, recipe_servings, post_gym_shake, note)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      date,
+      meal.slot,
+      position,
+      meal.name,
+      meal.recipe_id ?? null,
+      meal.recipe_id !== undefined ? (meal.recipe_servings ?? null) : null,
+      meal.post_gym_shake ? 1 : 0,
+      meal.note ?? null,
+    ],
+  );
+  const mealId = Number(result.lastInsertRowid);
+  for (const [position, ing] of (meal.items ?? []).entries()) {
+    const resolved = resolveItem(db, ing);
+    const isAdhoc = ing.macros !== undefined;
+    db.run(
+      `INSERT INTO planned_meal_items
+         (planned_meal_id, position, product_id, description, grams, quantity, portion_name, kcal, protein, fat, carbs)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        mealId,
+        position,
+        ing.product_id ?? null,
+        resolved.description,
+        // verbatim input: portion items keep grams NULL (recipe_ingredients convention)
+        isAdhoc || ing.portion_name === undefined ? (ing.grams ?? null) : null,
+        ing.quantity ?? null,
+        isAdhoc ? null : (ing.portion_name ?? null),
+        ing.macros?.kcal ?? null,
+        ing.macros?.protein ?? null,
+        ing.macros?.fat ?? null,
+        ing.macros?.carbs ?? null,
+      ],
+    );
+  }
+}
+
+// Batch upsert — THE write path shared by the plan_week MCP tool and the UI.
+// replace=true (default): slots mentioned in `meals` are replaced wholesale.
+// Soft lock: editing a confirmed day works but the returned view carries a
+// varning — the log is only changed via confirm/unconfirm/edit_meal.
+// NOTE: replacing/clearing planned meals that were already logged severs
+// their logged_meal_id link, so a later unconfirm won't remove those logged
+// meals — deliberate (the warning tells Philip the log is unaffected).
+export function upsertPlanDays(db: Database, days: PlanDayInput[], replace = true): PlanDayView[] {
+  if (days.length === 0) throw new Error("Inga dagar angivna");
+  db.transaction(() => {
+    for (const day of days) {
+      if (!isValidDate(day.date)) throw new Error(`Invalid date: ${day.date} (expected YYYY-MM-DD)`);
+      db.run("INSERT OR IGNORE INTO days (date) VALUES (?)", [day.date]);
+      if (day.day_type !== undefined) {
+        getTargetsFor(db, day.day_type); // validates the type
+        db.run("UPDATE days SET day_type = ? WHERE date = ?", [day.day_type, day.date]);
+      }
+      for (const slot of day.clear_slots ?? []) {
+        assertSlot(slot);
+        db.run("DELETE FROM planned_meals WHERE day_date = ? AND slot = ?", [day.date, slot]);
+      }
+      const meals = day.meals ?? [];
+      for (const meal of meals) validatePlannedMeal(db, meal);
+      if (replace) {
+        for (const slot of new Set(meals.map((m) => m.slot))) {
+          db.run("DELETE FROM planned_meals WHERE day_date = ? AND slot = ?", [day.date, slot]);
+        }
+      }
+      for (const meal of meals) insertPlannedMeal(db, day.date, meal);
+    }
+  })();
+
+  return days.map((day) => {
+    const view = readPlanDay(db, day.date);
+    if (view.confirmed) {
+      view.warning = "dagen är redan bekräftad — ändringar påverkar inte loggen";
+    }
+    return view;
+  });
+}
+
+export function getPlanWeek(
+  db: Database,
+  opts: { start?: string; weeks?: number; include_items?: boolean } = {},
+): PlanWeekView {
+  const anchor = opts.start ?? todayStockholm();
+  if (!isValidDate(anchor)) throw new Error(`Invalid date: ${anchor} (expected YYYY-MM-DD)`);
+  const start = mondayOf(anchor);
+  const weeks = Math.min(4, Math.max(1, Math.trunc(opts.weeks ?? 1)));
+  const total = weeks * 7;
+
+  const days: PlanDayView[] = [];
+  for (let i = 0; i < total; i++) {
+    days.push(readPlanDay(db, addDays(start, i), opts.include_items ?? false));
+  }
+
+  const planned = days.filter((d) => d.meals.length > 0);
+  return {
+    start_date: start,
+    end_date: addDays(start, total - 1),
+    days,
+    week: {
+      planned_days: planned.length,
+      confirmed_days: days.filter((d) => d.confirmed).length,
+      avg_planned_kcal:
+        planned.length === 0
+          ? null
+          : Math.round(planned.reduce((a, d) => a + d.totals.kcal, 0) / planned.length),
+      avg_target_kcal: Math.round(days.reduce((a, d) => a + d.targets.kcal, 0) / days.length),
+    },
+  };
+}

--- a/kcal-assistant/src/db/plan.ts
+++ b/kcal-assistant/src/db/plan.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { type Macros, scaleMacros, sumMacros } from "../lib/macros";
-import { resolveItem, type MealItemInput, type DayView, getDay } from "./meals";
+import { resolveItem, logMeal, getDay, type MealItemInput, type DayView } from "./meals";
 import { getRecipe, reconstructInput, type IngredientRow } from "./recipes";
 import { getTargetsFor, type DayTargets } from "./preferences";
 import { todayStockholm, isValidDate, toEpochDays, epochDaysToDate, addDays } from "../lib/dates";
@@ -381,6 +381,159 @@ export function upsertPlanDays(db: Database, days: PlanDayInput[], replace = tru
     }
     return view;
   });
+}
+
+export interface ShoppingLine {
+  product_id: number | null;
+  description: string;
+  grams: number | null;
+  quantity: number | null;
+  portion_name: string | null;
+}
+
+// Handlingslista: aggregates the range's UNLOGGED planned meals — recipe
+// meals expand their ingredients scaled by the planned servings. Product
+// lines merge on (product, portion); ad-hoc/unresolved lines are listed
+// individually so nothing silently disappears.
+export function buildShoppingList(db: Database, start: string, days: number): ShoppingLine[] {
+  if (!isValidDate(start)) throw new Error(`Invalid date: ${start} (expected YYYY-MM-DD)`);
+  const span = Math.min(28, Math.max(1, Math.trunc(days)));
+  const end = addDays(start, span - 1);
+
+  const rows = db
+    .query<PlannedMealRow, [string, string]>(
+      `SELECT id, day_date, slot, position, name, recipe_id, recipe_servings, post_gym_shake, logged_meal_id, note
+       FROM planned_meals WHERE day_date >= ? AND day_date <= ? AND logged_meal_id IS NULL ORDER BY day_date, id`,
+    )
+    .all(start, end);
+
+  const productLines = new Map<string, ShoppingLine>();
+  const looseLines: ShoppingLine[] = [];
+
+  const addResolved = (
+    item: { product_id: number | null; description: string; grams: number | null; quantity: number | null; portion_name: string | null },
+    factor: number,
+  ) => {
+    if (item.product_id === null) {
+      looseLines.push({
+        product_id: null,
+        description: item.description,
+        grams: item.grams !== null ? item.grams * factor : null,
+        quantity: item.quantity !== null ? item.quantity * factor : null,
+        portion_name: item.portion_name,
+      });
+      return;
+    }
+    const key = `${item.product_id}|${item.portion_name ?? ""}`;
+    const line =
+      productLines.get(key) ??
+      ({ product_id: item.product_id, description: item.description, grams: null, quantity: null, portion_name: item.portion_name } as ShoppingLine);
+    if (item.grams !== null) line.grams = (line.grams ?? 0) + item.grams * factor;
+    if (item.portion_name !== null && item.quantity !== null) {
+      line.quantity = (line.quantity ?? 0) + item.quantity * factor;
+    }
+    productLines.set(key, line);
+  };
+
+  for (const row of rows) {
+    if (row.recipe_id !== null || row.recipe_servings !== null) {
+      const recipe = row.recipe_id !== null ? getRecipe(db, row.recipe_id) : null;
+      if (!recipe) {
+        looseLines.push({ product_id: null, description: `${row.name} (recept saknas)`, grams: null, quantity: null, portion_name: null });
+        continue;
+      }
+      const servings = row.recipe_servings ?? 1;
+      const factor = recipe.servings !== null && recipe.servings > 0 ? servings / recipe.servings : servings;
+      for (const ing of recipe.ingredients) {
+        addResolved(
+          { product_id: ing.product_id, description: ing.description, grams: ing.grams, quantity: ing.quantity, portion_name: ing.portion_name },
+          factor,
+        );
+      }
+      continue;
+    }
+    const r = resolvePlannedMeal(db, row);
+    for (const item of r.items) {
+      addResolved(
+        { product_id: item.product_id, description: item.description, grams: item.grams, quantity: item.quantity, portion_name: item.portion_name },
+        1,
+      );
+    }
+  }
+
+  const round1 = (x: number | null) => (x === null ? null : Math.round(x * 10) / 10);
+  return [...productLines.values(), ...looseLines]
+    .map((l) => ({ ...l, grams: round1(l.grams), quantity: round1(l.quantity) }))
+    .sort((a, b) => a.description.localeCompare(b.description, "sv"));
+}
+
+// Confirm = lock + log: copies planned meals into `meals` through logMeal
+// (the exact same insert/rounding path as chat logging) and links each via
+// logged_meal_id. Idempotent per meal; a fully confirmed day refuses.
+export function confirmDay(
+  db: Database,
+  date: string,
+  slots?: PlanSlot[],
+): { day: DayView; plan: PlanDayView } {
+  if (!isValidDate(date)) throw new Error(`Invalid date: ${date} (expected YYYY-MM-DD)`);
+  for (const slot of slots ?? []) assertSlot(slot);
+  const rows = readPlannedMealRows(db, date).filter((r) => !slots || slots.includes(r.slot));
+  if (rows.length === 0) throw new Error("inget planerat");
+  const pending = rows.filter((r) => r.logged_meal_id === null);
+  if (pending.length === 0) throw new Error("redan bekräftad");
+
+  const resolved = pending.map((row) => ({ row, r: resolvePlannedMeal(db, row) }));
+  const broken = resolved.filter((x) => x.r.incomplete);
+  if (broken.length > 0) {
+    throw new Error(
+      `kan inte bekräfta: olösta poster i ${broken.map((x) => `"${x.row.name}"`).join(", ")}`,
+    );
+  }
+
+  db.transaction(() => {
+    for (const { row, r } of resolved) {
+      const { meal_id } = logMeal(db, {
+        name: row.name,
+        date,
+        post_gym_shake: row.post_gym_shake === 1,
+        items: r.loggableItems,
+      });
+      db.run(
+        "UPDATE planned_meals SET logged_meal_id = ?, updated_at = datetime('now') WHERE id = ?",
+        [meal_id, row.id],
+      );
+    }
+    const remaining = db
+      .query<{ n: number }, [string]>(
+        "SELECT count(*) AS n FROM planned_meals WHERE day_date = ? AND logged_meal_id IS NULL",
+      )
+      .get(date)!.n;
+    if (remaining === 0) {
+      db.run("UPDATE days SET plan_confirmed_at = datetime('now') WHERE date = ?", [date]);
+    }
+  })();
+
+  return { day: getDay(db, date), plan: readPlanDay(db, date) };
+}
+
+// Removes ONLY plan-originated meals (via the logged_meal_id links); meals
+// logged outside the plan survive. FK ON DELETE SET NULL clears the links.
+export function unconfirmDay(db: Database, date: string): { day: DayView; plan: PlanDayView } {
+  if (!isValidDate(date)) throw new Error(`Invalid date: ${date} (expected YYYY-MM-DD)`);
+  const ids = db
+    .query<{ logged_meal_id: number }, [string]>(
+      "SELECT logged_meal_id FROM planned_meals WHERE day_date = ? AND logged_meal_id IS NOT NULL",
+    )
+    .all(date)
+    .map((r) => r.logged_meal_id);
+  if (ids.length === 0) throw new Error("inget att ångra");
+
+  db.transaction(() => {
+    for (const id of ids) db.run("DELETE FROM meals WHERE id = ?", [id]);
+    db.run("UPDATE days SET plan_confirmed_at = NULL WHERE date = ?", [date]);
+  })();
+
+  return { day: getDay(db, date), plan: readPlanDay(db, date) };
 }
 
 export function getPlanWeek(

--- a/kcal-assistant/src/db/recipes.ts
+++ b/kcal-assistant/src/db/recipes.ts
@@ -69,7 +69,7 @@ interface RecipeRow {
   updated_at: string;
 }
 
-interface IngredientRow {
+export interface IngredientRow {
   product_id: number | null;
   description: string;
   grams: number | null;
@@ -85,7 +85,8 @@ interface IngredientRow {
 // non-null => ad-hoc (description IS input); else portion_name => portion item;
 // else grams item. Product rows get NO description — live resolution supplies
 // the current product name, so renames propagate.
-function reconstructInput(row: IngredientRow): MealItemInput {
+// Exported for db/plan.ts: planned_meal_items share the raw-input row shape.
+export function reconstructInput(row: IngredientRow): MealItemInput {
   if (row.kcal !== null && row.protein !== null && row.fat !== null && row.carbs !== null) {
     return {
       description: row.description,

--- a/kcal-assistant/src/mcp.ts
+++ b/kcal-assistant/src/mcp.ts
@@ -9,6 +9,7 @@ import { registerStoreTools } from "./tools/store";
 import { registerWeightTools } from "./tools/weights";
 import { registerRecipeTools } from "./tools/recipes";
 import { registerProfileTools } from "./tools/profile";
+import { registerPlanTools } from "./tools/plan";
 
 // A fresh McpServer per request (stateless Streamable HTTP). The Database is
 // the shared singleton — safe because bun:sqlite is synchronous.
@@ -23,5 +24,6 @@ export function buildMcpServer(db: Database): McpServer {
   registerWeightTools(server, db);
   registerRecipeTools(server, db);
   registerProfileTools(server, db);
+  registerPlanTools(server, db);
   return server;
 }

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -122,9 +122,13 @@ export function createHttpServer(opts: { token: string; db: Database; uiAuth: Ui
             return;
           }
         }
-        if (req.method !== "GET" && !(req.method === "PUT" && pathname === "/ui/api/profile")) {
+        // The only writable UI routes: profile plus plan/confirm per-date.
+        const putRoute =
+          pathname === "/ui/api/profile" ||
+          /^\/ui\/api\/(plan|confirm)\/\d{4}-\d{2}-\d{2}$/.test(pathname);
+        if (req.method !== "GET" && !(req.method === "PUT" && putRoute)) {
           uiHeaders(res);
-          res.writeHead(405, { allow: pathname === "/ui/api/profile" ? "GET, PUT" : "GET" }).end();
+          res.writeHead(405, { allow: putRoute ? "GET, PUT" : "GET" }).end();
           return;
         }
         const staticRoute = STATIC_ROUTES[pathname];

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -4,7 +4,9 @@ import type { Database } from "bun:sqlite";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { buildMcpServer } from "./mcp";
 import { handleUiApi } from "./ui/api";
-import { buildInternalSummary } from "./ui/internal";
+import { buildInternalSummary, buildInternalPlanner } from "./ui/internal";
+import { confirmDay } from "./db/plan";
+import { isValidDate } from "./lib/dates";
 import type { UiAuthState } from "./ui/auth";
 
 function safeEqual(a: string, b: string): boolean {
@@ -190,7 +192,7 @@ export function createHttpServer(opts: { token: string; db: Database; uiAuth: Ui
 // unauthenticated read-only route in this app gets its own port instead,
 // gated at the network layer by a CiliumNetworkPolicy (Task 13).
 export function createInternalServer(opts: { db: Database }): Server {
-  return createServer((req, res) => {
+  return createServer(async (req, res) => {
     try {
       const raw = req.url ?? "/";
       if (raw.includes("..") || raw.includes("%") || raw.includes("\\") || raw.includes("//")) {
@@ -212,6 +214,52 @@ export function createInternalServer(opts: { db: Database }): Server {
         res
           .writeHead(200, { "content-type": "application/json", "cache-control": "no-store" })
           .end(JSON.stringify(buildInternalSummary(opts.db)));
+        return;
+      }
+
+      if (pathname === "/internal/planner") {
+        if (req.method !== "GET") {
+          res.writeHead(405, { allow: "GET" }).end();
+          return;
+        }
+        res
+          .writeHead(200, { "content-type": "application/json", "cache-control": "no-store" })
+          .end(JSON.stringify(buildInternalPlanner(opts.db)));
+        return;
+      }
+
+      // The single write on this listener: the wall panel's Bekräfta button
+      // (HA rest_command). Whole-day confirm only; unconfirm deliberately
+      // stays off the panel. Cilium L7 pins exactly this method+path to the
+      // HA host identity.
+      if (pathname === "/internal/planner/confirm") {
+        if (req.method !== "POST") {
+          res.writeHead(405, { allow: "POST" }).end();
+          return;
+        }
+        const rawBody = await readBody(req, 4096);
+        let date: unknown;
+        try {
+          date = rawBody === null ? undefined : (JSON.parse(rawBody) as { date?: unknown }).date;
+        } catch {
+          /* handled below */
+        }
+        if (typeof date !== "string" || !isValidDate(date)) {
+          res.writeHead(400, { "content-type": "application/json" }).end('{"error":"ogiltigt datum"}');
+          return;
+        }
+        try {
+          confirmDay(opts.db, date);
+          res
+            .writeHead(200, { "content-type": "application/json" })
+            .end(JSON.stringify({ ok: true, date }));
+        } catch (e) {
+          const message = e instanceof Error ? e.message : "fel";
+          const conflict = /redan bekräftad|inget planerat/.test(message);
+          res
+            .writeHead(conflict ? 409 : 400, { "content-type": "application/json" })
+            .end(JSON.stringify({ error: message }));
+        }
         return;
       }
 

--- a/kcal-assistant/src/tools/plan.ts
+++ b/kcal-assistant/src/tools/plan.ts
@@ -1,0 +1,95 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import {
+  upsertPlanDays,
+  getPlanWeek,
+  confirmDay,
+  unconfirmDay,
+  buildShoppingList,
+  mondayOf,
+} from "../db/plan";
+import { todayStockholm } from "../lib/dates";
+import { dateSchema, dayTypeSchema, mealItemSchema } from "./schemas";
+import { jsonResult, wrap } from "./util";
+
+const slotSchema = z
+  .enum(["frukost", "lunch", "middag", "mellis"])
+  .describe("Meal slot in the week plan");
+
+const plannedMealSchema = z
+  .object({
+    slot: slotSchema,
+    name: z.string().min(1).describe("Meal name shown in the plan, e.g. 'Köttfärssås'"),
+    recipe_id: z.number().int().optional().describe("Plan a saved recipe (requires recipe_servings)"),
+    recipe_servings: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Servings of the recipe to plan (batches if the recipe lacks servings)"),
+    items: z.array(mealItemSchema).min(1).optional().describe("Item-based meal (recipe_id XOR items)"),
+    post_gym_shake: z.boolean().optional(),
+    note: z.string().optional(),
+  })
+  .describe("One planned meal: recipe_id + recipe_servings OR items");
+
+const planDaySchema = z.object({
+  date: dateSchema,
+  day_type: dayTypeSchema.optional().describe("Also set the day's type while planning"),
+  clear_slots: z.array(slotSchema).optional().describe("Slots to empty on this day"),
+  meals: z.array(plannedMealSchema).optional(),
+});
+
+export function registerPlanTools(server: McpServer, db: Database): void {
+  server.registerTool(
+    "plan_week",
+    {
+      description:
+        "THE meal-planning tool: batch-upsert the week plan (Mon-Sun calendar with frukost/lunch/middag/mellis slots) — plan a whole week in ONE call. Per day you can set day_type (vilodag/gymdag/flexdag), clear slots, and add meals (saved recipe via recipe_id+recipe_servings, or explicit items). Default replace=true: slots you provide are replaced wholesale; replace=false appends. Server computes all macros live (product/recipe edits propagate) and returns per-day totals, remaining vs targets and floor checks so you see immediately whether the plan hits targets. Planning does NOT log anything — Philip confirms days with confirm_day ('lås dagen').",
+      inputSchema: {
+        days: z.array(planDaySchema).min(1),
+        replace: z.boolean().optional().describe("Default true: provided slots are replaced"),
+      },
+    },
+    wrap(({ days, replace }) => jsonResult({ days: upsertPlanDays(db, days, replace ?? true) })),
+  );
+
+  server.registerTool(
+    "get_plan",
+    {
+      description:
+        "Read the week meal plan (Mon-Sun, snapped to Monday). Call before planning discussions. Compact by default; include_items adds per-meal item detail; shopping_list adds an aggregated handlingslista (unlogged planned meals only, recipes expanded). weeks 1-4 extends the range.",
+      inputSchema: {
+        start: dateSchema.optional().describe("Any date in the desired week; defaults to today"),
+        weeks: z.number().int().min(1).max(4).optional(),
+        include_items: z.boolean().optional(),
+        shopping_list: z.boolean().optional(),
+      },
+    },
+    wrap(({ start, weeks, include_items, shopping_list }) => {
+      const week = getPlanWeek(db, { start, weeks, include_items });
+      if (!shopping_list) return jsonResult(week);
+      const days = (weeks ?? 1) * 7;
+      return jsonResult({
+        ...week,
+        shopping_list: buildShoppingList(db, mondayOf(start ?? todayStockholm()), days),
+      });
+    }),
+  );
+
+  server.registerTool(
+    "confirm_day",
+    {
+      description:
+        "Philip's 'lås dagen': action 'confirm' logs the day's planned meals into the real log (day totals, veckosnitt and forecast all pick them up) and locks the day; optional slots confirms only those slots (e.g. logga bara frukosten). Idempotent — already-logged meals are skipped. action 'unconfirm' undoes it: removes ONLY plan-originated logged meals and unlocks. Returns the updated day and plan state.",
+      inputSchema: {
+        date: dateSchema,
+        action: z.enum(["confirm", "unconfirm"]),
+        slots: z.array(slotSchema).optional().describe("confirm only: limit to these slots"),
+      },
+    },
+    wrap(({ date, action, slots }) =>
+      jsonResult(action === "confirm" ? confirmDay(db, date, slots) : unconfirmDay(db, date)),
+    ),
+  );
+}

--- a/kcal-assistant/src/ui/api.ts
+++ b/kcal-assistant/src/ui/api.ts
@@ -6,6 +6,18 @@ import { getTrend, listWeights } from "../db/weights";
 import { listPreferences, getTargets } from "../db/preferences";
 import { buildForecast, type IntakeSource } from "../db/forecast";
 import { getProfile, setProfile, type ProfileInput } from "../db/profile";
+import {
+  getPlanWeek,
+  upsertPlanDays,
+  confirmDay,
+  unconfirmDay,
+  buildShoppingList,
+  PLAN_SLOTS,
+  type PlanDayInput,
+  type PlannedMealInput,
+  type PlanSlot,
+} from "../db/plan";
+import type { MealItemInput } from "../db/meals";
 import { isValidDate } from "../lib/dates";
 
 export interface UiApiResponse {
@@ -112,19 +124,80 @@ export function handleUiApi(db: Database, req: UiApiRequest): UiApiResponse {
           }),
         };
       }
+      case "plan": {
+        if (req.method === "GET") {
+          if (param !== undefined) return NOT_FOUND;
+          const start = search.get("start");
+          if (start !== null && !isValidDate(start)) {
+            return { status: 400, body: { error: "ogiltigt datum" } };
+          }
+          const weeksRaw = search.get("weeks");
+          const weeks = weeksRaw === null ? 1 : Number(weeksRaw);
+          if (!Number.isInteger(weeks) || weeks < 1 || weeks > 4) {
+            return { status: 400, body: { error: "ogiltig weeks" } };
+          }
+          const week = getPlanWeek(db, { start: start ?? undefined, weeks, include_items: true });
+          return {
+            status: 200,
+            body: { ...week, shopping_list: buildShoppingList(db, week.start_date, weeks * 7) },
+          };
+        }
+        if (req.method === "PUT") {
+          if (param === undefined) return NOT_FOUND;
+          if (!isValidDate(param)) return { status: 400, body: { error: "ogiltigt datum" } };
+          const gate = writeGate(req);
+          if (gate) return gate;
+          const coerced = coercePlanDayBody(req.body as Record<string, unknown>);
+          if ("error" in coerced) return { status: 400, body: { error: coerced.error } };
+          try {
+            const days = upsertPlanDays(db, [{ date: param, ...coerced.input }], coerced.replace);
+            return { status: 200, body: { day: days[0] } };
+          } catch (e) {
+            return { status: 400, body: { error: e instanceof Error ? e.message : "ogiltig plan" } };
+          }
+        }
+        return { status: 405, body: { error: "metod stöds inte" } };
+      }
+      case "confirm": {
+        if (req.method !== "PUT") return { status: 405, body: { error: "metod stöds inte" } };
+        if (param === undefined) return NOT_FOUND;
+        if (!isValidDate(param)) return { status: 400, body: { error: "ogiltigt datum" } };
+        const gate = writeGate(req);
+        if (gate) return gate;
+        const body = req.body;
+        if (typeof body !== "object" || body === null || Array.isArray(body)) {
+          return { status: 400, body: { error: "ogiltig JSON" } };
+        }
+        const { action, slots, ...rest } = body as Record<string, unknown>;
+        if (Object.keys(rest).length > 0) {
+          return { status: 400, body: { error: `okänt fält: ${Object.keys(rest)[0]}` } };
+        }
+        if (action !== "confirm" && action !== "unconfirm") {
+          return { status: 400, body: { error: "ogiltigt värde för action" } };
+        }
+        let slotList: PlanSlot[] | undefined;
+        if (slots !== undefined) {
+          if (!Array.isArray(slots) || slots.some((s) => !PLAN_SLOTS.includes(s as PlanSlot))) {
+            return { status: 400, body: { error: "ogiltigt värde för slots" } };
+          }
+          slotList = slots as PlanSlot[];
+        }
+        try {
+          const result =
+            action === "confirm" ? confirmDay(db, param, slotList) : unconfirmDay(db, param);
+          return { status: 200, body: result };
+        } catch (e) {
+          const message = e instanceof Error ? e.message : "fel";
+          const conflict = /redan bekräftad|inget planerat|inget att ångra/.test(message);
+          return { status: conflict ? 409 : 400, body: { error: message } };
+        }
+      }
       case "profile": {
         if (param !== undefined) return NOT_FOUND;
         if (req.method === "GET") return { status: 200, body: { profile: getProfile(db) } };
         if (req.method === "PUT") {
-          if (req.secFetchSite !== "same-origin") {
-            return { status: 403, body: { error: "otillåten källa" } };
-          }
-          if (!req.contentType?.includes("application/json")) {
-            return { status: 403, body: { error: "fel innehållstyp" } };
-          }
-          if (typeof req.body !== "object" || req.body === null || Array.isArray(req.body)) {
-            return { status: 400, body: { error: "ogiltig JSON" } };
-          }
+          const gate = writeGate(req);
+          if (gate) return gate;
           const coerced = coerceProfileBody(req.body as Record<string, unknown>);
           if ("error" in coerced) return { status: 400, body: { error: coerced.error } };
           try {
@@ -146,6 +219,165 @@ export function handleUiApi(db: Database, req: UiApiRequest): UiApiResponse {
     console.error("ui api error:", e instanceof Error ? e.message : e);
     return { status: 500, body: { error: "internal" } };
   }
+}
+
+// Shared gate for every UI write: CSRF signals (403) + JSON object body (400).
+// Auth itself happened upstream (Authentik at the edge + server verification).
+function writeGate(req: UiApiRequest): UiApiResponse | null {
+  if (req.secFetchSite !== "same-origin") {
+    return { status: 403, body: { error: "otillåten källa" } };
+  }
+  if (!req.contentType?.includes("application/json")) {
+    return { status: 403, body: { error: "fel innehållstyp" } };
+  }
+  if (typeof req.body !== "object" || req.body === null || Array.isArray(req.body)) {
+    return { status: 400, body: { error: "ogiltig JSON" } };
+  }
+  return null;
+}
+
+function coerceMealItem(raw: unknown): { item: MealItemInput } | { error: string } {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { error: "ogiltig item" };
+  }
+  const item: MealItemInput = {};
+  for (const key of Object.keys(raw)) {
+    const value = (raw as Record<string, unknown>)[key];
+    switch (key) {
+      case "product_id":
+        if (typeof value !== "number") return { error: "ogiltigt värde för product_id" };
+        item.product_id = value;
+        break;
+      case "description":
+        if (typeof value !== "string") return { error: "ogiltigt värde för description" };
+        item.description = value;
+        break;
+      case "grams":
+        if (typeof value !== "number") return { error: "ogiltigt värde för grams" };
+        item.grams = value;
+        break;
+      case "quantity":
+        if (typeof value !== "number") return { error: "ogiltigt värde för quantity" };
+        item.quantity = value;
+        break;
+      case "portion_name":
+        if (typeof value !== "string") return { error: "ogiltigt värde för portion_name" };
+        item.portion_name = value;
+        break;
+      case "macros": {
+        if (typeof value !== "object" || value === null || Array.isArray(value)) {
+          return { error: "ogiltigt värde för macros" };
+        }
+        const m = value as Record<string, unknown>;
+        const keys = Object.keys(m).sort();
+        if (
+          keys.join(",") !== "carbs,fat,kcal,protein" ||
+          keys.some((k) => typeof m[k] !== "number")
+        ) {
+          return { error: "macros måste ha exakt kcal, protein, fat, carbs (tal)" };
+        }
+        item.macros = { kcal: m.kcal as number, protein: m.protein as number, fat: m.fat as number, carbs: m.carbs as number };
+        break;
+      }
+      default:
+        return { error: `okänt fält i item: ${key}` };
+    }
+  }
+  return { item };
+}
+
+function coercePlannedMeal(raw: unknown): { meal: PlannedMealInput } | { error: string } {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { error: "ogiltig måltid" };
+  }
+  const record = raw as Record<string, unknown>;
+  const meal = {} as PlannedMealInput;
+  for (const key of Object.keys(record)) {
+    const value = record[key];
+    switch (key) {
+      case "slot":
+        if (typeof value !== "string" || !PLAN_SLOTS.includes(value as PlanSlot)) {
+          return { error: "ogiltigt värde för slot" };
+        }
+        meal.slot = value as PlanSlot;
+        break;
+      case "name":
+        if (typeof value !== "string" || value.trim() === "") return { error: "ogiltigt värde för name" };
+        meal.name = value;
+        break;
+      case "recipe_id":
+        if (typeof value !== "number") return { error: "ogiltigt värde för recipe_id" };
+        meal.recipe_id = value;
+        break;
+      case "recipe_servings":
+        if (typeof value !== "number") return { error: "ogiltigt värde för recipe_servings" };
+        meal.recipe_servings = value;
+        break;
+      case "items": {
+        if (!Array.isArray(value)) return { error: "ogiltigt värde för items" };
+        const items: MealItemInput[] = [];
+        for (const rawItem of value) {
+          const coerced = coerceMealItem(rawItem);
+          if ("error" in coerced) return coerced;
+          items.push(coerced.item);
+        }
+        meal.items = items;
+        break;
+      }
+      case "post_gym_shake":
+        if (typeof value !== "boolean") return { error: "ogiltigt värde för post_gym_shake" };
+        meal.post_gym_shake = value;
+        break;
+      case "note":
+        if (typeof value !== "string") return { error: "ogiltigt värde för note" };
+        meal.note = value;
+        break;
+      default:
+        return { error: `okänt fält i måltid: ${key}` };
+    }
+  }
+  if (!meal.slot || !meal.name) return { error: "måltid behöver slot och name" };
+  return { meal };
+}
+
+function coercePlanDayBody(
+  body: Record<string, unknown>,
+): { input: Omit<PlanDayInput, "date">; replace?: boolean } | { error: string } {
+  const input: Omit<PlanDayInput, "date"> = {};
+  let replace: boolean | undefined;
+  for (const key of Object.keys(body)) {
+    const value = body[key];
+    switch (key) {
+      case "day_type":
+        if (typeof value !== "string") return { error: "ogiltigt värde för day_type" };
+        input.day_type = value;
+        break;
+      case "clear_slots":
+        if (!Array.isArray(value) || value.some((s) => !PLAN_SLOTS.includes(s as PlanSlot))) {
+          return { error: "ogiltigt värde för clear_slots" };
+        }
+        input.clear_slots = value as PlanSlot[];
+        break;
+      case "meals": {
+        if (!Array.isArray(value)) return { error: "ogiltigt värde för meals" };
+        const meals: PlannedMealInput[] = [];
+        for (const rawMeal of value) {
+          const coerced = coercePlannedMeal(rawMeal);
+          if ("error" in coerced) return coerced;
+          meals.push(coerced.meal);
+        }
+        input.meals = meals;
+        break;
+      }
+      case "replace":
+        if (typeof value !== "boolean") return { error: "ogiltigt värde för replace" };
+        replace = value;
+        break;
+      default:
+        return { error: `okänt fält: ${key}` };
+    }
+  }
+  return { input, ...(replace !== undefined && { replace }) };
 }
 
 function count(db: Database, table: "products" | "recipes" | "meals" | "weights"): number {

--- a/kcal-assistant/src/ui/app/api.ts
+++ b/kcal-assistant/src/ui/app/api.ts
@@ -85,3 +85,12 @@ export interface ForecastView { forecast: Forecast | null; reason?: string;
 export interface Profile { birth_date: string; sex: "man" | "kvinna"; height_cm: number; activity_factor: number; goal_weight_kg: number | null; goal_date: string | null }
 export interface Preference { id: number; category: string; content: string }
 export interface OverviewView { day: DayView; trend: TrendView; week: WeekView; counts: { products: number; recipes: number } }
+export type PlanSlot = "frukost" | "lunch" | "middag" | "mellis";
+export interface PlanItem { product_id: number | null; description: string; grams: number | null; quantity: number | null; portion_name: string | null; macros?: Macros; kcal?: number; protein?: number; fat?: number; carbs?: number; unresolved?: true; reason?: string }
+export interface PlanMeal extends Macros { id: number; slot: PlanSlot; position: number; name: string; recipe_id: number | null; recipe_servings: number | null; post_gym_shake: boolean; note: string | null; logged: boolean; totals_incomplete?: true; items?: PlanItem[] }
+export interface PlanDay { date: string; weekday: string; day_type: string; targets: DayTargets; confirmed: boolean; confirmed_at: string | null; meals: PlanMeal[]; totals: Macros; remaining: { kcal: number; protein_to_min: number; fat_to_min: number; carbs: number | null }; checks: { kcal_ok: boolean; protein_floor_ok: boolean; fat_floor_ok: boolean }; warning?: string }
+export interface ShoppingLine { product_id: number | null; description: string; grams: number | null; quantity: number | null; portion_name: string | null }
+export interface PlanWeek { start_date: string; end_date: string; days: PlanDay[]; week: { planned_days: number; confirmed_days: number; avg_planned_kcal: number | null; avg_target_kcal: number }; shopping_list: ShoppingLine[] }
+
+export const putJson = <T,>(path: string, body: unknown): Promise<T> =>
+  api<T>(path, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });

--- a/kcal-assistant/src/ui/app/index.tsx
+++ b/kcal-assistant/src/ui/app/index.tsx
@@ -8,9 +8,10 @@ import { Recept } from "./views/Recept";
 import { ReceptDetalj } from "./views/ReceptDetalj";
 import { Vikt } from "./views/Vikt";
 import { Regler } from "./views/Regler";
+import { Vecka } from "./views/Vecka";
 
 const TABS = [
-  ["idag", "Idag"], ["dagar", "Dagar"], ["produkter", "Produkter"],
+  ["idag", "Idag"], ["vecka", "Vecka"], ["dagar", "Dagar"], ["produkter", "Produkter"],
   ["recept", "Recept"], ["vikt", "Vikt"], ["regler", "Regler"],
 ] as const;
 
@@ -29,6 +30,7 @@ export interface Route { tab: string; el: ReactNode }
 export function resolveRoute(hash: string): Route {
   let m: RegExpMatchArray | null;
   if (/^#\/idag$/.test(hash)) return { tab: "idag", el: <Idag /> };
+  if (/^#\/vecka$/.test(hash)) return { tab: "vecka", el: <Vecka /> };
   if (/^#\/dagar$/.test(hash)) return { tab: "dagar", el: <Dagar /> };
   if ((m = hash.match(/^#\/dagar\/(\d{4}-\d{2}-\d{2})$/))) return { tab: "dagar", el: <DagDetalj date={m[1]!} /> };
   if (/^#\/produkter$/.test(hash)) return { tab: "produkter", el: <Produkter /> };

--- a/kcal-assistant/src/ui/app/views/Vecka.tsx
+++ b/kcal-assistant/src/ui/app/views/Vecka.tsx
@@ -1,0 +1,384 @@
+import { useState } from "react";
+import {
+  putJson,
+  sv,
+  useApi,
+  type PlanDay,
+  type PlanItem,
+  type PlanMeal,
+  type PlanSlot,
+  type PlanWeek,
+  type RecipeSummary,
+} from "../api";
+import { EmptyState, ErrorNote, macroLine } from "../components/Bits";
+import { KvittoSelect } from "../components/ui/Select";
+
+const SLOTS: readonly PlanSlot[] = ["frukost", "lunch", "middag", "mellis"];
+const SLOT_LABEL: Record<PlanSlot, string> = { frukost: "Frukost", lunch: "Lunch", middag: "Middag", mellis: "Mellis" };
+const DAY_TYPES = [
+  { value: "vilodag", label: "vilodag" },
+  { value: "gymdag", label: "gymdag" },
+  { value: "flexdag", label: "flexdag" },
+];
+
+function addDaysStr(date: string, n: number): string {
+  const [y, m, d] = date.split("-").map(Number) as [number, number, number];
+  return new Date(Date.UTC(y, m - 1, d + n)).toISOString().slice(0, 10);
+}
+
+// Server-side raw input reconstruction: PUT /ui/api/plan replaces whole slots,
+// so edits rebuild the slot from the round-tripped raw item input.
+function itemToInput(it: PlanItem): Record<string, unknown> {
+  if (it.macros) {
+    return {
+      description: it.description,
+      ...(it.grams !== null && { grams: it.grams }),
+      ...(it.quantity !== null && { quantity: it.quantity }),
+      macros: it.macros,
+    };
+  }
+  const out: Record<string, unknown> = { product_id: it.product_id };
+  if (it.portion_name !== null) {
+    out.portion_name = it.portion_name;
+    if (it.quantity !== null) out.quantity = it.quantity;
+  } else if (it.grams !== null) {
+    out.grams = it.grams;
+  }
+  return out;
+}
+
+function mealToInput(meal: PlanMeal, overrides: { slot?: PlanSlot; recipe_servings?: number } = {}): Record<string, unknown> {
+  const base = {
+    slot: overrides.slot ?? meal.slot,
+    name: meal.name,
+    ...(meal.post_gym_shake && { post_gym_shake: true }),
+    ...(meal.note !== null && { note: meal.note }),
+  };
+  if (meal.recipe_id !== null) {
+    return { ...base, recipe_id: meal.recipe_id, recipe_servings: overrides.recipe_servings ?? meal.recipe_servings ?? 1 };
+  }
+  return { ...base, items: (meal.items ?? []).map(itemToInput) };
+}
+
+interface WriteApi {
+  run: (fn: () => Promise<unknown>) => Promise<void>;
+  busy: boolean;
+}
+
+function AddMealForm({ day, slot, writer, onDone }: { day: PlanDay; slot: PlanSlot; writer: WriteApi; onDone: () => void }) {
+  const [mode, setMode] = useState<"recept" | "snabb">("recept");
+  const recipes = useApi<{ recipes: RecipeSummary[] }>(mode === "recept" ? "/ui/api/recipes" : null);
+  const [recipeId, setRecipeId] = useState("");
+  const [servings, setServings] = useState("1");
+  const [name, setName] = useState("");
+  const [m, setM] = useState({ kcal: "", protein: "", fat: "", carbs: "" });
+
+  const selected = recipes.data?.recipes.find((r) => String(r.id) === recipeId);
+  const canSaveRecipe = mode === "recept" && selected !== undefined && Number(servings) > 0;
+  const canSaveSnabb =
+    mode === "snabb" && name.trim() !== "" && Object.values(m).every((v) => v !== "" && Number.isFinite(Number(v)));
+
+  const save = () =>
+    writer.run(async () => {
+      const meal =
+        mode === "recept"
+          ? { slot, name: selected!.name, recipe_id: selected!.id, recipe_servings: Number(servings) }
+          : {
+              slot,
+              name: name.trim(),
+              items: [
+                {
+                  description: name.trim(),
+                  macros: { kcal: Number(m.kcal), protein: Number(m.protein), fat: Number(m.fat), carbs: Number(m.carbs) },
+                },
+              ],
+            };
+      await putJson(`/ui/api/plan/${day.date}`, { meals: [meal], replace: false });
+      onDone();
+    });
+
+  return (
+    <div className="vadd">
+      <div className="vadd-tabs">
+        <button className={mode === "recept" ? "active" : ""} onClick={() => setMode("recept")}>Från recept</button>
+        <button className={mode === "snabb" ? "active" : ""} onClick={() => setMode("snabb")}>Snabb</button>
+      </div>
+      {mode === "recept" ? (
+        <div className="vadd-fields">
+          <KvittoSelect
+            value={recipeId}
+            onChange={setRecipeId}
+            ariaLabel="välj recept"
+            placeholder="Välj recept…"
+            options={(recipes.data?.recipes ?? []).map((r) => ({
+              value: String(r.id),
+              label: r.name,
+              description: r.kcal_per_serving !== null ? `${sv(r.kcal_per_serving, 0)} kcal/port` : undefined,
+            }))}
+          />
+          <label className="vadd-servings">
+            portioner
+            <input type="number" min="0.5" step="0.5" value={servings} onChange={(e) => setServings(e.target.value)} />
+          </label>
+        </div>
+      ) : (
+        <div className="vadd-fields">
+          <input placeholder="Namn" value={name} onChange={(e) => setName(e.target.value)} />
+          <div className="vadd-macros">
+            {(["kcal", "protein", "fat", "carbs"] as const).map((k) => (
+              <label key={k}>
+                {k === "carbs" ? "kolh" : k === "fat" ? "fett" : k}
+                <input type="number" inputMode="decimal" value={m[k]} onChange={(e) => setM({ ...m, [k]: e.target.value })} />
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="vadd-actions">
+        <button disabled={writer.busy || !(canSaveRecipe || canSaveSnabb)} onClick={save}>Lägg till</button>
+        <button className="ghost" onClick={onDone}>Avbryt</button>
+      </div>
+    </div>
+  );
+}
+
+function MealRow({ day, meal, week, writer, reload }: { day: PlanDay; meal: PlanMeal; week: PlanWeek; writer: WriteApi; reload: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [servings, setServings] = useState(meal.recipe_servings !== null ? String(meal.recipe_servings) : "");
+  const [moveDate, setMoveDate] = useState(day.date);
+  const [moveSlot, setMoveSlot] = useState<PlanSlot>(meal.slot);
+
+  const slotMeals = day.meals.filter((x) => x.slot === meal.slot);
+  const rebuildWithout = () => {
+    const rest = slotMeals.filter((x) => x.id !== meal.id).map((x) => mealToInput(x));
+    return rest.length > 0
+      ? putJson(`/ui/api/plan/${day.date}`, { meals: rest, replace: true })
+      : putJson(`/ui/api/plan/${day.date}`, { clear_slots: [meal.slot] });
+  };
+
+  const remove = () =>
+    writer.run(async () => {
+      await rebuildWithout();
+      reload();
+    });
+
+  const move = () =>
+    writer.run(async () => {
+      await putJson(`/ui/api/plan/${moveDate}`, { meals: [mealToInput(meal, { slot: moveSlot })], replace: false });
+      await rebuildWithout();
+      reload();
+    });
+
+  const saveServings = () =>
+    writer.run(async () => {
+      const rebuilt = slotMeals.map((x) =>
+        x.id === meal.id ? mealToInput(x, { recipe_servings: Number(servings) }) : mealToInput(x),
+      );
+      await putJson(`/ui/api/plan/${day.date}`, { meals: rebuilt, replace: true });
+      reload();
+    });
+
+  return (
+    <>
+      <button className="rowlink vmeal" onClick={() => setOpen(!open)}>
+        <span>{meal.name}</span>
+        {meal.logged ? <span className="vlogged">loggad ✓</span> : null}
+        {meal.totals_incomplete ? <span className="vwarn">olöst</span> : null}
+        <span className="grow" />
+        <span className="num">{sv(meal.kcal, 0)} kcal</span>
+      </button>
+      {open ? (
+        <div className="vmeal-detail">
+          <div className="vmacro">{macroLine(meal)}</div>
+          {meal.recipe_id !== null ? (
+            <div className="vfield">
+              <label>
+                portioner
+                <input type="number" min="0.5" step="0.5" value={servings} onChange={(e) => setServings(e.target.value)} />
+              </label>
+              <button disabled={writer.busy || !(Number(servings) > 0) || Number(servings) === meal.recipe_servings} onClick={saveServings}>
+                Spara
+              </button>
+            </div>
+          ) : null}
+          {(meal.items ?? []).length > 0 ? (
+            <ul className="vitems">
+              {meal.items!.map((it, i) => (
+                <li key={i}>
+                  {it.description}
+                  {it.grams !== null ? ` · ${sv(it.grams, 0)} g` : ""}
+                  {it.unresolved ? ` — ${it.reason ?? "olöst"}` : ` · ${sv(it.kcal ?? (it.macros?.kcal ?? 0), 0)} kcal`}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <div className="vfield">
+            <KvittoSelect
+              value={moveDate}
+              onChange={setMoveDate}
+              ariaLabel="flytta till dag"
+              options={week.days.map((d) => ({ value: d.date, label: `${d.weekday} ${d.date.slice(8)}` }))}
+            />
+            <KvittoSelect
+              value={moveSlot}
+              onChange={(v) => setMoveSlot(v as PlanSlot)}
+              ariaLabel="flytta till lucka"
+              options={SLOTS.map((s) => ({ value: s, label: SLOT_LABEL[s] }))}
+            />
+            <button disabled={writer.busy || (moveDate === day.date && moveSlot === meal.slot)} onClick={move}>Flytta</button>
+          </div>
+          <div className="vfield">
+            <button className="danger" disabled={writer.busy} onClick={remove}>Ta bort</button>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function DayCard({ day, week, writer, reload }: { day: PlanDay; week: PlanWeek; writer: WriteApi; reload: () => void }) {
+  const [adding, setAdding] = useState<PlanSlot | null>(null);
+  const today = new Date().toLocaleDateString("sv-SE");
+  const hasMeals = day.meals.length > 0;
+
+  const setDayType = (value: string) =>
+    writer.run(async () => {
+      await putJson(`/ui/api/plan/${day.date}`, { day_type: value });
+      reload();
+    });
+
+  const confirm = () => {
+    if (!window.confirm(`Bekräfta ${day.weekday} ${day.date}? Måltiderna loggas mot dagens mål.`)) return;
+    void writer.run(async () => {
+      await putJson(`/ui/api/confirm/${day.date}`, { action: "confirm" });
+      reload();
+    });
+  };
+
+  const unconfirm = () => {
+    if (!window.confirm(`Ångra bekräftelsen för ${day.weekday} ${day.date}? Planens loggade måltider tas bort ur loggen.`)) return;
+    void writer.run(async () => {
+      await putJson(`/ui/api/confirm/${day.date}`, { action: "unconfirm" });
+      reload();
+    });
+  };
+
+  const warnings = [
+    !day.checks.kcal_ok ? "över kcal-budget" : null,
+    !day.checks.protein_floor_ok && hasMeals ? "under proteingolv" : null,
+    !day.checks.fat_floor_ok && hasMeals ? "under fettgolv" : null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <section className={`vday${day.confirmed ? " confirmed" : ""}${day.date === today ? " today" : ""}`}>
+      <header className="vday-head">
+        <div className="vday-title">
+          <span className="vday-name">{day.weekday}</span>
+          <span className="vday-date num">{day.date.slice(5)}</span>
+          {day.confirmed ? <span className="vday-lock">låst ✓</span> : null}
+        </div>
+        <div className="vday-type">
+          <KvittoSelect value={day.day_type} onChange={setDayType} ariaLabel="dagstyp" options={DAY_TYPES} />
+        </div>
+      </header>
+      <div className="vday-sum num">
+        {sv(day.totals.kcal, 0)} / {sv(day.targets.kcal, 0)} kcal · P {sv(day.totals.protein, 0)} / {sv(day.targets.protein_min, 0)} g
+      </div>
+      {warnings.length > 0 ? <div className="vday-warn">⚠ {warnings.join(" · ")}</div> : null}
+      {SLOTS.map((slot) => {
+        const meals = day.meals.filter((meal) => meal.slot === slot);
+        if (meals.length === 0 && adding !== slot && day.confirmed) return null;
+        return (
+          <div key={slot} className="vslot">
+            <div className="vslot-head">
+              <span>{SLOT_LABEL[slot]}</span>
+              {!day.confirmed && adding !== slot ? (
+                <button className="vslot-add" onClick={() => setAdding(slot)} aria-label={`lägg till ${SLOT_LABEL[slot]}`}>+ lägg till</button>
+              ) : null}
+            </div>
+            {meals.map((meal) => (
+              <MealRow key={meal.id} day={day} meal={meal} week={week} writer={writer} reload={reload} />
+            ))}
+            {adding === slot ? <AddMealForm day={day} slot={slot} writer={writer} onDone={() => { setAdding(null); reload(); }} /> : null}
+          </div>
+        );
+      })}
+      <div className="vday-actions">
+        {day.confirmed ? (
+          <button className="ghost" disabled={writer.busy} onClick={unconfirm}>Ångra bekräftelse</button>
+        ) : hasMeals ? (
+          <button className="vconfirm" disabled={writer.busy} onClick={confirm}>Bekräfta dagen 🔒</button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export function Vecka() {
+  const [start, setStart] = useState<string | null>(null);
+  const path = `/ui/api/plan${start ? `?start=${start}` : ""}`;
+  const { data, error, reload } = useApi<PlanWeek>(path, true);
+  const [writeError, setWriteError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const writer: WriteApi = {
+    busy,
+    run: async (fn) => {
+      setBusy(true);
+      setWriteError(null);
+      try {
+        await fn();
+      } catch (e) {
+        setWriteError((e as Error).message);
+      }
+      setBusy(false);
+    },
+  };
+
+  if (error) return <ErrorNote message={error} />;
+  if (!data) return null;
+
+  return (
+    <>
+      <div className="vnav">
+        <button onClick={() => setStart(addDaysStr(data.start_date, -7))}>‹ förra</button>
+        <span className="vnav-range num">{data.start_date} – {data.end_date}</span>
+        <button onClick={() => setStart(null)}>idag</button>
+        <button onClick={() => setStart(addDaysStr(data.start_date, 7))}>nästa ›</button>
+      </div>
+      <div className="tiles">
+        <div className="tile">
+          <div className="t-label">Planerade dagar</div>
+          <div className="t-value">{data.week.planned_days} / 7</div>
+          <div className="t-sub">{data.week.confirmed_days} bekräftade</div>
+        </div>
+        {data.week.avg_planned_kcal !== null ? (
+          <div className="tile">
+            <div className="t-label">Snitt planerat</div>
+            <div className="t-value">{sv(data.week.avg_planned_kcal, 0)}</div>
+            <div className="t-sub">mål {sv(data.week.avg_target_kcal, 0)} kcal</div>
+          </div>
+        ) : null}
+      </div>
+      {writeError ? <ErrorNote message={writeError} /> : null}
+      {data.days.map((day) => (
+        <DayCard key={day.date} day={day} week={data} writer={writer} reload={reload} />
+      ))}
+      {data.week.planned_days === 0 ? <EmptyState>Inget planerat den här veckan. Planera i chatten eller med + lägg till.</EmptyState> : null}
+      {data.shopping_list.length > 0 ? (
+        <details className="vshop">
+          <summary>Handlingslista ({data.shopping_list.length})</summary>
+          <ul>
+            {data.shopping_list.map((line, i) => (
+              <li key={i}>
+                {line.description}
+                {line.grams !== null ? ` · ${sv(line.grams, 0)} g` : ""}
+                {line.quantity !== null && line.portion_name !== null ? ` · ${sv(line.quantity, 1)} × ${line.portion_name}` : ""}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </>
+  );
+}

--- a/kcal-assistant/src/ui/internal.ts
+++ b/kcal-assistant/src/ui/internal.ts
@@ -1,5 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { readDay } from "../db/meals";
+import { getPlanWeek } from "../db/plan";
+import { todayStockholm } from "../lib/dates";
 import { getTrend, listWeights } from "../db/weights";
 import { buildForecast } from "../db/forecast";
 import { getProfile } from "../db/profile";
@@ -36,6 +38,65 @@ export interface InternalSummary {
 }
 
 const r1 = (x: number): number => Math.round(x * 10) / 10;
+
+export interface InternalPlannerDay {
+  date: string;
+  weekday: string;
+  day_type: string;
+  confirmed: boolean;
+  meals: Array<{
+    slot: string;
+    name: string;
+    kcal: number;
+    protein: number;
+    fat: number;
+    carbs: number;
+    logged: boolean;
+  }>;
+  total_kcal: number;
+  target_kcal: number;
+  protein_ok: boolean;
+  kcal_ok: boolean;
+}
+
+export interface InternalPlanner {
+  status: "ok";
+  week_start: string;
+  today: string;
+  confirmed_days: number;
+  days: InternalPlannerDay[];
+}
+
+// Read-only week-plan projection for the wall-hub planner page (no auth —
+// cluster-only listener, see server.ts). Same read functions as the UI.
+export function buildInternalPlanner(db: Database): InternalPlanner {
+  const week = getPlanWeek(db);
+  return {
+    status: "ok",
+    week_start: week.start_date,
+    today: todayStockholm(),
+    confirmed_days: week.week.confirmed_days,
+    days: week.days.map((d) => ({
+      date: d.date,
+      weekday: d.weekday,
+      day_type: d.day_type,
+      confirmed: d.confirmed,
+      meals: d.meals.map((m) => ({
+        slot: m.slot,
+        name: m.name,
+        kcal: Math.round(m.kcal),
+        protein: r1(m.protein),
+        fat: r1(m.fat),
+        carbs: r1(m.carbs),
+        logged: m.logged,
+      })),
+      total_kcal: Math.round(d.totals.kcal),
+      target_kcal: Math.round(d.targets.kcal),
+      protein_ok: d.checks.protein_floor_ok,
+      kcal_ok: d.checks.kcal_ok,
+    })),
+  };
+}
 
 // Read-only projection for the in-cluster wall-hub poller (no auth — see
 // server.ts). Reuses the same read functions as ui/api.ts's overview/forecast

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -523,3 +523,56 @@ button.chip:focus-visible { outline: 2px solid var(--accent-dim); outline-offset
 /* collapsible profile (v0.8) */
 .collapsible-summary { display: block; width: 100%; text-align: left; font: inherit; font-family: var(--mono); font-size: 13px; color: var(--ink); background: none; border: none; padding: 10px 12px; cursor: pointer; }
 .collapsible-summary:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+
+/* vecka — meal planner (v0.11) */
+.vnav { display: flex; align-items: center; gap: 8px; margin: 14px 0 4px; }
+.vnav button { font: inherit; font-family: var(--mono); font-size: 12px; color: var(--ink); background: var(--surface); border: 1px solid var(--hair-2); border-radius: 2px; padding: 6px 10px; cursor: pointer; }
+.vnav button:hover { border-color: var(--accent-dim); }
+.vnav button:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+.vnav-range { flex: 1; text-align: center; font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.vday { margin: 14px 0; padding: 12px 12px 10px; background: var(--surface); border: 1px solid var(--hair); border-radius: 2px; }
+.vday.today { border-color: var(--accent-dim); }
+.vday.confirmed { background: var(--surface-2); }
+.vday-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.vday-title { display: flex; align-items: baseline; gap: 8px; }
+.vday-name { font-family: var(--mono); font-size: 13px; font-weight: 700; text-transform: capitalize; }
+.vday-date { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.vday-lock { font-family: var(--mono); font-size: 11px; color: var(--ok); }
+.vday-type { width: 120px; }
+.vday-sum { font-family: var(--mono); font-size: 11px; color: var(--ink-2); margin: 8px 0 2px; font-variant-numeric: tabular-nums; }
+.vday-warn { font-family: var(--mono); font-size: 11px; color: var(--under); margin: 4px 0; }
+.vslot { margin-top: 8px; border-top: 1px dotted var(--hair); padding-top: 6px; }
+.vslot-head { display: flex; align-items: baseline; justify-content: space-between; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-3); }
+.vslot-add { font: inherit; font-family: var(--mono); font-size: 10px; color: var(--accent); background: none; border: none; cursor: pointer; padding: 2px 0; }
+.vslot-add:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+.vmeal { width: 100%; }
+.vlogged { font-family: var(--mono); font-size: 10px; color: var(--ok); margin-left: 8px; }
+.vwarn { font-family: var(--mono); font-size: 10px; color: var(--under); margin-left: 8px; }
+.vmeal-detail { padding: 6px 8px 10px; border-left: 2px solid var(--hair-2); margin: 2px 0 8px 6px; display: flex; flex-direction: column; gap: 8px; }
+.vmacro { font-family: var(--mono); font-size: 11px; color: var(--ink-2); }
+.vitems { list-style: none; font-family: var(--mono); font-size: 11px; color: var(--ink-3); display: flex; flex-direction: column; gap: 2px; }
+.vfield { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.vfield label { display: flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.vfield input, .vadd-fields input { font: inherit; font-family: var(--mono); color: var(--ink); background: var(--bg); border: 1px solid var(--hair-2); border-radius: 2px; padding: 5px 8px; width: 80px; }
+.vfield input:focus, .vadd-fields input:focus { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+.vfield button, .vadd-actions button, .vday-actions button { font: inherit; font-family: var(--mono); font-size: 12px; color: var(--ink); background: var(--surface); border: 1px solid var(--hair-2); border-radius: 2px; padding: 5px 10px; cursor: pointer; }
+.vfield button:disabled, .vadd-actions button:disabled, .vday-actions button:disabled { opacity: 0.5; cursor: default; }
+.vfield button:focus-visible, .vadd-actions button:focus-visible, .vday-actions button:focus-visible { outline: 2px solid var(--accent-dim); outline-offset: 0; }
+.vfield button.danger { color: var(--under); border-color: var(--under); }
+.vday-actions { margin-top: 10px; display: flex; justify-content: flex-end; }
+.vday-actions .vconfirm { color: var(--accent); border-color: var(--accent-dim); }
+.vday-actions .ghost, .vadd-actions .ghost { color: var(--ink-3); }
+.vadd { margin: 6px 0; padding: 8px; background: var(--bg); border: 1px dashed var(--hair-2); border-radius: 2px; display: flex; flex-direction: column; gap: 8px; }
+.vadd-tabs { display: flex; gap: 6px; }
+.vadd-tabs button { font: inherit; font-family: var(--mono); font-size: 11px; color: var(--ink-3); background: none; border: 1px solid var(--hair); border-radius: 2px; padding: 4px 8px; cursor: pointer; }
+.vadd-tabs button.active { color: var(--accent); border-color: var(--accent-dim); }
+.vadd-fields { display: flex; flex-direction: column; gap: 8px; }
+.vadd-fields > input { width: 100%; }
+.vadd-servings { display: flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.vadd-macros { display: flex; gap: 8px; flex-wrap: wrap; }
+.vadd-macros label { display: flex; flex-direction: column; gap: 3px; font-family: var(--mono); font-size: 10px; color: var(--ink-3); }
+.vadd-macros input { width: 72px; }
+.vadd-actions { display: flex; gap: 8px; }
+.vshop { margin: 16px 0; padding: 10px 12px; background: var(--surface); border: 1px solid var(--hair); border-radius: 2px; }
+.vshop summary { font-family: var(--mono); font-size: 12px; cursor: pointer; }
+.vshop ul { list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px; font-family: var(--mono); font-size: 12px; color: var(--ink-2); }

--- a/kcal-assistant/tests/internal-planner.test.ts
+++ b/kcal-assistant/tests/internal-planner.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { createHttpServer, createInternalServer } from "../src/server";
+import { saveProduct } from "../src/db/products";
+import { upsertPlanDays, mondayOf } from "../src/db/plan";
+import { todayStockholm } from "../src/lib/dates";
+
+let internalServer: Server;
+let mainServer: Server;
+let db: Database;
+let base: string;
+let mainBase: string;
+let productId: number;
+
+beforeAll(async () => {
+  db = openDb(":memory:");
+  productId = saveProduct(db, { name: "Planmat", per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 } }).id;
+  internalServer = createInternalServer({ db });
+  mainServer = createHttpServer({ token: "t", db, uiAuth: { mode: "unconfigured" } });
+  await new Promise<void>((r) => internalServer.listen(0, r));
+  await new Promise<void>((r) => mainServer.listen(0, r));
+  base = `http://127.0.0.1:${(internalServer.address() as AddressInfo).port}`;
+  mainBase = `http://127.0.0.1:${(mainServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((r) => internalServer.close(r));
+  await new Promise((r) => mainServer.close(r));
+});
+
+describe("GET /internal/planner", () => {
+  test("returns the current week with meals, checks and confirm state", async () => {
+    const today = todayStockholm();
+    upsertPlanDays(db, [
+      { date: today, meals: [{ slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 500 }] }] },
+    ]);
+    const res = await fetch(`${base}/internal/planner`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.week_start).toBe(mondayOf(today));
+    expect(body.today).toBe(today);
+    expect(body.days).toHaveLength(7);
+    const day = body.days.find((d: any) => d.date === today);
+    expect(day.meals).toEqual([
+      { slot: "middag", name: "Lax", kcal: 500, protein: 50, fat: 25, carbs: 40, logged: false },
+    ]);
+    expect(day.total_kcal).toBe(500);
+    expect(day.target_kcal).toBeGreaterThan(0);
+    expect(typeof day.kcal_ok).toBe("boolean");
+  });
+});
+
+describe("POST /internal/planner/confirm", () => {
+  test("confirms a planned day; conflicts are 409; bad input 400", async () => {
+    const today = todayStockholm();
+    const ok = await fetch(`${base}/internal/planner/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ date: today }),
+    });
+    expect(ok.status).toBe(200);
+    expect((await ok.json()).ok).toBe(true);
+
+    const again = await fetch(`${base}/internal/planner/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ date: today }),
+    });
+    expect(again.status).toBe(409);
+
+    const bad = await fetch(`${base}/internal/planner/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ date: "not-a-date" }),
+    });
+    expect(bad.status).toBe(400);
+
+    const wrongMethod = await fetch(`${base}/internal/planner/confirm`);
+    expect(wrongMethod.status).toBe(405);
+  });
+});
+
+// SECURITY PARITY: like /internal/summary, the planner routes must never be
+// reachable through the ingress-facing server.
+describe("planner routes are NOT on the main server", () => {
+  test("GET and POST both 404", async () => {
+    expect((await fetch(`${mainBase}/internal/planner`)).status).toBe(404);
+    const post = await fetch(`${mainBase}/internal/planner/confirm`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(post.status).toBe(404);
+  });
+});

--- a/kcal-assistant/tests/plan-confirm.test.ts
+++ b/kcal-assistant/tests/plan-confirm.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+import { saveRecipe } from "../src/db/recipes";
+import { setTargets } from "../src/db/preferences";
+import { getDay, logMeal, editMeal } from "../src/db/meals";
+import { upsertPlanDays, confirmDay, unconfirmDay, readPlanDay } from "../src/db/plan";
+
+let db: Database;
+let productId: number;
+
+const DATE = "2026-07-20";
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  productId = saveProduct(db, {
+    name: "Testmat",
+    per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 },
+  }).id;
+  setTargets(db, { day_type: "vilodag", kcal: 1400, protein_min: 150, fat_min: 50 });
+});
+
+function planBasicDay(): void {
+  upsertPlanDays(db, [
+    {
+      date: DATE,
+      meals: [
+        { slot: "frukost", name: "Gröt", items: [{ product_id: productId, grams: 300 }] },
+        { slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 500 }] },
+        { slot: "mellis", name: "Shake", post_gym_shake: true, items: [{ description: "Shake", macros: { kcal: 200, protein: 30, fat: 3, carbs: 10 } }] },
+      ],
+    },
+  ]);
+}
+
+describe("confirmDay", () => {
+  test("logs all planned meals and stamps the day confirmed", () => {
+    planBasicDay();
+    const { day, plan } = confirmDay(db, DATE);
+    expect(day.meals).toHaveLength(3);
+    expect(day.totals.kcal).toBe(1000); // 300 + 500 + 200
+    expect(plan.confirmed).toBe(true);
+    expect(plan.meals.every((m) => m.logged)).toBe(true);
+    const shake = day.meals.find((m) => m.name === "Shake")!;
+    expect(shake.post_gym_shake).toBe(true);
+  });
+
+  test("second confirm throws 'redan bekräftad'", () => {
+    planBasicDay();
+    confirmDay(db, DATE);
+    expect(() => confirmDay(db, DATE)).toThrow(/redan bekräftad/);
+  });
+
+  test("empty day throws 'inget planerat'", () => {
+    expect(() => confirmDay(db, DATE)).toThrow(/inget planerat/);
+  });
+
+  test("partial slot confirm logs only that slot; rest completes later", () => {
+    planBasicDay();
+    const first = confirmDay(db, DATE, ["middag"]);
+    expect(first.day.meals).toHaveLength(1);
+    expect(first.plan.confirmed).toBe(false);
+    expect(first.plan.meals.find((m) => m.slot === "middag")!.logged).toBe(true);
+    const rest = confirmDay(db, DATE);
+    expect(rest.day.meals).toHaveLength(3);
+    expect(rest.plan.confirmed).toBe(true);
+  });
+
+  test("recipe-based meal logs one aggregate item", () => {
+    const recipe = saveRecipe(db, {
+      name: "Köttfärssås",
+      servings: 4,
+      ingredients: [{ product_id: productId, grams: 1000 }],
+    });
+    upsertPlanDays(db, [
+      { date: DATE, meals: [{ slot: "middag", name: "Köttfärssås", recipe_id: recipe.id, recipe_servings: 2 }] },
+    ]);
+    const { day } = confirmDay(db, DATE);
+    expect(day.meals).toHaveLength(1);
+    expect(day.meals[0]!.items).toHaveLength(1);
+    expect(day.meals[0]!.items[0]!.description).toBe("Köttfärssås (2 port)");
+    expect(day.meals[0]!.kcal).toBe(500);
+  });
+
+  test("unresolved items block confirm with meal name in the error", () => {
+    const doomed = saveProduct(db, { name: "Snart borta", per_100g: { kcal: 200, protein: 1, fat: 1, carbs: 1 } }).id;
+    upsertPlanDays(db, [
+      { date: DATE, meals: [{ slot: "lunch", name: "Trasig lunch", items: [{ product_id: doomed, grams: 100 }] }] },
+    ]);
+    db.run("DELETE FROM products WHERE id = ?", [doomed]);
+    expect(() => confirmDay(db, DATE)).toThrow(/Trasig lunch/);
+  });
+
+  test("deleting a plan-logged meal via edit_meal clears the link so confirm can re-log it", () => {
+    planBasicDay();
+    confirmDay(db, DATE);
+    const day = getDay(db, DATE);
+    const grot = day.meals.find((m) => m.name === "Gröt")!;
+    editMeal(db, { meal_id: grot.id, action: "delete" });
+    const plan = readPlanDay(db, DATE);
+    expect(plan.meals.find((m) => m.name === "Gröt")!.logged).toBe(false);
+    const again = confirmDay(db, DATE); // re-logs only Gröt
+    expect(again.day.meals).toHaveLength(3);
+  });
+});
+
+describe("unconfirmDay", () => {
+  test("removes only plan-originated meals and clears the stamp", () => {
+    planBasicDay();
+    logMeal(db, { name: "Extra kaka", date: DATE, items: [{ description: "Kaka", macros: { kcal: 150, protein: 2, fat: 7, carbs: 20 } }] });
+    confirmDay(db, DATE);
+    expect(getDay(db, DATE).meals).toHaveLength(4);
+
+    const { day, plan } = unconfirmDay(db, DATE);
+    expect(day.meals).toHaveLength(1);
+    expect(day.meals[0]!.name).toBe("Extra kaka");
+    expect(plan.confirmed).toBe(false);
+    expect(plan.meals.every((m) => !m.logged)).toBe(true);
+  });
+
+  test("nothing logged throws 'inget att ångra'", () => {
+    planBasicDay();
+    expect(() => unconfirmDay(db, DATE)).toThrow(/inget att ångra/);
+  });
+});

--- a/kcal-assistant/tests/plan-shopping.test.ts
+++ b/kcal-assistant/tests/plan-shopping.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+import { saveRecipe } from "../src/db/recipes";
+import { upsertPlanDays, confirmDay, buildShoppingList } from "../src/db/plan";
+
+let db: Database;
+let chicken: number;
+let rice: number;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  chicken = saveProduct(db, { name: "Kycklingfilé", per_100g: { kcal: 106, protein: 22, fat: 2, carbs: 0 } }).id;
+  rice = saveProduct(db, { name: "Ris", per_100g: { kcal: 350, protein: 7, fat: 1, carbs: 77 } }).id;
+});
+
+describe("buildShoppingList", () => {
+  test("aggregates grams per product across meals and expands recipes", () => {
+    const recipe = saveRecipe(db, {
+      name: "Kyckling & ris",
+      servings: 4,
+      ingredients: [
+        { product_id: chicken, grams: 600 },
+        { product_id: rice, grams: 400 },
+      ],
+    });
+    upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [
+          { slot: "lunch", name: "Kycklingwok", items: [{ product_id: chicken, grams: 200 }] },
+          { slot: "middag", name: "Kyckling & ris", recipe_id: recipe.id, recipe_servings: 2 },
+        ],
+      },
+      {
+        date: "2026-07-21",
+        meals: [
+          { slot: "middag", name: "Mer kyckling", items: [{ product_id: chicken, grams: 300 }] },
+          { slot: "mellis", name: "Godis", items: [{ description: "Lösgodis", macros: { kcal: 300, protein: 0, fat: 5, carbs: 60 } }] },
+        ],
+      },
+    ]);
+
+    const list = buildShoppingList(db, "2026-07-20", 7);
+    // recipe at 2/4 servings => chicken 300g + rice 200g
+    const chickenLine = list.find((l) => l.product_id === chicken)!;
+    expect(chickenLine.grams).toBe(800); // 200 + 300 + 300
+    const riceLine = list.find((l) => l.product_id === rice)!;
+    expect(riceLine.grams).toBe(200);
+    const adhoc = list.find((l) => l.description === "Lösgodis")!;
+    expect(adhoc.product_id).toBeNull();
+  });
+
+  test("excludes logged meals and out-of-range dates", () => {
+    upsertPlanDays(db, [
+      { date: "2026-07-20", meals: [{ slot: "middag", name: "Loggad", items: [{ product_id: chicken, grams: 100 }] }] },
+      { date: "2026-07-21", meals: [{ slot: "middag", name: "Kvar", items: [{ product_id: chicken, grams: 250 }] }] },
+      { date: "2026-08-04", meals: [{ slot: "middag", name: "Utanför", items: [{ product_id: chicken, grams: 999 }] }] },
+    ]);
+    confirmDay(db, "2026-07-20");
+    const list = buildShoppingList(db, "2026-07-20", 7);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.grams).toBe(250);
+  });
+});

--- a/kcal-assistant/tests/plan-tools.test.ts
+++ b/kcal-assistant/tests/plan-tools.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { createHttpServer } from "../src/server";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+
+const TOKEN = "test-token-plan";
+let httpServer: Server;
+let db: Database;
+let baseUrl: string;
+let productId: number;
+
+beforeAll(async () => {
+  db = openDb(":memory:");
+  productId = saveProduct(db, {
+    name: "Testmat",
+    per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 },
+  }).id;
+  httpServer = createHttpServer({ token: TOKEN, db, uiAuth: { mode: "unconfigured" } });
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => httpServer.close(resolve));
+});
+
+async function connect(): Promise<Client> {
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp/${TOKEN}`)));
+  return client;
+}
+
+function parseResult(result: Awaited<ReturnType<Client["callTool"]>>): any {
+  const content = result.content as Array<{ type: string; text: string }>;
+  return JSON.parse(content[0]!.text);
+}
+
+describe("plan tools over MCP", () => {
+  test("plan_week -> get_plan -> confirm_day round-trip", async () => {
+    const client = await connect();
+
+    const planned = parseResult(
+      await client.callTool({
+        name: "plan_week",
+        arguments: {
+          days: [
+            {
+              date: "2026-07-20",
+              day_type: "gymdag",
+              meals: [
+                { slot: "frukost", name: "Gröt", items: [{ product_id: productId, grams: 300 }] },
+                { slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 500 }] },
+              ],
+            },
+            {
+              date: "2026-07-21",
+              meals: [{ slot: "lunch", name: "Rester", items: [{ product_id: productId, grams: 400 }] }],
+            },
+          ],
+        },
+      }),
+    );
+    expect(planned.days).toHaveLength(2);
+    expect(planned.days[0].day_type).toBe("gymdag");
+    expect(planned.days[0].totals.kcal).toBe(800);
+    expect(planned.days[0].meals[0].items).toBeUndefined(); // compact
+
+    const plan = parseResult(
+      await client.callTool({
+        name: "get_plan",
+        arguments: { start: "2026-07-22", shopping_list: true },
+      }),
+    );
+    expect(plan.start_date).toBe("2026-07-20");
+    expect(plan.week.planned_days).toBe(2);
+    expect(plan.shopping_list).toHaveLength(1);
+    expect(plan.shopping_list[0].grams).toBe(1200);
+
+    const confirmed = parseResult(
+      await client.callTool({
+        name: "confirm_day",
+        arguments: { date: "2026-07-20", action: "confirm" },
+      }),
+    );
+    expect(confirmed.day.totals.kcal).toBe(800);
+    expect(confirmed.plan.confirmed).toBe(true);
+
+    const undone = parseResult(
+      await client.callTool({
+        name: "confirm_day",
+        arguments: { date: "2026-07-20", action: "unconfirm" },
+      }),
+    );
+    expect(undone.day.meals).toHaveLength(0);
+    expect(undone.plan.confirmed).toBe(false);
+
+    await client.close();
+  });
+
+  test("domain errors surface as isError payloads", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "confirm_day",
+      arguments: { date: "2026-07-25", action: "confirm" },
+    });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toMatch(/inget planerat/);
+    await client.close();
+  });
+});

--- a/kcal-assistant/tests/plan.test.ts
+++ b/kcal-assistant/tests/plan.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { saveProduct } from "../src/db/products";
+import { saveRecipe } from "../src/db/recipes";
+import { setTargets } from "../src/db/preferences";
+import { mondayOf, getPlanWeek, upsertPlanDays } from "../src/db/plan";
+
+let db: Database;
+let productId: number;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+  productId = saveProduct(db, {
+    name: "Testmat",
+    per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 },
+  }).id;
+  setTargets(db, { day_type: "vilodag", kcal: 1400, protein_min: 150, fat_min: 50 });
+  setTargets(db, { day_type: "gymdag", kcal: 1600, protein_min: 150, fat_min: 50 });
+});
+
+describe("mondayOf", () => {
+  test("snaps every weekday to its Monday", () => {
+    expect(mondayOf("2026-07-20")).toBe("2026-07-20"); // Monday stays
+    expect(mondayOf("2026-07-22")).toBe("2026-07-20"); // Wednesday
+    expect(mondayOf("2026-07-26")).toBe("2026-07-20"); // Sunday -> prior Monday
+  });
+
+  test("handles DST transition and year boundary", () => {
+    expect(mondayOf("2026-03-29")).toBe("2026-03-23"); // DST Sunday
+    expect(mondayOf("2026-01-01")).toBe("2025-12-29"); // year boundary Thursday
+  });
+});
+
+describe("upsertPlanDays", () => {
+  test("inserts planned meals and returns totals vs targets", () => {
+    const days = upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        day_type: "gymdag",
+        meals: [
+          { slot: "frukost", name: "Gröt", items: [{ product_id: productId, grams: 300 }] },
+          { slot: "middag", name: "Kyckling", items: [{ product_id: productId, grams: 500 }] },
+        ],
+      },
+    ]);
+    expect(days).toHaveLength(1);
+    const day = days[0]!;
+    expect(day.date).toBe("2026-07-20");
+    expect(day.day_type).toBe("gymdag");
+    expect(day.confirmed).toBe(false);
+    expect(day.meals).toHaveLength(2);
+    expect(day.totals.kcal).toBe(800);
+    expect(day.targets.kcal).toBe(1600);
+    expect(day.remaining.kcal).toBe(800);
+    expect(day.checks.kcal_ok).toBe(true);
+    expect(day.checks.protein_floor_ok).toBe(false); // 80 < 150
+  });
+
+  test("replace=true replaces only slots present in meals", () => {
+    upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [
+          { slot: "frukost", name: "Gröt", items: [{ product_id: productId, grams: 300 }] },
+          { slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 400 }] },
+        ],
+      },
+    ]);
+    const days = upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [{ slot: "middag", name: "Kyckling", items: [{ product_id: productId, grams: 500 }] }],
+      },
+    ]);
+    const meals = days[0]!.meals;
+    expect(meals).toHaveLength(2);
+    expect(meals.find((m) => m.slot === "frukost")!.name).toBe("Gröt");
+    expect(meals.find((m) => m.slot === "middag")!.name).toBe("Kyckling");
+  });
+
+  test("replace=false appends within the slot", () => {
+    upsertPlanDays(db, [
+      { date: "2026-07-20", meals: [{ slot: "mellis", name: "Shake", items: [{ product_id: productId, grams: 100 }] }] },
+    ]);
+    const days = upsertPlanDays(
+      db,
+      [{ date: "2026-07-20", meals: [{ slot: "mellis", name: "Frukt", items: [{ product_id: productId, grams: 150 }] }] }],
+      false,
+    );
+    const mellis = days[0]!.meals.filter((m) => m.slot === "mellis");
+    expect(mellis.map((m) => m.name)).toEqual(["Shake", "Frukt"]);
+  });
+
+  test("clear_slots empties a slot", () => {
+    upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [
+          { slot: "lunch", name: "Sallad", items: [{ product_id: productId, grams: 200 }] },
+          { slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 400 }] },
+        ],
+      },
+    ]);
+    const days = upsertPlanDays(db, [{ date: "2026-07-20", clear_slots: ["middag"] }]);
+    expect(days[0]!.meals.map((m) => m.slot)).toEqual(["lunch"]);
+  });
+
+  test("rejects invalid day_type and invalid slot payloads", () => {
+    expect(() => upsertPlanDays(db, [{ date: "2026-07-20", day_type: "festdag" }])).toThrow();
+    expect(() =>
+      upsertPlanDays(db, [
+        {
+          date: "2026-07-20",
+          meals: [
+            {
+              slot: "middag",
+              name: "Både och",
+              recipe_id: 1,
+              recipe_servings: 1,
+              items: [{ product_id: productId, grams: 100 }],
+            },
+          ],
+        },
+      ]),
+    ).toThrow(); // recipe XOR items
+    expect(() =>
+      upsertPlanDays(db, [{ date: "2026-07-20", meals: [{ slot: "middag", name: "Recept utan portioner", recipe_id: 999 }] }]),
+    ).toThrow(); // recipe_servings required + recipe must exist
+  });
+
+  test("recipe-based meal scales per serving", () => {
+    const recipe = saveRecipe(db, {
+      name: "Köttfärssås",
+      servings: 4,
+      ingredients: [{ product_id: productId, grams: 1000 }], // 1000 kcal total, 250/serving
+    });
+    const days = upsertPlanDays(db, [
+      { date: "2026-07-21", meals: [{ slot: "middag", name: "Köttfärssås", recipe_id: recipe.id, recipe_servings: 2 }] },
+    ]);
+    const meal = days[0]!.meals[0]!;
+    expect(meal.kcal).toBe(500);
+    expect(meal.recipe_id).toBe(recipe.id);
+    expect(meal.recipe_servings).toBe(2);
+  });
+
+  test("recipe without servings scales as batches", () => {
+    const recipe = saveRecipe(db, {
+      name: "Sås",
+      ingredients: [{ product_id: productId, grams: 200 }], // 200 kcal/batch
+    });
+    const days = upsertPlanDays(db, [
+      { date: "2026-07-21", meals: [{ slot: "middag", name: "Sås", recipe_id: recipe.id, recipe_servings: 2 }] },
+    ]);
+    expect(days[0]!.meals[0]!.kcal).toBe(400);
+  });
+
+  test("deleted product flags the meal incomplete and excludes it from totals", () => {
+    const doomed = saveProduct(db, { name: "Snart borta", per_100g: { kcal: 200, protein: 1, fat: 1, carbs: 1 } }).id;
+    upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [
+          { slot: "lunch", name: "Trasig", items: [{ product_id: doomed, grams: 100 }] },
+          { slot: "middag", name: "Hel", items: [{ product_id: productId, grams: 100 }] },
+        ],
+      },
+    ]);
+    db.run("DELETE FROM products WHERE id = ?", [doomed]);
+    const week = getPlanWeek(db, { start: "2026-07-20" });
+    const day = week.days[0]!;
+    const broken = day.meals.find((m) => m.name === "Trasig")!;
+    expect(broken.totals_incomplete).toBe(true);
+    expect(day.totals.kcal).toBe(100); // only the intact meal counts
+  });
+});
+
+describe("getPlanWeek", () => {
+  test("returns 7 monday-aligned days with weekday names and aggregates", () => {
+    upsertPlanDays(db, [
+      { date: "2026-07-22", day_type: "gymdag", meals: [{ slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 500 }] }] },
+    ]);
+    const week = getPlanWeek(db, { start: "2026-07-24" });
+    expect(week.start_date).toBe("2026-07-20");
+    expect(week.end_date).toBe("2026-07-26");
+    expect(week.days).toHaveLength(7);
+    expect(week.days[0]!.weekday).toBe("måndag");
+    expect(week.days[2]!.meals).toHaveLength(1);
+    expect(week.week.planned_days).toBe(1);
+    expect(week.week.confirmed_days).toBe(0);
+    expect(week.week.avg_planned_kcal).toBe(500);
+    expect(week.week.avg_target_kcal).toBe(Math.round((6 * 1400 + 1600) / 7));
+  });
+
+  test("weeks=2 spans 14 days", () => {
+    const week = getPlanWeek(db, { start: "2026-07-20", weeks: 2 });
+    expect(week.days).toHaveLength(14);
+    expect(week.end_date).toBe("2026-08-02");
+  });
+
+  test("does not create day rows (read-only)", () => {
+    getPlanWeek(db, { start: "2026-07-20" });
+    const count = db.query<{ n: number }, []>("SELECT count(*) AS n FROM days").get()!.n;
+    expect(count).toBe(0);
+  });
+
+  test("include_items exposes raw input for lossless slot rebuilds", () => {
+    upsertPlanDays(db, [
+      {
+        date: "2026-07-20",
+        meals: [
+          {
+            slot: "middag",
+            name: "Blandat",
+            items: [
+              { product_id: productId, grams: 150 },
+              { description: "Okänd sås", macros: { kcal: 90, protein: 1, fat: 8, carbs: 3 } },
+            ],
+          },
+        ],
+      },
+    ]);
+    const week = getPlanWeek(db, { start: "2026-07-20", include_items: true });
+    const items = week.days[0]!.meals[0]!.items!;
+    expect(items).toHaveLength(2);
+    expect(items[0]!.product_id).toBe(productId);
+    expect(items[0]!.grams).toBe(150);
+    expect(items[0]!.kcal).toBe(150);
+    expect(items[1]!.description).toBe("Okänd sås");
+    expect(items[1]!.macros).toEqual({ kcal: 90, protein: 1, fat: 8, carbs: 3 }); // raw ad-hoc input preserved
+  });
+});

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -128,7 +128,7 @@ describe("createInternalServer — cluster-internal-only :3001-style listener", 
 });
 
 describe("mcp over streamable http", () => {
-  test("lists all 24 tools", async () => {
+  test("lists all 27 tools", async () => {
     const client = await connect();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
@@ -158,6 +158,9 @@ describe("mcp over streamable http", () => {
         "delete_recipe",
         "set_profile",
         "get_forecast",
+        "plan_week",
+        "get_plan",
+        "confirm_day",
       ].sort(),
     );
     await client.close();

--- a/kcal-assistant/tests/ui-api-plan.test.ts
+++ b/kcal-assistant/tests/ui-api-plan.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { createHttpServer } from "../src/server";
+import { saveProduct } from "../src/db/products";
+
+let httpServer: Server;
+let db: Database;
+let base: string;
+let productId: number;
+
+beforeAll(async () => {
+  db = openDb(":memory:");
+  productId = saveProduct(db, { name: "Planmat", per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 8 } }).id;
+  httpServer = createHttpServer({ token: "t", db, uiAuth: { mode: "dev-bypass" } });
+  await new Promise<void>((r) => httpServer.listen(0, r));
+  base = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((r) => httpServer.close(r));
+});
+
+const get = (path: string) => fetch(`${base}${path}`);
+const put = (path: string, body: unknown, headers: Record<string, string> = {}) =>
+  fetch(`${base}${path}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json", "sec-fetch-site": "same-origin", ...headers },
+    body: JSON.stringify(body),
+  });
+
+describe("PUT /ui/api/plan/<date>", () => {
+  test("upserts a day and returns the plan day view", async () => {
+    const res = await put("/ui/api/plan/2026-07-20", {
+      day_type: "gymdag",
+      meals: [
+        { slot: "middag", name: "Lax", items: [{ product_id: productId, grams: 500 }] },
+        { slot: "mellis", name: "Snabb", items: [{ description: "Snabb", macros: { kcal: 200, protein: 20, fat: 5, carbs: 15 } }] },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.day.day_type).toBe("gymdag");
+    expect(body.day.totals.kcal).toBe(700);
+    expect(body.day.meals).toHaveLength(2);
+  });
+
+  test("CSRF gates: cross-site and wrong content-type are 403", async () => {
+    const cross = await put("/ui/api/plan/2026-07-20", {}, { "sec-fetch-site": "cross-site" });
+    expect(cross.status).toBe(403);
+    const wrongType = await fetch(`${base}/ui/api/plan/2026-07-20`, {
+      method: "PUT",
+      headers: { "content-type": "text/plain", "sec-fetch-site": "same-origin" },
+      body: "{}",
+    });
+    expect(wrongType.status).toBe(403);
+  });
+
+  test("unknown fields and invalid shapes are 400", async () => {
+    expect((await put("/ui/api/plan/2026-07-20", { surprise: 1 })).status).toBe(400);
+    expect((await put("/ui/api/plan/2026-07-20", { meals: [{ slot: "brunch", name: "Nej", items: [] }] })).status).toBe(400);
+    expect((await put("/ui/api/plan/2026-13-40", { day_type: "vilodag" })).status).toBe(400);
+  });
+});
+
+describe("PUT /ui/api/confirm/<date>", () => {
+  test("confirm and unconfirm round-trip; domain errors are 409", async () => {
+    await put("/ui/api/plan/2026-07-21", {
+      meals: [{ slot: "middag", name: "Kyckling", items: [{ product_id: productId, grams: 400 }] }],
+    });
+    const confirmed = await put("/ui/api/confirm/2026-07-21", { action: "confirm" });
+    expect(confirmed.status).toBe(200);
+    const cBody = await confirmed.json();
+    expect(cBody.plan.confirmed).toBe(true);
+    expect(cBody.day.totals.kcal).toBe(400);
+
+    expect((await put("/ui/api/confirm/2026-07-21", { action: "confirm" })).status).toBe(409);
+
+    const undone = await put("/ui/api/confirm/2026-07-21", { action: "unconfirm" });
+    expect(undone.status).toBe(200);
+    expect((await undone.json()).plan.confirmed).toBe(false);
+
+    expect((await put("/ui/api/confirm/2026-07-22", { action: "confirm" })).status).toBe(409); // inget planerat
+    expect((await put("/ui/api/confirm/2026-07-21", { action: "festa" })).status).toBe(400);
+  });
+});
+
+describe("GET /ui/api/plan", () => {
+  test("returns a monday-aligned week with items and shopping list", async () => {
+    const res = await get("/ui/api/plan?start=2026-07-22");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.start_date).toBe("2026-07-20");
+    expect(body.days).toHaveLength(7);
+    expect(body.days[0].meals[0].items).toBeDefined();
+    expect(Array.isArray(body.shopping_list)).toBe(true);
+  });
+
+  test("invalid params are 400", async () => {
+    expect((await get("/ui/api/plan?start=2026-13-40")).status).toBe(400);
+    expect((await get("/ui/api/plan?weeks=9")).status).toBe(400);
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.10.1
+          image: rutbergphilip/kcal-assistant:v0.11.0
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/kubernetes/apps/home-automation/kcal-assistant/networkpolicy.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/networkpolicy.yaml
@@ -45,4 +45,8 @@ spec:
               - method: "GET"
                 path: "/internal/summary"
               - method: "GET"
+                path: "/internal/planner"
+              - method: "POST"
+                path: "/internal/planner/confirm"
+              - method: "GET"
                 path: "/healthz"


### PR DESCRIPTION
## Summary
Interactive Mon–Sun meal planner for kcal-assistant, per the spec in `docs/superpowers/specs/2026-07-18-meal-planner-design.md`:

- **Schema (migration 6)**: `planned_meals` (slot frukost/lunch/middag/mellis, recipe- or item-based, raw-input rows resolved live) + `planned_meal_items` + `days.plan_confirmed_at`
- **Confirm = lock + log**: planned meals copy into `meals` via the existing `logMeal` path; per-meal `logged_meal_id` links give idempotent confirm, per-slot partial confirm and clean unconfirm
- **MCP**: 3 new tools — `plan_week` (batch week upsert incl. day types), `get_plan` (Mon–Sun weeks + shopping list), `confirm_day` (confirm/unconfirm) → **27 tools**
- **KCAL·DB UI**: new **Vecka** view (week list, day-type select, add-from-recipe / quick meal, move/delete/servings, Bekräfta 🔒 / Ångra, handlingslista). Writes reuse the profile PUT's CSRF+Authentik gate
- **Internal (:3001)**: `GET /internal/planner` + `POST /internal/planner/confirm` for the wall panel; Cilium L7 rules pinned to exactly these routes; security-parity tests keep them 404 on :3000
- **Wall hub**: new **Vecka** page (7-day grid, day popup with Bekräfta via `rest_command`) + Hem chip showing today's next planned meal
- **v0.11.0** + deployment image tag

## Test plan
- 257 bun tests green (26 files) incl. plan upsert/replace/clear, recipe scaling, confirm idempotency/partial/unconfirm, shopping aggregation, UI-API auth matrix, internal endpoint parity
- 109 vitest tests green incl. new planner-model suite
- Browser walk of the Vecka UI (dev server): grid, expand, move-between-days verified