### PR TITLE
ci(kcal): test gate before image build + PR test job

### DIFF
--- a/.github/workflows/kcal-assistant.yaml
+++ b/.github/workflows/kcal-assistant.yaml
@@ -5,15 +5,48 @@ on:
   push:
     branches: ["main"]
     paths: ["kcal-assistant/**"]
+  pull_request:
+    paths: ["kcal-assistant/**"]
   workflow_dispatch: {}
 
 jobs:
-  build-push:
-    name: Build and push image
+  test:
+    name: Test
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: kcal-assistant
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: kcal-assistant
+        run: bun test
+
+  build-push:
+    name: Build and push image
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: kcal-assistant
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: kcal-assistant
+        run: bun test
 
       - name: Read version
         id: version


### PR DESCRIPTION
## Summary
- Add a `bun test` step (via `oven-sh/setup-bun`) before the docker build/push in the `build-push` job, so a broken test suite blocks the image push on main.
- Add a `pull_request` trigger (paths: `kcal-assistant/**`) with a separate `test` job that runs install+test only (no docker build), gating PRs that touch kcal-assistant.

No typecheck script exists in `kcal-assistant/package.json`, so no `tsc --noEmit` step was added (per instructions, not inventing one).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/kcal-assistant.yaml'))"` — valid YAML
- [x] `actionlint .github/workflows/kcal-assistant.yaml` — no issues
- [ ] Live proof of the test step passing awaits the next push/PR touching `kcal-assistant/**` (this PR itself only touches the workflow file, so its own `pull_request` job won't trigger against `kcal-assistant/**` changes)