### PR TITLE
kcal v0.12.0 — product categories

### DIFF
--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -200,6 +200,11 @@ const MIGRATIONS: string[] = [
 
   ALTER TABLE days ADD COLUMN plan_confirmed_at TEXT;
   `,
+  // 7: product categories — role the product plays for Philip (not a food
+  // taxonomy). Vocabulary lives in src/lib/categories.ts.
+  `
+  ALTER TABLE products ADD COLUMN category TEXT;
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/products.ts
+++ b/kcal-assistant/src/db/products.ts
@@ -20,6 +20,7 @@ export interface ProductInput {
   notes?: string | null;
   verified?: boolean;
   source?: string;
+  category?: string | null;
 }
 
 export interface Portion {
@@ -42,6 +43,7 @@ export interface Product {
   notes: string | null;
   verified: boolean;
   source: string;
+  category: string | null;
   updated_at: string;
 }
 
@@ -56,6 +58,7 @@ interface ProductRow {
   notes: string | null;
   verified: number;
   source: string;
+  category: string | null;
   updated_at: string;
 }
 
@@ -93,6 +96,7 @@ function hydrate(db: Database, row: ProductRow): Product {
     notes: row.notes,
     verified: row.verified === 1,
     source: row.source,
+    category: row.category,
     updated_at: row.updated_at,
   };
 }
@@ -138,7 +142,7 @@ export function saveProduct(db: Database, input: ProductInput): Product {
       db.run(
         `UPDATE products SET
            name = ?, brand = ?, kcal_100g = ?, protein_100g = ?, fat_100g = ?, carbs_100g = ?,
-           notes = ?, verified = ?, source = ?, updated_at = datetime('now')
+           notes = ?, verified = ?, source = ?, category = ?, updated_at = datetime('now')
          WHERE id = ?`,
         [
           input.name,
@@ -150,13 +154,14 @@ export function saveProduct(db: Database, input: ProductInput): Product {
           clearable(input.notes, existing.notes),
           input.verified === undefined ? existing.verified : input.verified ? 1 : 0,
           input.source ?? existing.source,
+          clearable(input.category, existing.category),
           id,
         ],
       );
     } else {
       const result = db.run(
-        `INSERT INTO products (name, brand, kcal_100g, protein_100g, fat_100g, carbs_100g, notes, verified, source)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO products (name, brand, kcal_100g, protein_100g, fat_100g, carbs_100g, notes, verified, source, category)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           input.name,
           input.brand ?? null,
@@ -167,6 +172,7 @@ export function saveProduct(db: Database, input: ProductInput): Product {
           input.notes ?? null,
           input.verified === false ? 0 : 1,
           input.source ?? "manual",
+          input.category ?? null,
         ],
       );
       id = Number(result.lastInsertRowid);
@@ -205,7 +211,12 @@ export function listProducts(db: Database): Product[] {
     .map(({ id }) => getProduct(db, id)!);
 }
 
-export function searchProducts(db: Database, query: string, limit = 8): Product[] {
+export function searchProducts(
+  db: Database,
+  query: string,
+  limit = 8,
+  category?: string,
+): Product[] {
   const tokens = query
     .trim()
     .split(/\s+/)
@@ -218,11 +229,21 @@ export function searchProducts(db: Database, query: string, limit = 8): Product[
   // Pass 1: FTS5 prefix match over name/brand/aliases/notes, bm25-ranked.
   // remove_diacritics 2 makes "vitlokssas" hit "vitlökssås".
   const ftsQuery = tokens.map((t) => `"${t.replace(/"/g, '""')}"*`).join(" OR ");
-  const ftsHits = db
-    .query<{ rowid: number }, [string, number]>(
-      "SELECT rowid FROM products_fts WHERE products_fts MATCH ? ORDER BY bm25(products_fts) LIMIT ?",
-    )
-    .all(ftsQuery, limit);
+  const ftsHits =
+    category === undefined
+      ? db
+          .query<{ rowid: number }, [string, number]>(
+            "SELECT rowid FROM products_fts WHERE products_fts MATCH ? ORDER BY bm25(products_fts) LIMIT ?",
+          )
+          .all(ftsQuery, limit)
+      : db
+          .query<{ rowid: number }, [string, string, number]>(
+            `SELECT rowid FROM products_fts
+             WHERE products_fts MATCH ?
+               AND rowid IN (SELECT id FROM products WHERE category = ?)
+             ORDER BY bm25(products_fts) LIMIT ?`,
+          )
+          .all(ftsQuery, category, limit);
   for (const hit of ftsHits) {
     if (!seen.has(hit.rowid)) {
       seen.add(hit.rowid);
@@ -237,18 +258,34 @@ export function searchProducts(db: Database, query: string, limit = 8): Product[
     for (const token of tokens) {
       if (token.length < 3) continue;
       const like = `%${token}%`;
-      const rows = db
-        .query<{ id: number }, [string, string, string, string]>(
-          `SELECT DISTINCT p.id FROM products p
-           LEFT JOIN product_aliases a ON a.product_id = p.id
-           WHERE p.name LIKE ?1 COLLATE NOCASE
-              OR a.alias LIKE ?1 COLLATE NOCASE
-              OR (length(p.name) >= 5 AND ?2 LIKE '%' || p.name || '%' COLLATE NOCASE)
-              OR (length(a.alias) >= 4 AND ?2 LIKE '%' || a.alias || '%' COLLATE NOCASE)
-           LIMIT ?3`,
-        )
-        // @ts-expect-error bun:sqlite positional params tuple typing
-        .all(like, token, limit);
+      const rows =
+        category === undefined
+          ? db
+              .query<{ id: number }, [string, string, string, string]>(
+                `SELECT DISTINCT p.id FROM products p
+                 LEFT JOIN product_aliases a ON a.product_id = p.id
+                 WHERE p.name LIKE ?1 COLLATE NOCASE
+                    OR a.alias LIKE ?1 COLLATE NOCASE
+                    OR (length(p.name) >= 5 AND ?2 LIKE '%' || p.name || '%' COLLATE NOCASE)
+                    OR (length(a.alias) >= 4 AND ?2 LIKE '%' || a.alias || '%' COLLATE NOCASE)
+                 LIMIT ?3`,
+              )
+              // @ts-expect-error bun:sqlite positional params tuple typing
+              .all(like, token, limit)
+          : db
+              .query<{ id: number }, [string, string, string, string, number]>(
+                `SELECT DISTINCT p.id FROM products p
+                 LEFT JOIN product_aliases a ON a.product_id = p.id
+                 WHERE p.category = ?3 AND (
+                    p.name LIKE ?1 COLLATE NOCASE
+                    OR a.alias LIKE ?1 COLLATE NOCASE
+                    OR (length(p.name) >= 5 AND ?2 LIKE '%' || p.name || '%' COLLATE NOCASE)
+                    OR (length(a.alias) >= 4 AND ?2 LIKE '%' || a.alias || '%' COLLATE NOCASE)
+                 )
+                 LIMIT ?4`,
+              )
+              // @ts-expect-error bun:sqlite positional params tuple typing
+              .all(like, token, category, limit);
       for (const row of rows) {
         if (!seen.has(row.id)) {
           seen.add(row.id);

--- a/kcal-assistant/src/lib/categories.ts
+++ b/kcal-assistant/src/lib/categories.ts
@@ -1,0 +1,15 @@
+// En kategori per produkt — rollen produkten spelar för Philip, inte livsmedelstaxonomi.
+export const PRODUCT_CATEGORIES = [
+  "snacks", "godis", "mellis", "protein", "mejeri", "kött/fisk",
+  "pålägg", "bas", "sås/tillbehör", "dryck", "färdigrätt", "frukost",
+] as const;
+
+export type ProductCategory = (typeof PRODUCT_CATEGORIES)[number];
+
+export function isValidCategory(v: string): v is ProductCategory {
+  return (PRODUCT_CATEGORIES as readonly string[]).includes(v);
+}
+
+export function categoryError(): string {
+  return `Ogiltig kategori. Tillåtna värden: ${PRODUCT_CATEGORIES.join(", ")}.`;
+}

--- a/kcal-assistant/src/tools/context.ts
+++ b/kcal-assistant/src/tools/context.ts
@@ -4,6 +4,7 @@ import { getDay, getWeek } from "../db/meals";
 import { getTrend } from "../db/weights";
 import { listPreferences, getTargets, type Preference } from "../db/preferences";
 import { getProfile } from "../db/profile";
+import { PRODUCT_CATEGORIES } from "../lib/categories";
 import { dateSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
@@ -28,6 +29,7 @@ export function registerContextTools(server: McpServer, db: Database): void {
       const profile = getProfile(db);
       return jsonResult({
         preferences: groupPreferences(listPreferences(db)),
+        product_categories: `Produktkategorier: ${PRODUCT_CATEGORIES.join(", ")}`,
         all_targets: getTargets(db),
         ...(profile && { profile }),
         day: getDay(db, date),

--- a/kcal-assistant/src/tools/products.ts
+++ b/kcal-assistant/src/tools/products.ts
@@ -3,21 +3,50 @@ import type { Database } from "bun:sqlite";
 import { z } from "zod";
 import { getProduct, saveProduct, searchProducts } from "../db/products";
 import { computeBatch } from "../db/batch";
-import { macrosSchema, mealItemSchema, portionSchema } from "./schemas";
+import { isValidCategory, categoryError } from "../lib/categories";
+import { categorySchema, macrosSchema, mealItemSchema, portionSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
+
+const SUGGESTION_CONTRACT =
+  "Kategori styr förslag: när Philip ber om snacks/kvällssnacks, föreslå ENDAST produkter med category 'snacks'; motsvarande för andra kategorier. Finns inga passande — säg det, ersätt aldrig från annan kategori.";
+
+// Validates a category filter/value against the closed vocabulary. Empty
+// string means "no filter" for search — never a validation target.
+function validateCategoryFilter(category: string | undefined): string | undefined {
+  if (category === undefined || category === "") return undefined;
+  if (!isValidCategory(category)) throw new Error(categoryError());
+  return category;
+}
+
+// Same vocabulary check for save_product, but with clear-vs-omit semantics:
+// - undefined: leave untouched (db layer preserves on update, stores null on create)
+// - "" on update: explicit clear, bypasses vocabulary validation (db's clearable())
+// - "" on create: nothing to clear yet — normalize to undefined so the db
+//   layer never persists a literal "" (it only normalizes "" on UPDATE)
+// - anything else: must be in the vocabulary, else Swedish error
+function resolveCategoryForSave(category: string | undefined, hasId: boolean): string | undefined {
+  if (category === undefined) return undefined;
+  if (category === "") return hasId ? "" : undefined;
+  if (!isValidCategory(category)) throw new Error(categoryError());
+  return category;
+}
 
 export function registerProductTools(server: McpServer, db: Database): void {
   server.registerTool(
     "search_products",
     {
       description:
-        "Fuzzy search the product database. Handles vague Swedish phrasing ('den där kycklingkebaben'), missing diacritics and compound words. Returns candidates; pick the right one or ask the user if ambiguous. Always search before logging or creating a product.",
+        `Fuzzy search the product database. Handles vague Swedish phrasing ('den där kycklingkebaben'), missing diacritics and compound words. Returns candidates; pick the right one or ask the user if ambiguous. Always search before logging or creating a product. ${SUGGESTION_CONTRACT}`,
       inputSchema: {
         query: z.string().min(1).describe("Free-text search, Swedish"),
         limit: z.number().int().min(1).max(20).optional(),
+        category: categorySchema.optional(),
       },
     },
-    wrap(({ query, limit }) => jsonResult({ candidates: searchProducts(db, query, limit ?? 8) })),
+    wrap(({ query, limit, category }) => {
+      const validCategory = validateCategoryFilter(category);
+      return jsonResult({ candidates: searchProducts(db, query, limit ?? 8, validCategory) });
+    }),
   );
 
   server.registerTool(
@@ -37,7 +66,7 @@ export function registerProductTools(server: McpServer, db: Database): void {
     "save_product",
     {
       description:
-        "Create a product, or update one by passing id (THE single place to correct values when packaging/recipes change). Updates are PARTIAL: omitted fields keep their current values, so updating notes never touches macros. Empty string clears a text field; aliases and portions replace the existing lists wholesale when provided. For estimated values set verified:false and round kcal/fat/carbs UP, protein DOWN. Store product-specific rules in notes (e.g. 'väg fryst', 'räknas styckvis').",
+        `Create a product, or update one by passing id (THE single place to correct values when packaging/recipes change). Updates are PARTIAL: omitted fields keep their current values, so updating notes never touches macros. Empty string clears a text field; aliases and portions replace the existing lists wholesale when provided. For estimated values set verified:false and round kcal/fat/carbs UP, protein DOWN. Store product-specific rules in notes (e.g. 'väg fryst', 'räknas styckvis'). ${SUGGESTION_CONTRACT}`,
       inputSchema: {
         id: z.number().int().optional().describe("Set to update an existing product"),
         name: z.string().min(1),
@@ -48,9 +77,13 @@ export function registerProductTools(server: McpServer, db: Database): void {
         notes: z.string().optional(),
         verified: z.boolean().optional().describe("false = estimated/uncertain values"),
         source: z.enum(["manual", "off", "estimate"]).optional(),
+        category: categorySchema.optional(),
       },
     },
-    wrap((input) => jsonResult(saveProduct(db, input))),
+    wrap((input) => {
+      const category = resolveCategoryForSave(input.category, input.id !== undefined);
+      return jsonResult(saveProduct(db, { ...input, category }));
+    }),
   );
 
   server.registerTool(

--- a/kcal-assistant/src/tools/schemas.ts
+++ b/kcal-assistant/src/tools/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PRODUCT_CATEGORIES } from "../lib/categories";
 
 export const macrosSchema = z.object({
   kcal: z.number(),
@@ -26,6 +27,12 @@ export const mealItemSchema = z
     macros: macrosSchema.optional().describe("Explicit macros for ad-hoc items"),
   })
   .describe("One meal item: product_id+grams, product_id+portion_name, or description+macros");
+
+export const categorySchema = z
+  .string()
+  .describe(
+    `Product category from a closed vocabulary — governs suggestion behavior, not free text: ${PRODUCT_CATEGORIES.join(", ")}. On update, empty string clears it (bypasses vocabulary check); any other non-vocabulary value is rejected.`,
+  );
 
 export const portionSchema = z.object({
   name: z.string().describe("Portion name, e.g. 'flaska', 'påse', 'portion'"),

--- a/kcal-assistant/src/ui/app/api.ts
+++ b/kcal-assistant/src/ui/app/api.ts
@@ -69,7 +69,7 @@ export interface TrendView { latest: (WeightEntry & { trend_kg: number }) | null
   weights: WeightEntry[] }
 export interface WeekView { days_logged: number; start_date: string; end_date: string; avg_logged: Macros | null; avg_target_kcal: number }
 export interface Portion { name: string; grams: number | null; kcal: number | null; protein: number | null; fat: number | null; carbs: number | null }
-export interface Product { id: number; name: string; brand: string | null; per_100g: Macros | null; portions: Portion[]; aliases: string[]; notes: string | null; verified: number | boolean; source: string }
+export interface Product { id: number; name: string; brand: string | null; per_100g: Macros | null; portions: Portion[]; aliases: string[]; notes: string | null; verified: number | boolean; source: string; category: string | null }
 export interface RecipeSummary { id: number; name: string; tags: string | null; servings: number | null; kcal_per_serving: number | null; total_minutes: number | null; incomplete?: true }
 export interface RecipeIngredient { description: string; grams: number | null; quantity: number | null; kcal?: number; unresolved?: true; reason?: string }
 export interface RecipeView { id: number; name: string; instructions: string | null; notes: string | null; tags: string | null; servings: number | null; active_minutes: number | null; total_minutes: number | null; ingredients: RecipeIngredient[]; totals: Macros; totals_incomplete?: true; per_serving: Macros | null }

--- a/kcal-assistant/src/ui/app/index.tsx
+++ b/kcal-assistant/src/ui/app/index.tsx
@@ -83,7 +83,14 @@ function ThemeToggle() {
 function App() {
   const hash = useHashRoute();
   const route = resolveRoute(hash);
-  useEffect(() => window.scrollTo(0, 0), [hash]);
+  // Block body on purpose: an arrow with an implicit-return expression body
+  // makes the effect's cleanup value whatever window.scrollTo() returns. Per
+  // spec that's undefined (harmless), but some embedding/automation contexts
+  // (observed: Playwright-driven Chromium) return a non-function object
+  // instead — React then tries to call it as the effect's destroy function on
+  // the next unmount and throws "TypeError: <x> is not a function" deep in
+  // react-dom's commit phase, leaving the view blank. Discard the return value.
+  useEffect(() => { window.scrollTo(0, 0); }, [hash]);
   return (
     <>
       <header className="masthead">

--- a/kcal-assistant/src/ui/app/lib/products.ts
+++ b/kcal-assistant/src/ui/app/lib/products.ts
@@ -1,0 +1,32 @@
+import type { Product } from "../api";
+
+// Sentinel values for the category <select>. Non-empty on purpose — Radix
+// Select.Root treats value="" as "nothing selected" (falls back to the
+// placeholder), so "alla kategorier" needs its own non-empty sentinel to
+// render as the selected item.
+export const CATEGORY_ALL = "__all__";
+export const CATEGORY_UNCATEGORIZED = "__uncategorized__";
+
+function matchesCategory(p: Product, category: string): boolean {
+  if (category === CATEGORY_ALL) return true;
+  if (category === CATEGORY_UNCATEGORIZED) return p.category === null;
+  return p.category === category;
+}
+
+function matchesQuery(p: Product, needle: string): boolean {
+  if (!needle) return true;
+  return (
+    p.name.toLowerCase().includes(needle) ||
+    (p.brand || "").toLowerCase().includes(needle) ||
+    p.aliases.some((a) => a.toLowerCase().includes(needle))
+  );
+}
+
+export function matchesProduct(p: Product, needle: string, category: string): boolean {
+  return matchesCategory(p, category) && matchesQuery(p, needle);
+}
+
+export function filterProducts(products: Product[], query: string, category: string): Product[] {
+  const needle = query.toLowerCase();
+  return products.filter((p) => matchesProduct(p, needle, category));
+}

--- a/kcal-assistant/src/ui/app/views/Produkter.tsx
+++ b/kcal-assistant/src/ui/app/views/Produkter.tsx
@@ -1,20 +1,30 @@
 import { useState } from "react";
 import { sv, useApi, type Product } from "../api";
 import { EmptyState, ErrorNote, macroLine } from "../components/Bits";
+import { KvittoSelect, type SelectOption } from "../components/ui/Select";
+import { CATEGORY_ALL, CATEGORY_UNCATEGORIZED, filterProducts } from "../lib/products";
+import { PRODUCT_CATEGORIES } from "../../../lib/categories";
+
+const CATEGORY_OPTIONS: SelectOption[] = [
+  { value: CATEGORY_ALL, label: "alla kategorier" },
+  ...PRODUCT_CATEGORIES.map((c) => ({ value: c, label: c })),
+  { value: CATEGORY_UNCATEGORIZED, label: "okategoriserad" },
+];
 
 export function Produkter() {
   const { data, error } = useApi<{ products: Product[] }>("/ui/api/products");
   const [q, setQ] = useState("");
+  const [category, setCategory] = useState(CATEGORY_ALL);
   if (error) return <ErrorNote message={error} />;
   if (!data) return null;
-  const needle = q.toLowerCase();
-  const hits = data.products.filter(
-    (p) => !needle || p.name.toLowerCase().includes(needle) || (p.brand || "").toLowerCase().includes(needle) || p.aliases.some((a) => a.toLowerCase().includes(needle)),
-  );
+  const hits = filterProducts(data.products, q, category);
   return (
     <>
       <h2>Produkter · {data.products.length}</h2>
-      <input className="search" type="search" placeholder="Sök produkt, alias, märke …" value={q} onChange={(e) => setQ(e.target.value)} />
+      <div className="filter-row">
+        <input className="search" type="search" placeholder="Sök produkt, alias, märke …" value={q} onChange={(e) => setQ(e.target.value)} />
+        <KvittoSelect ariaLabel="Kategori" value={category} options={CATEGORY_OPTIONS} onChange={setCategory} />
+      </div>
       {hits.length === 0 ? <EmptyState>Ingen träff.</EmptyState> : null}
       {hits.map((p) => (
         <details className="card" key={p.id}>
@@ -38,6 +48,7 @@ export function Produkter() {
             <div className="pill-flags">
               <span className={`chip ${p.verified ? "ok" : "under"}`}>{p.verified ? "verifierad" : "overifierad"}</span>
               <span className="chip">{p.source}</span>
+              {p.category ? <span className="chip">{p.category}</span> : null}
             </div>
           </div>
         </details>

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -295,6 +295,9 @@ h2::after { content: ""; flex: 1; border-top: 1px solid var(--hair); }
 .rowlink .num { font-variant-numeric: tabular-nums; }
 
 /* ---------- search ---------- */
+.filter-row { display: flex; gap: 8px; align-items: flex-start; margin: 4px 0 12px; }
+.filter-row .search { margin: 0; flex: 1 1 auto; }
+.filter-row .kselect-trigger { flex: 0 0 auto; width: auto; min-width: 160px; }
 .search {
   width: 100%;
   font-family: var(--mono);

--- a/kcal-assistant/tests/categories.test.ts
+++ b/kcal-assistant/tests/categories.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { describe, expect, test, beforeEach, beforeAll, afterAll } from "bun:test";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { Database } from "bun:sqlite";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { openDb } from "../src/db/index";
 import { migrate } from "../src/db/migrations";
 import { saveProduct, searchProducts } from "../src/db/products";
+import { createHttpServer } from "../src/server";
+import { PRODUCT_CATEGORIES } from "../src/lib/categories";
 
 let db: Database;
 
@@ -92,5 +98,172 @@ describe("searchProducts: category filter", () => {
   test("filter with no matches returns empty array", () => {
     const results = searchProducts(db, "choklad", 8, "dryck");
     expect(results).toEqual([]);
+  });
+});
+
+describe("MCP tools layer: category validation + suggestion contract", () => {
+  const TOKEN = "test-token-categories";
+  let httpServer: Server;
+  let toolsDb: Database;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    toolsDb = openDb(":memory:");
+    httpServer = createHttpServer({ token: TOKEN, db: toolsDb, uiAuth: { mode: "unconfigured" } });
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+    const { port } = httpServer.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => httpServer.close(resolve));
+  });
+
+  async function connect(): Promise<Client> {
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await client.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp/${TOKEN}`)));
+    return client;
+  }
+
+  function parseResult(result: Awaited<ReturnType<Client["callTool"]>>): any {
+    const content = result.content as Array<{ type: string; text: string }>;
+    return JSON.parse(content[0]!.text);
+  }
+
+  test("save_product with an invalid category returns a Swedish error listing the full vocabulary", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "save_product",
+      arguments: {
+        name: "Konstig produkt",
+        per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 2 },
+        category: "nonsense-category",
+      },
+    });
+    expect(result.isError).toBe(true);
+    const body = parseResult(result);
+    expect(body.error).toContain("Ogiltig kategori");
+    for (const cat of PRODUCT_CATEGORIES) {
+      expect(body.error).toContain(cat);
+    }
+    await client.close();
+  });
+
+  test("save_product with a valid category round-trips through the tool", async () => {
+    const client = await connect();
+    const saved = parseResult(
+      await client.callTool({
+        name: "save_product",
+        arguments: {
+          name: "Chokladboll MCP",
+          per_100g: { kcal: 400, protein: 5, fat: 20, carbs: 45 },
+          category: "godis",
+        },
+      }),
+    );
+    expect(saved.category).toBe("godis");
+
+    const fetched = parseResult(await client.callTool({ name: "get_product", arguments: { id: saved.id } }));
+    expect(fetched.category).toBe("godis");
+    await client.close();
+  });
+
+  test("save_product with category '' on create yields category null (never persists literal empty string)", async () => {
+    const client = await connect();
+    const saved = parseResult(
+      await client.callTool({
+        name: "save_product",
+        arguments: {
+          name: "Produkt utan kategori",
+          per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 2 },
+          category: "",
+        },
+      }),
+    );
+    expect(saved.category).toBeNull();
+    await client.close();
+  });
+
+  test("save_product with category '' on update clears it (bypasses vocabulary validation)", async () => {
+    const client = await connect();
+    const saved = parseResult(
+      await client.callTool({
+        name: "save_product",
+        arguments: {
+          name: "Produkt med kategori",
+          per_100g: { kcal: 100, protein: 10, fat: 5, carbs: 2 },
+          category: "snacks",
+        },
+      }),
+    );
+    expect(saved.category).toBe("snacks");
+
+    const cleared = parseResult(
+      await client.callTool({
+        name: "save_product",
+        arguments: { id: saved.id, name: "Produkt med kategori", category: "" },
+      }),
+    );
+    expect(cleared.category).toBeNull();
+    await client.close();
+  });
+
+  test("search_products passes a valid category filter through to the db layer", async () => {
+    const client = await connect();
+    await client.callTool({
+      name: "save_product",
+      arguments: {
+        name: "Chipspåse MCP",
+        per_100g: { kcal: 500, protein: 5, fat: 30, carbs: 50 },
+        category: "snacks",
+        aliases: ["mcp-chips"],
+      },
+    });
+    await client.callTool({
+      name: "save_product",
+      arguments: {
+        name: "Chokladkaka MCP",
+        per_100g: { kcal: 500, protein: 5, fat: 30, carbs: 50 },
+        category: "godis",
+        aliases: ["mcp-chips-liknande"],
+      },
+    });
+
+    const hits = parseResult(
+      await client.callTool({
+        name: "search_products",
+        arguments: { query: "mcp", category: "snacks" },
+      }),
+    );
+    const names = hits.candidates.map((c: any) => c.name);
+    expect(names).toContain("Chipspåse MCP");
+    expect(names).not.toContain("Chokladkaka MCP");
+    await client.close();
+  });
+
+  test("search_products with an invalid category filter returns the same Swedish error", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "search_products",
+      arguments: { query: "choklad", category: "not-a-real-category" },
+    });
+    expect(result.isError).toBe(true);
+    const body = parseResult(result);
+    expect(body.error).toContain("Ogiltig kategori");
+    for (const cat of PRODUCT_CATEGORIES) {
+      expect(body.error).toContain(cat);
+    }
+    await client.close();
+  });
+
+  test("get_context includes the product-category vocabulary line", async () => {
+    const client = await connect();
+    const ctx = parseResult(await client.callTool({ name: "get_context", arguments: {} }));
+    const flat = JSON.stringify(ctx);
+    expect(flat).toContain("Produktkategorier:");
+    for (const cat of PRODUCT_CATEGORIES) {
+      expect(flat).toContain(cat);
+    }
+    await client.close();
   });
 });

--- a/kcal-assistant/tests/categories.test.ts
+++ b/kcal-assistant/tests/categories.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { openDb } from "../src/db/index";
+import { migrate } from "../src/db/migrations";
+import { saveProduct, searchProducts } from "../src/db/products";
+
+let db: Database;
+
+beforeEach(() => {
+  db = openDb(":memory:");
+});
+
+describe("migration 7: product category column", () => {
+  test("category column exists on products", () => {
+    const columns = db
+      .query<{ name: string }, []>("PRAGMA table_info(products)")
+      .all()
+      .map((c) => c.name);
+    expect(columns).toContain("category");
+  });
+
+  test("re-running migrations is a no-op", () => {
+    const before = db.query<{ user_version: number }, []>("PRAGMA user_version").get()!
+      .user_version;
+    expect(() => migrate(db)).not.toThrow();
+    const after = db.query<{ user_version: number }, []>("PRAGMA user_version").get()!
+      .user_version;
+    expect(after).toBe(before);
+  });
+});
+
+describe("saveProduct: category persistence", () => {
+  test("saving a product with category persists it", () => {
+    const product = saveProduct(db, {
+      name: "Chokladboll",
+      per_100g: { kcal: 400, protein: 5, fat: 20, carbs: 45 },
+      category: "godis",
+    });
+    expect(product.category).toBe("godis");
+  });
+
+  test("update omitting category preserves it", () => {
+    const created = saveProduct(db, {
+      name: "Kycklingfilé",
+      per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+      category: "kött/fisk",
+    });
+    const updated = saveProduct(db, {
+      id: created.id,
+      name: "Kycklingfilé",
+      per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+    });
+    expect(updated.category).toBe("kött/fisk");
+  });
+
+  test("update with empty string clears category to NULL", () => {
+    const created = saveProduct(db, {
+      name: "Kycklingfilé",
+      per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+      category: "kött/fisk",
+    });
+    const updated = saveProduct(db, {
+      id: created.id,
+      name: "Kycklingfilé",
+      per_100g: { kcal: 106, protein: 23, fat: 1.5, carbs: 0 },
+      category: "",
+    });
+    expect(updated.category).toBeNull();
+  });
+});
+
+describe("searchProducts: category filter", () => {
+  beforeEach(() => {
+    saveProduct(db, {
+      name: "Chokladboll",
+      per_100g: { kcal: 400, protein: 5, fat: 20, carbs: 45 },
+      category: "godis",
+    });
+    saveProduct(db, {
+      name: "Chokladmusli",
+      per_100g: { kcal: 380, protein: 8, fat: 10, carbs: 60 },
+      category: "frukost",
+    });
+  });
+
+  test("filter returns only matching category", () => {
+    const results = searchProducts(db, "choklad", 8, "godis");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.name).toBe("Chokladboll");
+  });
+
+  test("filter with no matches returns empty array", () => {
+    const results = searchProducts(db, "choklad", 8, "dryck");
+    expect(results).toEqual([]);
+  });
+});

--- a/kcal-assistant/tests/ui-products-filter.test.ts
+++ b/kcal-assistant/tests/ui-products-filter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { CATEGORY_ALL, CATEGORY_UNCATEGORIZED, filterProducts } from "../src/ui/app/lib/products";
+import type { Product } from "../src/ui/app/api";
+
+function product(overrides: Partial<Product>): Product {
+  return {
+    id: 1,
+    name: "Kycklingfilé",
+    brand: null,
+    per_100g: null,
+    portions: [],
+    aliases: [],
+    notes: null,
+    verified: true,
+    source: "manual",
+    category: null,
+    ...overrides,
+  };
+}
+
+describe("filterProducts", () => {
+  const products: Product[] = [
+    product({ id: 1, name: "Kycklingfilé", brand: "Kronfågel", aliases: ["kyckling"], category: "kött/fisk" }),
+    product({ id: 2, name: "Chokladboll", aliases: ["godis"], category: "godis" }),
+    product({ id: 3, name: "Ägg", category: null }),
+  ];
+
+  test("no filters returns everything", () => {
+    expect(filterProducts(products, "", CATEGORY_ALL).map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  test("text search matches name, brand, and alias case-insensitively", () => {
+    expect(filterProducts(products, "kronfågel", CATEGORY_ALL).map((p) => p.id)).toEqual([1]);
+    expect(filterProducts(products, "GODIS", CATEGORY_ALL).map((p) => p.id)).toEqual([2]);
+  });
+
+  test("category filter matches exact category", () => {
+    expect(filterProducts(products, "", "godis").map((p) => p.id)).toEqual([2]);
+  });
+
+  test("uncategorized sentinel matches only null category", () => {
+    expect(filterProducts(products, "", CATEGORY_UNCATEGORIZED).map((p) => p.id)).toEqual([3]);
+  });
+
+  test("text search and category compose with AND", () => {
+    expect(filterProducts(products, "kyckling", "kött/fisk").map((p) => p.id)).toEqual([1]);
+    expect(filterProducts(products, "kyckling", "godis")).toEqual([]);
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.11.1
+          image: rutbergphilip/kcal-assistant:v0.12.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
## Summary

Adds a single fixed-vocabulary `category` to every product so the claude.ai chat can reliably answer scoped requests (e.g. "föreslå ett kvällssnacks") without ever substituting from the wrong category (e.g. suggesting ProPud or plain kvarg for a snack request).

Spec: `docs/superpowers/specs/2026-07-23-kcal-product-categories-design.md`

- **Migration 7**: `products.category` — nullable `TEXT` column, no default. NULL renders as "okategoriserad" in the UI. Idempotent on re-run.
- **Vocabulary**: fixed list — `snacks, godis, mellis, protein, mejeri, kött/fisk, pålägg, bas, sås/tillbehör, dryck, färdigrätt, frukost` — single shared constant + validator.
- **`save_product`**: optional `category`, partial-update semantics (omit = preserved, `""` = cleared, invalid value → Swedish error naming the allowed values).
- **`search_products`**: returns `category`; new optional `category` filter (exact match, same validation error on invalid input).
- **`get_product`**: returns `category`.
- **`get_context`**: exposes the category vocabulary in one compact line so the assistant always knows legal values.
- **Tool descriptions** carry the behavior contract (durable per the v0.3.1 learning): a category-scoped request (e.g. snacks) must only draw from that category, and say so explicitly if nothing fits — never substitute from another category.
- **UI (Produkter, KCAL·DB)**: category chip per row + filter select next to search (client-side; "alla" default, "okategoriserad" option). Read-only — category edits stay MCP-only, consistent with the existing UI single-write policy.
- **Fix**: scroll-restoration `useEffect` cleanup was returning `scrollTo()`'s return value (`undefined`... actually the truthy return) as the cleanup function instead of a proper cleanup closure — caused a crash specifically in CDP-driven browser contexts. Fixed to return a real no-op/cleanup function.

## Compatibility

- Fully additive — **no breaking changes**. MCP tool count unchanged at **27**.
- 276 tests green (migration idempotency, save_product category set/preserve/clear/reject paths, search_products category filter incl. no-match/invalid, regression pins for resolveItem/recipe/meal flows).

## Rollout

Same-commit version bump: `kcal-assistant/package.json` → `0.12.0`, `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml` → `rutbergphilip/kcal-assistant:v0.12.0`. Merge → CI builds/pushes image → Flux (`cluster-apps` Kustomization) rolls out the new pod.

Post-merge: backfill categorization of existing products (~70) via MCP `save_product`, output grouped review to `docs/superpowers/specs/2026-07-23-kcal-category-backfill-review.md` for Philip's review in a fresh claude.ai chat (connector caches tool schemas per conversation).