### PR TITLE
kcal v0.15.0 — receptbetyg (decimal 1–10)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-kcal-recipe-rating.md
+++ b/docs/superpowers/plans/2026-07-28-kcal-recipe-rating.md
@@ -1,0 +1,83 @@
+# Kcal Recipe Rating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decimal recipe ratings (1.0–10.0) stored in kcal-assistant, settable from chat (`rate_recipe`) and the KCAL·DB UI, filterable in `find_recipes` and visible/sortable in the UI.
+
+**Architecture:** Migration 11 adds `recipes.rating REAL`. One shared validation/write function in `db/recipes.ts` serves both the new MCP tool and a new `PUT /ui/api/recipes/:id` endpoint (body `{ rating }`, behind the existing `writeGate`). UI shows a badge + sort on the list, a tile + slider editor on the detail page.
+
+**Tech Stack:** Bun + bun:sqlite, zod (MCP tools), React 19 UI, bun test.
+
+## Global Constraints
+
+- Scale 1.0–10.0, ONE decimal (server rounds via `Math.round(r*10)/10`), `null` = cleared/unrated.
+- Swedish error copy: `"betyg måste vara mellan 1 och 10"`.
+- `save_recipe` must NOT gain a rating field.
+- Routing: `API_ROUTE` allows only `/ui/api/<resource>/<param>` — the UI write is `PUT /ui/api/recipes/:id` with strict single-key body `{ rating: number|null }`. (Spec amended from `/rating` sub-path.)
+- Bump: package.json `0.15.0` + deployment.yaml `v0.15.0` in the SAME commit/PR.
+- All work in `kcal-assistant/` (tests via `cd kcal-assistant && bun test`).
+
+---
+
+### Task 1: DB layer — migration + rateRecipe + summaries/filter
+
+**Files:**
+- Modify: `kcal-assistant/src/db/migrations.ts` (append migration 11)
+- Modify: `kcal-assistant/src/db/recipes.ts`
+- Test: `kcal-assistant/tests/recipes.test.ts` (new describe block)
+
+**Interfaces:**
+- Produces: `rateRecipe(db, id: number, rating: number | null): RecipeView` (throws on unknown id / invalid rating); `RecipeView.rating: number | null`; `RecipeSummary.rating: number | null`; `findRecipes(db, query?, minRating?: number)`.
+
+- [x] **Step 1: Write failing tests** — new `describe("rateRecipe / rating")` block: set rating returns rounded value; 8.55 → 8.6; update overwrites; null clears; 0.9 / 10.1 / NaN throw with Swedish message; unknown id throws; `getRecipe` + `findRecipes` summaries carry rating; `findRecipes(db, undefined, 8)` returns only recipes with rating >= 8 (unrated excluded).
+- [x] **Step 2: Run to verify failure** (`bun test tests/recipes.test.ts`)
+- [x] **Step 3: Implement** — migration 11 `ALTER TABLE recipes ADD COLUMN rating REAL;`; `RecipeRow.rating`; RecipeView/RecipeSummary rating; `rateRecipe` (validate finite + 1..10, round, UPDATE with `updated_at = datetime('now')`, return `getRecipe`); `findRecipes` optional `minRating` (`rating IS NOT NULL AND rating >= ?`).
+- [x] **Step 4: Tests pass**
+- [x] **Step 5: Commit**
+
+### Task 2: MCP surface — rate_recipe tool + find_recipes min_rating
+
+**Files:**
+- Modify: `kcal-assistant/src/tools/recipes.ts`
+
+**Interfaces:**
+- Consumes: `rateRecipe`, `findRecipes` from Task 1.
+- Produces: tool `rate_recipe` `{ id: int, rating: number|null }`; `find_recipes` gains `min_rating: number optional`.
+
+- [x] Register `rate_recipe` (description: decimal 1–10, null clears, confirm saved rounded value back to Philip); add `min_rating` to `find_recipes` schema + pass through. Typecheck + full test run. Commit.
+
+### Task 3: UI API — PUT /ui/api/recipes/:id + rating in GET
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/api.ts` (recipes case: method branch, strict body coercion `{rating}` only)
+- Test: `kcal-assistant/tests/ui-api.test.ts` (or existing pattern file) — PUT matrix
+
+- [x] Failing tests: PUT ok (200, body.rating), clear (null → 200), cross-site 403, wrong content-type 403, invalid rating 400, unknown field 400, unknown id 404, GET list carries rating. Implement: recipes case handles GET (unchanged) + PUT param path via `writeGate` + strict shape (`rating` number|null only) + `rateRecipe` in try/catch (unknown id → 404, validation → 400). Tests green. Commit.
+
+### Task 4: UI — list badge/sort + detail editor
+
+**Files:**
+- Modify: `kcal-assistant/src/ui/app/api.ts` (RecipeSummary/RecipeView + rating)
+- Modify: `kcal-assistant/src/ui/app/views/Recept.tsx` (badge `★ 8,5`; sort select Namn/Betyg — betyg desc, unrated last)
+- Modify: `kcal-assistant/src/ui/app/views/ReceptDetalj.tsx` (Betyg tile; `<details>`-style inline editor: range 1–10 step 0.1 + value + Spara/Rensa via `putJson`, then `reload()`)
+- Modify: `kcal-assistant/src/ui/static/app.css` if a small style is needed (follow kvitto aesthetic)
+
+- [x] Implement, `bun run typecheck` (or tsc equivalent), `bun run build:ui` succeeds, full `bun test` green. Commit.
+
+### Task 5: Docs + release bump
+
+**Files:**
+- Modify: `kcal-assistant/README.md` (UI read-only invariant: profil, plan, receptbetyg; tool count 29)
+- Modify: `kcal-assistant/package.json` (`0.15.0`)
+- Modify: `kubernetes/apps/home-automation/kcal-assistant/deployment.yaml` (`v0.15.0`)
+
+- [x] Update, full test suite green, commit (bump files staged TOGETHER).
+
+### Task 6: Ship — PR, merge, CI, Flux, verify
+
+- [x] Branch → push → PR → merge (Philip pre-approved autonomous deploy) → CI green → Flux reconcile → pod runs v0.15.0 → healthz 200 → MCP tools/list = 29 → UI spot-check (list badge + detail editor) via browser if feasible, else curl the JSON APIs live.
+
+## Self-Review
+
+- Spec coverage: scale/rounding (T1), storage (T1), rate_recipe + min_rating + get_recipe (T1/T2), no save_recipe change (constraint), UI badge/sort/editor (T4), writeGate matrix (T3), README invariant (T5), release flow (T5/T6). Spec's `/rating` sub-path amended to `PUT /ui/api/recipes/:id` (routing regex constraint) — spec updated in same commit.
+- No placeholders; types consistent (`rating: number | null` everywhere).

--- a/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
+++ b/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
@@ -1,0 +1,78 @@
+# Kcal: Receptbetyg (decimalbetyg 1–10)
+
+**Datum:** 2026-07-28
+**Status:** Godkänd (Philip förhandsgodkände autonom design + deploy)
+**Version:** v0.15.0 (migration 11, verktyg 29)
+
+## Varför
+
+Philip vill kunna betygsätta recept han lagat — med decimaler — så att han kan
+filtrera på betyg, minnas vad som var bra och låta assistenten föreslå därefter.
+
+## Skala: 1,0–10,0 med en decimal
+
+Vald för konsekvens: stilregeln i databasen ger redan varje loggad måltid
+"betyg 1-10". Recepten talar samma språk. Servern avrundar till en decimal och
+validerar 1 ≤ betyg ≤ 10. `null` = obetygsatt (rensat).
+
+## Lagring
+
+Migration 11:
+
+```sql
+ALTER TABLE recipes ADD COLUMN rating REAL;
+```
+
+Ingen egen tabell, ingen historik, ingen `rated_at` — en användare, ett betyg
+per recept, `updated_at` finns redan. Valideringen bor i koden (delas av MCP-
+och UI-vägen), inte i en CHECK — samma mönster som övriga kolumner.
+
+## MCP-yta (28 → 29 verktyg)
+
+- **Nytt verktyg `rate_recipe`**: `{ id, rating: number | null }`. `null`
+  rensar. Svarar med uppdaterad receptsammanfattning. Beskrivningen säger åt
+  Claude att bekräfta med betyget som sparades (avrundat).
+- **`find_recipes`**: nytt valfritt `min_rating` (obetygsatta filtreras bort
+  när det anges); sammanfattningar får `rating`.
+- **`get_recipe`**: returnerar `rating`.
+- **`save_recipe` ändras INTE** — betyget har exakt en skrivväg per kanal,
+  och ett partial-update-fält vore en rensningsfälla.
+
+Philip behöver NY CHATT efteråt (connectorn cachar verktygslistan per
+konversation).
+
+## UI (KCAL·DB)
+
+- **Receptlistan** (`Recept.tsx`): betygsbricka på kortet ("★ 8,5"), och en
+  sorteringsväxel Namn/Betyg (betyg fallande, obetygsatta sist). Sökfältet
+  ändras inte.
+- **Receptdetalj** (`ReceptDetalj.tsx`): Betyg-tile + inline-redigering:
+  slider 1,0–10,0 (steg 0,1) med värdesiffra, Spara och Rensa. Skrivningen
+  går till `PUT /ui/api/recipes/:id/rating` med body `{ rating: number|null }`
+  genom befintliga `writeGate` (Sec-Fetch-Site same-origin + JSON-typ) —
+  tredje UI-skrivningen, samma mönster som profil och plan.
+- README-invarianten uppdateras: UI:t är läs-bart utom profil, plan och
+  receptbetyg.
+
+## Felhantering
+
+- MCP: ogiltigt betyg → svenskt felmeddelande ("betyg måste vara 1–10");
+  okänt id → "Recipe X not found" (befintligt mönster).
+- UI: 400 vid ogiltigt värde/okänt fält (strikt shape-koll som profil), 404
+  vid okänt recept, 403 via writeGate.
+
+## Tester
+
+- `recipes.test.ts` (eller ny `recipe-rating.test.ts`): sätt/uppdatera/rensa,
+  avrundning (8,55 → 8,6 — SQLite/JS-avrundning en gång, serverns sanning),
+  validering (0,9 / 10,1 / NaN avvisas), `find_recipes` min_rating +
+  rating i sammanfattningar, obetygsatta exkluderas vid filter.
+- `ui-api.test.ts`-mönstret: PUT-matris (fel Sec-Fetch-Site 403, fel
+  content-type 403, ogiltig body 400, okänt fält 400, okänt id 404, ok 200,
+  rensning 200), GET-svar innehåller rating.
+
+## Utrullning
+
+Samma release-flöde som alltid: bumpa `package.json` till 0.15.0 OCH
+`deployment.yaml`-taggen till v0.15.0 i samma PR → merge → CI bygger →
+Flux rullar → verifiera pod, healthz, tools/list = 29, UI visuellt.

--- a/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
+++ b/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
@@ -30,8 +30,10 @@ och UI-vägen), inte i en CHECK — samma mönster som övriga kolumner.
 ## MCP-yta (28 → 29 verktyg)
 
 - **Nytt verktyg `rate_recipe`**: `{ id, rating: number | null }`. `null`
-  rensar. Svarar med uppdaterad receptsammanfattning. Beskrivningen säger åt
-  Claude att bekräfta med betyget som sparades (avrundat).
+  rensar. Svarar minimalt med `{ id, name, rating }` — det räcker för att
+  bekräfta det SPARADE (avrundade) betyget, och hela receptvyn vore
+  tokenslöseri. Beskrivningen säger åt Claude att bekräfta med det sparade
+  värdet.
 - **`find_recipes`**: nytt valfritt `min_rating` (obetygsatta filtreras bort
   när det anges); sammanfattningar får `rating`.
 - **`get_recipe`**: returnerar `rating`.

--- a/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
+++ b/docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md
@@ -48,9 +48,11 @@ konversation).
   ändras inte.
 - **Receptdetalj** (`ReceptDetalj.tsx`): Betyg-tile + inline-redigering:
   slider 1,0–10,0 (steg 0,1) med värdesiffra, Spara och Rensa. Skrivningen
-  går till `PUT /ui/api/recipes/:id/rating` med body `{ rating: number|null }`
-  genom befintliga `writeGate` (Sec-Fetch-Site same-origin + JSON-typ) —
-  tredje UI-skrivningen, samma mönster som profil och plan.
+  går till `PUT /ui/api/recipes/:id` med strikt body `{ rating: number|null }`
+  (enda tillåtna fältet) genom befintliga `writeGate` (Sec-Fetch-Site
+  same-origin + JSON-typ) — tredje UI-skrivningen, samma mönster som profil
+  och plan. (Ursprungligt förslag `/recipes/:id/rating` föll på API_ROUTE-
+  regexen som bara tillåter två segment.)
 - README-invarianten uppdateras: UI:t är läs-bart utom profil, plan och
   receptbetyg.
 

--- a/kcal-assistant/README.md
+++ b/kcal-assistant/README.md
@@ -1,6 +1,6 @@
 # kcal-assistant
 
-Personal MCP server for Philip's calorie tracking, used as a custom connector in the Claude app. Holds the product database, meal log, standing preferences/rules, an Open Food Facts lookup, live discovery against his ICA store (Maxi ICA Stormarknad Nynäshamn via handlaprivatkund.ica.se, `search_store`), week summaries (`get_week`), a weight log with backwards-computed TDEE (`log_weight`/`get_trend`), a mealprep batch calculator (`compute_batch`), and dry-run day planning (`preview_day`), and executable recipes (`save_recipe`/`get_recipe`/`find_recipes`/`delete_recipe`) whose ingredients resolve against current product data at every read. Runs on the homelab cluster at `https://kcal.rutberg.dev/mcp/<token>`.
+Personal MCP server for Philip's calorie tracking, used as a custom connector in the Claude app. Holds the product database, meal log, standing preferences/rules, an Open Food Facts lookup, live discovery against his ICA store (Maxi ICA Stormarknad Nynäshamn via handlaprivatkund.ica.se, `search_store`), week summaries (`get_week`), a weight log with backwards-computed TDEE (`log_weight`/`get_trend`), a mealprep batch calculator (`compute_batch`), and dry-run day planning (`preview_day`), and executable recipes (`save_recipe`/`get_recipe`/`find_recipes`/`delete_recipe`, with decimal betyg 1–10 via `rate_recipe`) whose ingredients resolve against current product data at every read. Runs on the homelab cluster at `https://kcal.rutberg.dev/mcp/<token>`.
 
 The server owns ALL nutrition math: item/meal/day computation at logging, plan previews, batch per-100g derivation, and the TDEE trend (`TDEE = snittintag + Δkg × 7700 ÷ dagar`, intake averaged over the same span as the weight delta, with staleness and uncertainty flags). Weight data lives only in the SQLite database, never in this repo.
 
@@ -51,7 +51,7 @@ The Deployment must keep `replicas: 1` and `strategy: Recreate` — SQLite on NF
 
 ## Web UI (`/ui`)
 
-Read-only database browser (KCAL·DB) at `https://kcal.rutberg.dev/ui`: dagar, måltider, produkter, recept, vikt/TDEE, regler. Editing stays in chat via MCP — the UI has zero mutation endpoints.
+Read-only database browser (KCAL·DB) at `https://kcal.rutberg.dev/ui`: dagar, måltider, produkter, recept, vikt/TDEE, regler. Editing stays in chat via MCP — the UI's only writes are profile settings, the week planner (plan/confirm) and recipe betyg (`PUT /ui/api/recipes/:id`), all CSRF-gated.
 
 Layout width is per route, not per app (`src/ui/app/lib/routes.ts` sets `narrow` 720px / `wide` 1240px); `.app--narrow`/`.app--wide` drive a `--view-max` custom property that both the masthead and the view read.
 

--- a/kcal-assistant/package.json
+++ b/kcal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcal-assistant",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/kcal-assistant/src/db/migrations.ts
+++ b/kcal-assistant/src/db/migrations.ts
@@ -251,6 +251,12 @@ const MIGRATIONS: string[] = [
     locked       INTEGER NOT NULL DEFAULT 0
   );
   `,
+  // 11: recipe rating — Philip's decimal betyg 1.0–10.0 (same scale as the
+  // per-meal betyg in his style rules). NULL = unrated. Validation lives in
+  // db/recipes.ts rateRecipe, shared by the MCP tool and the UI write.
+  `
+  ALTER TABLE recipes ADD COLUMN rating REAL;
+  `,
 ];
 
 export function migrate(db: Database): void {

--- a/kcal-assistant/src/db/recipes.ts
+++ b/kcal-assistant/src/db/recipes.ts
@@ -39,6 +39,7 @@ export interface RecipeView {
   active_minutes: number | null;
   total_minutes: number | null;
   product_id: number | null;
+  rating: number | null;
   updated_at: string;
   ingredients: RecipeIngredientView[];
   totals: Macros;
@@ -52,6 +53,7 @@ export interface RecipeSummary {
   tags: string | null;
   servings: number | null;
   total_minutes: number | null;
+  rating: number | null;
   kcal_per_serving: number | null;
   incomplete?: true;
 }
@@ -66,6 +68,7 @@ interface RecipeRow {
   active_minutes: number | null;
   total_minutes: number | null;
   product_id: number | null;
+  rating: number | null;
   updated_at: string;
 }
 
@@ -183,6 +186,7 @@ export function getRecipe(db: Database, id: number): RecipeView | null {
     active_minutes: row.active_minutes,
     total_minutes: row.total_minutes,
     product_id: row.product_id,
+    rating: row.rating,
     updated_at: row.updated_at,
     ingredients,
     totals,
@@ -295,7 +299,7 @@ export function saveRecipe(db: Database, input: RecipeInput): RecipeView {
   return getRecipe(db, save())!;
 }
 
-export function findRecipes(db: Database, query?: string): RecipeSummary[] {
+export function findRecipes(db: Database, query?: string, minRating?: number): RecipeSummary[] {
   const rows = query
     ? db
         .query<RecipeRow, [string]>(
@@ -304,7 +308,12 @@ export function findRecipes(db: Database, query?: string): RecipeSummary[] {
         .all(`%${query}%`)
     : db.query<RecipeRow, []>("SELECT * FROM recipes ORDER BY name").all();
 
-  return rows.map((row) => {
+  const filtered =
+    minRating === undefined
+      ? rows
+      : rows.filter((row) => row.rating !== null && row.rating >= minRating);
+
+  return filtered.map((row) => {
     const full = getRecipe(db, row.id)!;
     return {
       id: row.id,
@@ -312,10 +321,24 @@ export function findRecipes(db: Database, query?: string): RecipeSummary[] {
       tags: row.tags,
       servings: row.servings,
       total_minutes: row.total_minutes,
+      rating: row.rating,
       kcal_per_serving: full.per_serving?.kcal ?? null,
       ...(full.totals_incomplete && { incomplete: true as const }),
     };
   });
+}
+
+// Betyg 1,0–10,0 med en decimal — samma skala som måltidsbetygen i stilreglerna.
+// null rensar. Shared by the rate_recipe tool and PUT /ui/api/recipes/:id.
+export function rateRecipe(db: Database, id: number, rating: number | null): RecipeView {
+  if (rating !== null && (!Number.isFinite(rating) || rating < 1 || rating > 10)) {
+    throw new Error("betyg måste vara mellan 1 och 10");
+  }
+  const exists = db.query("SELECT 1 FROM recipes WHERE id = ?").get(id);
+  if (!exists) throw new Error(`Recipe ${id} not found`);
+  const rounded = rating === null ? null : Math.round(rating * 10) / 10;
+  db.run("UPDATE recipes SET rating = ?, updated_at = datetime('now') WHERE id = ?", [rounded, id]);
+  return getRecipe(db, id)!;
 }
 
 export function deleteRecipe(db: Database, id: number): void {

--- a/kcal-assistant/src/server.ts
+++ b/kcal-assistant/src/server.ts
@@ -131,10 +131,12 @@ export function createHttpServer(opts: { token: string; db: Database; uiAuth: Ui
             return;
           }
         }
-        // The only writable UI routes: profile plus plan/confirm per-date.
+        // The only writable UI routes: profile, plan/confirm per-date, and
+        // recipe rating (PUT /ui/api/recipes/:id carries only { rating }).
         const putRoute =
           pathname === "/ui/api/profile" ||
-          /^\/ui\/api\/(plan|confirm)\/\d{4}-\d{2}-\d{2}$/.test(pathname);
+          /^\/ui\/api\/(plan|confirm)\/\d{4}-\d{2}-\d{2}$/.test(pathname) ||
+          /^\/ui\/api\/recipes\/\d+$/.test(pathname);
         if (req.method !== "GET" && !(req.method === "PUT" && putRoute)) {
           uiHeaders(res);
           res.writeHead(405, { allow: putRoute ? "GET, PUT" : "GET" }).end();

--- a/kcal-assistant/src/tools/recipes.ts
+++ b/kcal-assistant/src/tools/recipes.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
-import { saveRecipe, getRecipe, findRecipes, deleteRecipe } from "../db/recipes";
+import { saveRecipe, getRecipe, findRecipes, deleteRecipe, rateRecipe } from "../db/recipes";
 import { mealItemSchema } from "./schemas";
 import { jsonResult, wrap } from "./util";
 
@@ -47,10 +47,31 @@ export function registerRecipeTools(server: McpServer, db: Database): void {
     "find_recipes",
     {
       description:
-        "List/search recipes by name or tag ('vad kan jag laga?'). Returns summaries with kcal per serving; incomplete:true means an ingredient no longer resolves.",
-      inputSchema: { query: z.string().optional() },
+        "List/search recipes by name or tag ('vad kan jag laga?'). Returns summaries with kcal per serving and rating (betyg 1-10, null = obetygsatt); incomplete:true means an ingredient no longer resolves. min_rating filters to rated recipes at or above it ('nåt jag gillat').",
+      inputSchema: {
+        query: z.string().optional(),
+        min_rating: z.number().min(1).max(10).optional()
+          .describe("Bara recept med betyg >= detta; obetygsatta utesluts"),
+      },
     },
-    wrap(({ query }) => jsonResult({ recipes: findRecipes(db, query) })),
+    wrap(({ query, min_rating }) => jsonResult({ recipes: findRecipes(db, query, min_rating) })),
+  );
+
+  server.registerTool(
+    "rate_recipe",
+    {
+      description:
+        "Set Philip's betyg on a recipe he has cooked: 1.0-10.0, decimals allowed (same scale as meal betyg), null clears. Server rounds to one decimal — confirm back the SAVED value. Rating is NOT settable via save_recipe; this is the only write path.",
+      inputSchema: {
+        id: z.number().int(),
+        rating: z.number().nullable()
+          .describe("1.0-10.0 med en decimal; null rensar betyget"),
+      },
+    },
+    wrap(({ id, rating }) => {
+      const recipe = rateRecipe(db, id, rating);
+      return jsonResult({ id: recipe.id, name: recipe.name, rating: recipe.rating });
+    }),
   );
 
   server.registerTool(

--- a/kcal-assistant/src/ui/api.ts
+++ b/kcal-assistant/src/ui/api.ts
@@ -2,7 +2,7 @@ import type { Database } from "bun:sqlite";
 import { readDay, listDays, getWeek } from "../db/meals";
 import { listProducts } from "../db/products";
 import { productIdsWithImage } from "../db/product-images";
-import { findRecipes, getRecipe } from "../db/recipes";
+import { findRecipes, getRecipe, rateRecipe } from "../db/recipes";
 import { getTrend, listWeights } from "../db/weights";
 import { listPreferences, getTargets } from "../db/preferences";
 import { buildForecast, type IntakeSource } from "../db/forecast";
@@ -90,6 +90,27 @@ export function handleUiApi(db: Database, req: UiApiRequest): UiApiResponse {
         if (param !== undefined) {
           const id = Number(param);
           if (!Number.isInteger(id)) return { status: 400, body: { error: "ogiltigt id" } };
+          if (req.method === "PUT") {
+            // Rating is the recipe's ONLY UI-writable field — strict single-key
+            // body; everything else about recipes stays chat-only.
+            const gate = writeGate(req);
+            if (gate) return gate;
+            const body = req.body as Record<string, unknown>;
+            const keys = Object.keys(body);
+            if (keys.length !== 1 || keys[0] !== "rating") {
+              return { status: 400, body: { error: "body måste vara exakt { rating }" } };
+            }
+            const rating = body.rating;
+            if (rating !== null && typeof rating !== "number") {
+              return { status: 400, body: { error: "ogiltigt värde för rating" } };
+            }
+            if (!getRecipe(db, id)) return NOT_FOUND;
+            try {
+              return { status: 200, body: rateRecipe(db, id, rating) };
+            } catch (e) {
+              return { status: 400, body: { error: e instanceof Error ? e.message : "ogiltigt betyg" } };
+            }
+          }
           const recipe = getRecipe(db, id);
           return recipe ? { status: 200, body: recipe } : NOT_FOUND;
         }

--- a/kcal-assistant/src/ui/app/api.ts
+++ b/kcal-assistant/src/ui/app/api.ts
@@ -70,9 +70,9 @@ export interface TrendView { latest: (WeightEntry & { trend_kg: number }) | null
 export interface WeekView { days_logged: number; start_date: string; end_date: string; avg_logged: Macros | null; avg_target_kcal: number }
 export interface Portion { name: string; grams: number | null; kcal: number | null; protein: number | null; fat: number | null; carbs: number | null }
 export interface Product { id: number; name: string; brand: string | null; per_100g: Macros | null; portions: Portion[]; aliases: string[]; notes: string | null; verified: number | boolean; source: string; category: string | null; has_image: boolean }
-export interface RecipeSummary { id: number; name: string; tags: string | null; servings: number | null; kcal_per_serving: number | null; total_minutes: number | null; incomplete?: true }
+export interface RecipeSummary { id: number; name: string; tags: string | null; servings: number | null; kcal_per_serving: number | null; total_minutes: number | null; rating: number | null; incomplete?: true }
 export interface RecipeIngredient { description: string; grams: number | null; quantity: number | null; kcal?: number; unresolved?: true; reason?: string }
-export interface RecipeView { id: number; name: string; instructions: string | null; notes: string | null; tags: string | null; servings: number | null; active_minutes: number | null; total_minutes: number | null; ingredients: RecipeIngredient[]; totals: Macros; totals_incomplete?: true; per_serving: Macros | null }
+export interface RecipeView { id: number; name: string; instructions: string | null; notes: string | null; tags: string | null; servings: number | null; active_minutes: number | null; total_minutes: number | null; rating: number | null; ingredients: RecipeIngredient[]; totals: Macros; totals_incomplete?: true; per_serving: Macros | null }
 export interface Weight { date: string; weight_kg: number; trend_kg: number; note: string | null }
 export interface ForecastPoint { date: string; kg: number; low: number; high: number }
 export interface AccuracyBucket { days: number; n: number; mae_kg: number; bias_kg: number }

--- a/kcal-assistant/src/ui/app/views/Recept.tsx
+++ b/kcal-assistant/src/ui/app/views/Recept.tsx
@@ -5,27 +5,41 @@ import { EmptyState, ErrorNote } from "../components/Bits";
 export function Recept() {
   const { data, error } = useApi<{ recipes: RecipeSummary[] }>("/ui/api/recipes");
   const [q, setQ] = useState("");
+  const [sort, setSort] = useState<"namn" | "betyg">("namn");
   if (error) return <ErrorNote message={error} />;
   if (!data) return null;
   const needle = q.toLowerCase();
   const hits = data.recipes.filter((r) => !needle || r.name.toLowerCase().includes(needle) || (r.tags || "").toLowerCase().includes(needle));
+  // betyg: högst först, obetygsatta sist (namnordning inom samma betyg)
+  const sorted =
+    sort === "namn"
+      ? hits
+      : [...hits].sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0) || a.name.localeCompare(b.name, "sv"));
   return (
     <>
       <h2>Recept · {data.recipes.length}</h2>
       <input className="search" type="search" placeholder="Sök recept, taggar …" value={q} onChange={(e) => setQ(e.target.value)} />
+      <div className="chip-row">
+        {(["namn", "betyg"] as const).map((key) => (
+          <button key={key} className={`chip${sort === key ? " accent" : ""}`} onClick={() => setSort(key)}>
+            {key}
+          </button>
+        ))}
+      </div>
       {data.recipes.length === 0 ? (
         <EmptyState>Inga recept ännu. Säg åt assistenten: 'spara som recept'.</EmptyState>
       ) : hits.length === 0 ? (
         <EmptyState>Ingen träff.</EmptyState>
       ) : null}
       <div className="rgrid">
-        {hits.map((r) => (
+        {sorted.map((r) => (
           <button key={r.id} className="rcard" onClick={() => { location.hash = `#/recept/${r.id}`; }}>
             <span className="rcard-name">{r.name}</span>
             {r.tags ? <span className="rcard-tags">{r.tags}</span> : null}
             <span className="rcard-foot">
               <span className="num">{r.kcal_per_serving !== null ? `${sv(r.kcal_per_serving, 0)} kcal/port` : "—"}</span>
               {r.total_minutes !== null ? <span className="dim">~{sv(r.total_minutes, 0)} min</span> : null}
+              {r.rating !== null ? <span className="rcard-rating num">★ {sv(r.rating, 1)}</span> : null}
             </span>
           </button>
         ))}

--- a/kcal-assistant/src/ui/app/views/ReceptDetalj.tsx
+++ b/kcal-assistant/src/ui/app/views/ReceptDetalj.tsx
@@ -1,8 +1,52 @@
-import { sv, useApi, type RecipeView } from "../api";
+import { useState } from "react";
+import { putJson, sv, useApi, type RecipeView } from "../api";
 import { ErrorNote, LeaderRow, Tile, macroLine } from "../components/Bits";
 
+// Betyg 1,0–10,0 med en decimal — servern avrundar och är sanningen.
+function RatingEditor({ id, rating, onSaved }: { id: number; rating: number | null; onSaved: () => void }) {
+  const [draft, setDraft] = useState(rating ?? 7.5);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const save = async (value: number | null) => {
+    setSaving(true);
+    setStatus(null);
+    try {
+      await putJson(`/ui/api/recipes/${id}`, { rating: value });
+      setSaving(false);
+      onSaved();
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : "kunde inte spara");
+      setSaving(false);
+    }
+  };
+  return (
+    <div className="card rating-editor">
+      <div className="body">
+        <label className="field">
+          <span className="label">{rating !== null ? "Ändra betyg" : "Betygsätt"} · {sv(draft, 1)}</span>
+          <input
+            type="range"
+            min={1}
+            max={10}
+            step={0.1}
+            value={draft}
+            onChange={(e) => setDraft(Number(e.target.value))}
+          />
+        </label>
+        <div className="chip-row">
+          <button className="chip accent" disabled={saving} onClick={() => save(draft)}>Spara betyg</button>
+          {rating !== null ? (
+            <button className="chip" disabled={saving} onClick={() => save(null)}>Rensa</button>
+          ) : null}
+        </div>
+        {status ? <ErrorNote message={status} /> : null}
+      </div>
+    </div>
+  );
+}
+
 export function ReceptDetalj({ id }: { id: string }) {
-  const { data: r, error } = useApi<RecipeView>(`/ui/api/recipes/${id}`);
+  const { data: r, error, reload } = useApi<RecipeView>(`/ui/api/recipes/${id}`);
   return (
     <>
       <button className="backlink" onClick={() => { location.hash = "#/recept"; }}>← Alla recept</button>
@@ -33,7 +77,9 @@ export function ReceptDetalj({ id }: { id: string }) {
             {r.servings ? <Tile label="Portioner" value={sv(r.servings)} /> : null}
             {r.total_minutes !== null ? <Tile label="Tid" value={`${sv(r.total_minutes, 0)} min`} sub={r.active_minutes !== null ? `${sv(r.active_minutes, 0)} min aktiv` : null} /> : null}
             {r.per_serving ? <Tile label="Per portion" value={`${sv(r.per_serving.kcal, 0)} kcal`} sub={`P ${sv(r.per_serving.protein)} · F ${sv(r.per_serving.fat)} · K ${sv(r.per_serving.carbs)}`} /> : null}
+            {r.rating !== null ? <Tile label="Betyg" value={`★ ${sv(r.rating, 1)}`} sub="av 10" /> : null}
           </div>
+          <RatingEditor key={r.rating ?? "unrated"} id={r.id} rating={r.rating} onSaved={reload} />
           {r.instructions ? (
             <>
               <h2>Gör så här</h2>

--- a/kcal-assistant/src/ui/static/app.css
+++ b/kcal-assistant/src/ui/static/app.css
@@ -524,6 +524,9 @@ details.card .body { padding: 10px 12px 12px; }
   font-variant-numeric: tabular-nums;
 }
 .rcard-foot .dim { color: var(--ink-3); }
+.rcard-rating { color: var(--accent); margin-left: auto; }
+
+.rating-editor input[type="range"] { width: 100%; accent-color: var(--accent); }
 
 /* ---------- drawer (v0.14) ---------- */
 .drawer-scrim {

--- a/kcal-assistant/tests/recipes.test.ts
+++ b/kcal-assistant/tests/recipes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach } from "bun:test";
 import type { Database } from "bun:sqlite";
 import { openDb } from "../src/db/index";
 import { saveProduct } from "../src/db/products";
-import { saveRecipe, getRecipe, findRecipes, deleteRecipe } from "../src/db/recipes";
+import { saveRecipe, getRecipe, findRecipes, deleteRecipe, rateRecipe } from "../src/db/recipes";
 
 // Synthetic fixtures only — public repo.
 let db: Database;
@@ -222,5 +222,61 @@ describe("cooking times", () => {
     timeRecipe({ active_minutes: 10, total_minutes: 35 });
     const summary = findRecipes(db, "Tidsrecept")[0]!;
     expect(summary.total_minutes).toBe(35);
+  });
+});
+
+describe("rateRecipe / rating", () => {
+  test("new recipes are unrated", () => {
+    const r = makeRecipe();
+    expect(r.rating).toBeNull();
+    expect(findRecipes(db, "Testgryta")[0]!.rating).toBeNull();
+  });
+
+  test("sets a decimal rating and rounds to one decimal", () => {
+    const r = makeRecipe();
+    expect(rateRecipe(db, r.id, 8.55).rating).toBe(8.6);
+    expect(getRecipe(db, r.id)!.rating).toBe(8.6);
+  });
+
+  test("updates overwrite, null clears, bounds 1 and 10 are valid", () => {
+    const r = makeRecipe();
+    rateRecipe(db, r.id, 7.2);
+    expect(rateRecipe(db, r.id, 10).rating).toBe(10);
+    expect(rateRecipe(db, r.id, 1).rating).toBe(1);
+    expect(rateRecipe(db, r.id, null).rating).toBeNull();
+  });
+
+  test("rejects out-of-range and non-finite ratings in Swedish", () => {
+    const r = makeRecipe();
+    expect(() => rateRecipe(db, r.id, 0.9)).toThrow("betyg måste vara mellan 1 och 10");
+    expect(() => rateRecipe(db, r.id, 10.1)).toThrow("betyg måste vara mellan 1 och 10");
+    expect(() => rateRecipe(db, r.id, NaN)).toThrow("betyg måste vara mellan 1 och 10");
+  });
+
+  test("unknown recipe throws", () => {
+    expect(() => rateRecipe(db, 999, 5)).toThrow("Recipe 999 not found");
+  });
+
+  test("rating survives a save_recipe partial update", () => {
+    const r = makeRecipe();
+    rateRecipe(db, r.id, 9.1);
+    const upd = saveRecipe(db, { id: r.id, name: r.name, notes: "extra vitlök" });
+    expect(upd.rating).toBe(9.1);
+  });
+
+  test("findRecipes min_rating filters out lower-rated and unrated", () => {
+    const a = makeRecipe();
+    rateRecipe(db, a.id, 8);
+    const b = saveRecipe(db, {
+      name: "Lågbetyg",
+      ingredients: [{ product_id: chickenId, grams: 100 }],
+    });
+    rateRecipe(db, b.id, 6.5);
+    saveRecipe(db, { name: "Obetygsatt", ingredients: [{ product_id: chickenId, grams: 100 }] });
+    const hits = findRecipes(db, undefined, 8);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.name).toBe("Testgryta");
+    expect(hits[0]!.rating).toBe(8);
+    expect(findRecipes(db)).toHaveLength(3);
   });
 });

--- a/kcal-assistant/tests/server.test.ts
+++ b/kcal-assistant/tests/server.test.ts
@@ -128,7 +128,7 @@ describe("createInternalServer — cluster-internal-only :3001-style listener", 
 });
 
 describe("mcp over streamable http", () => {
-  test("lists all 28 tools", async () => {
+  test("lists all 29 tools", async () => {
     const client = await connect();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
@@ -156,6 +156,7 @@ describe("mcp over streamable http", () => {
         "save_recipe",
         "get_recipe",
         "find_recipes",
+        "rate_recipe",
         "delete_recipe",
         "set_profile",
         "get_forecast",

--- a/kcal-assistant/tests/ui-api.test.ts
+++ b/kcal-assistant/tests/ui-api.test.ts
@@ -280,3 +280,59 @@ describe("profile api", () => {
     expect((await fetch(`${pbase}/ui/api/weights`, { method: "PUT" })).status).toBe(405);
   });
 });
+
+describe("PUT /ui/api/recipes/:id — rating", () => {
+  const put = (path: string, body: unknown, headers: Record<string, string> = {}) =>
+    fetch(`${base}${path}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", "sec-fetch-site": "same-origin", ...headers },
+      body: JSON.stringify(body),
+    });
+
+  async function recipeId(): Promise<number> {
+    const body = await (await get("/ui/api/recipes")).json();
+    return body.recipes[0].id;
+  }
+
+  test("sets a decimal rating, returns the rounded recipe, GET reflects it", async () => {
+    const id = await recipeId();
+    const res = await put(`/ui/api/recipes/${id}`, { rating: 8.55 });
+    expect(res.status).toBe(200);
+    expect((await res.json()).rating).toBe(8.6);
+    const list = await (await get("/ui/api/recipes")).json();
+    expect(list.recipes[0].rating).toBe(8.6);
+    const detail = await (await get(`/ui/api/recipes/${id}`)).json();
+    expect(detail.rating).toBe(8.6);
+  });
+
+  test("null clears", async () => {
+    const id = await recipeId();
+    const res = await put(`/ui/api/recipes/${id}`, { rating: null });
+    expect(res.status).toBe(200);
+    expect((await res.json()).rating).toBeNull();
+  });
+
+  test("CSRF gates: cross-site and wrong content-type are 403", async () => {
+    const id = await recipeId();
+    expect((await put(`/ui/api/recipes/${id}`, { rating: 5 }, { "sec-fetch-site": "cross-site" })).status).toBe(403);
+    const wrongType = await fetch(`${base}/ui/api/recipes/${id}`, {
+      method: "PUT",
+      headers: { "content-type": "text/plain", "sec-fetch-site": "same-origin" },
+      body: "{}",
+    });
+    expect(wrongType.status).toBe(403);
+  });
+
+  test("strict shape: unknown field, wrong type, out-of-range are 400", async () => {
+    const id = await recipeId();
+    expect((await put(`/ui/api/recipes/${id}`, { rating: 5, note: "x" })).status).toBe(400);
+    expect((await put(`/ui/api/recipes/${id}`, { rating: "8" })).status).toBe(400);
+    expect((await put(`/ui/api/recipes/${id}`, { rating: 0.5 })).status).toBe(400);
+    expect((await put(`/ui/api/recipes/${id}`, {})).status).toBe(400);
+  });
+
+  test("unknown recipe is 404; non-numeric id is not a writable route (405)", async () => {
+    expect((await put("/ui/api/recipes/9999", { rating: 5 })).status).toBe(404);
+    expect((await put("/ui/api/recipes/abc", { rating: 5 })).status).toBe(405);
+  });
+});

--- a/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
+++ b/kubernetes/apps/home-automation/kcal-assistant/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: kcal-assistant
-          image: rutbergphilip/kcal-assistant:v0.14.0
+          image: rutbergphilip/kcal-assistant:v0.15.0
           imagePullPolicy: IfNotPresent
 
           ports:


### PR DESCRIPTION
## Sammanfattning

Recipe rating for kcal-assistant, designed and shipped autonomously per Philip's request (2026-07-28).

- **Migration 11**: `recipes.rating REAL` (NULL = obetygsatt)
- **`rate_recipe`** (verktyg 29): decimalbetyg 1,0–10,0 (samma skala som måltidsbetygen), `null` rensar, servern avrundar till en decimal
- **`find_recipes`**: `min_rating`-filter + `rating` i sammanfattningar; `get_recipe` returnerar `rating`
- **`save_recipe` oförändrad** — betyget har exakt en skrivväg per kanal
- **UI**: betygsbricka + namn/betyg-sortering i receptlistan; Betyg-tile + slider-redigering på detaljsidan via `PUT /ui/api/recipes/:id` bakom befintliga writeGate (CSRF)
- Version 0.15.0 + deployment-tag bumpade i samma commit

Spec: `docs/superpowers/specs/2026-07-28-kcal-recipe-rating-design.md`
Plan: `docs/superpowers/plans/2026-07-28-kcal-recipe-rating.md`

## Test

379 bun-tester gröna, inkl. ny PUT-matris (403/400/404/405) och rateRecipe-validering.

**OBS för Philip:** ny chatt behövs efteråt (connectorn cachar verktygslistan).